### PR TITLE
Notify page change

### DIFF
--- a/nuxeo-page-provider.html
+++ b/nuxeo-page-provider.html
@@ -132,7 +132,8 @@ element.
          */
         page: {
           type: Number,
-          value: 1
+          value: 1,
+          notify: true
         },
 
         /**
@@ -299,6 +300,7 @@ element.
             this.quickFilters = response.quickFilters;
             this.isNextPageAvailable = response.isNextPageAvailable;
             this.currentPageSize = response.currentPageSize;
+            this.page = response.pageIndex + 1;
             this.fire('update');
             return response;
           }.bind(this));


### PR DESCRIPTION
Hello !

I was observing the page number and all kind of info but this one was not updated.
This is a problem when you filter a column. 
Scenario:
1) I have 4 pages of data and I'm on page 3/4
2) I filter a column, now I only have 2 pages but I'm on page 3/2 instead of 1/2