### PR TITLE
ELEMENTS-935: remove unused npm deps (1.0.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,6 @@
     "lint": "npm run eslint && npm run polylint",
     "test": "polymer test --simpleOutput --expanded -l chrome"
   },
-  "dependencies": {
-    "@polymer/polymer": "^1.2.5-npm-test.2",
-    "@polymer/iron-elements": "0.0.3",
-    "nuxeo": "^2.0.2",
-    "es6-promise": "^3.1.2"
-  },
   "devDependencies": {
     "eslint": "^3.0.0",
     "eslint-plugin-html": "^2.0.0",


### PR DESCRIPTION
Backport of https://github.com/nuxeo/nuxeo-elements/commit/99baed3f35ed5637a6fae7200642c2c54d2b37d4 for 8.10.