### PR TITLE
Fix nuxeo document

### DIFF
--- a/nuxeo-document.html
+++ b/nuxeo-document.html
@@ -66,10 +66,10 @@ element.
       method: { type: String, value: 'get'},
 
       /* The document id. Either 'docId' or 'docPath' must be defined. */
-      docId: String,
+      docId: { type: String, value: ''},
 
       /* The document path. Either 'docId' or 'docPath' must be defined. */
-      docPath: String,
+      docPath: { type: String, value: ''},
 
       /* The path of the resource. */
       path: {

--- a/nuxeo-document.html
+++ b/nuxeo-document.html
@@ -66,10 +66,10 @@ element.
       method: { type: String, value: 'get'},
 
       /* The document id. Either 'docId' or 'docPath' must be defined. */
-      docId: { type: String, value: ''},
+      docId: String,
 
       /* The document path. Either 'docId' or 'docPath' must be defined. */
-      docPath: { type: String, value: ''},
+      docPath: String,
 
       /* The path of the resource. */
       path: {

--- a/nuxeo-document.html
+++ b/nuxeo-document.html
@@ -124,9 +124,9 @@ element.
 
     computePath: function(docId, docPath) {
       var path = '';
-      if (docId !== undefined && docId !== null) {
+      if (docId !== undefined && docId !== null && docId !== '') {
         path = '/id/' + docId;
-      } else if (docPath !== undefined && docPath !== null) {
+      } else if (docPath !== undefined && docPath !== null && docPath !== '') {
         path = '/path/' + docPath;
       }
       return path;


### PR DESCRIPTION
The properties docId and docPath are never undefined; they are defined
to be ‘’ in the properties list. So be sure to test for ‘’.