### PR TITLE
Change docPath into doc-path in nuxeo-document usage doc

### DIFF
--- a/nuxeo-document.html
+++ b/nuxeo-document.html
@@ -26,7 +26,7 @@ Contributors:
 <!--
 `nuxeo-document` allows managing Documents on a Nuxeo server.
 
-    <nuxeo-document auto docPath="/default-domain"></nuxeo-document>
+    <nuxeo-document auto doc-path="/default-domain"></nuxeo-document>
 
 With `auto` set to `true`, the GET method is executed whenever
 its `docPath` or `docId` properties are changed.


### PR DESCRIPTION
Here is a fix of the `nuxeo-document` usage documentation, regarding `docPath` which should be `doc-path`.