### PR TITLE
ELEMENTS-1181: fix selectivity's drop down icon when multivalued

### DIFF
--- a/ui/demo/nuxeo-directory-suggestion/index.html
+++ b/ui/demo/nuxeo-directory-suggestion/index.html
@@ -45,7 +45,11 @@ limitations under the License.
         </nuxeo-demo-section>
 
         <nuxeo-demo-section heading="Directory suggestion (single)" size="small">
-          <nuxeo-directory-suggestion directory-name="subject" value="{{singleDirectory}}"></nuxeo-directory-suggestion>
+          <nuxeo-directory-suggestion
+            directory-name="subject"
+            value="{{singleDirectory}}"
+            min-chars="0"
+          ></nuxeo-directory-suggestion>
           <div>Selected directory: [[singleDirectory]]</div>
         </nuxeo-demo-section>
 
@@ -53,6 +57,7 @@ limitations under the License.
           <nuxeo-directory-suggestion
             directory-name="subject"
             value="{{multipleDirectories}}"
+            min-chars="0"
             multiple="true"
           ></nuxeo-directory-suggestion>
           <div>Selected directories: [[multipleDirectories]]</div>

--- a/ui/widgets/nuxeo-selectivity.js
+++ b/ui/widgets/nuxeo-selectivity.js
@@ -6201,16 +6201,16 @@ typedArrayTags[weakMapTag] = false;
      *                enabled - Boolean whether the input is enabled.
      */
         multipleSelectInput(options) {
-          return (
-            `<div class="selectivity-multiple-input-container">${
-              options.enabled
-                ? '<input type="text" autocomplete="off" autocorrect="off" ' +
-                  'autocapitalize="off" class="selectivity-multiple-input">'
-                : '<div class="selectivity-multiple-input ' + 'selectivity-placeholder"></div>'
-            }<div class="selectivity-clearfix"></div>` +
-            '<i class="fa fa-sort-desc selectivity-caret"></i>' +
-            '</div>'
-          );
+          const enabledTemplate = '<input type="text" autocomplete="off" autocorrect="off" autocapitalize="off" ' +
+            'class="selectivity-multiple-input">';
+          const disabledTemplate = '<div class="selectivity-multiple-input selectivity-placeholder"/>';
+          return `
+            <div class="selectivity-multiple-input-container">
+              ${options.enabled ? enabledTemplate : disabledTemplate}
+              <div class="selectivity-clearfix"/>
+              <i class="fa fa-sort-desc selectivity-caret"/>
+            </div>
+          `;
         },
 
         /**
@@ -6324,15 +6324,13 @@ typedArrayTags[weakMapTag] = false;
      * the placeholder.
      */
         singleSelectInput(options) {
-          return (
-            `${'<div class="selectivity-single-select">' +
-            '<input type="text" class="selectivity-single-select-input"'}${
-              options.required ? ' required' : ''
-            }>` +
-            '<div class="selectivity-single-result-container"></div>' +
-            '<i class="fa fa-sort-desc selectivity-caret"></i>' +
-            '</div>'
-          );
+          return `
+            <div class="selectivity-single-select">
+              <input type="text" class="selectivity-single-select-input" ${options.required ? ' required' : ''}>
+              <div class="selectivity-single-result-container"/>
+              <i class="fa fa-sort-desc selectivity-caret"/>
+            </div>
+          `;
         },
 
         /**

--- a/ui/widgets/nuxeo-selectivity.js
+++ b/ui/widgets/nuxeo-selectivity.js
@@ -6208,7 +6208,7 @@ typedArrayTags[weakMapTag] = false;
             <div class="selectivity-multiple-input-container">
               ${options.enabled ? enabledTemplate : disabledTemplate}
               <div class="selectivity-clearfix"/>
-              <i class="fa fa-sort-desc selectivity-caret"/>
+              <i class="selectivity-caret"/>
             </div>
           `;
         },
@@ -6328,7 +6328,7 @@ typedArrayTags[weakMapTag] = false;
             <div class="selectivity-single-select">
               <input type="text" class="selectivity-single-select-input" ${options.required ? ' required' : ''}>
               <div class="selectivity-single-result-container"/>
-              <i class="fa fa-sort-desc selectivity-caret"/>
+              <i class="selectivity-caret"/>
             </div>
           `;
         },

--- a/ui/widgets/nuxeo-selectivity.js
+++ b/ui/widgets/nuxeo-selectivity.js
@@ -6208,6 +6208,7 @@ typedArrayTags[weakMapTag] = false;
                   'autocapitalize="off" class="selectivity-multiple-input">'
                 : '<div class="selectivity-multiple-input ' + 'selectivity-placeholder"></div>'
             }<div class="selectivity-clearfix"></div>` +
+            '<i class="fa fa-sort-desc selectivity-caret"></i>' +
             '</div>'
           );
         },


### PR DESCRIPTION
I went a little bit over the top on this one. The fix is simple but I added some suggestions for improvements. Everything is open to discussion.

6ae40e9: fixes the main issue.
08f4e6e: evens out the demo for `<nuxeo-directory-suggestion>`.
~e63eafe: concatenates the template in a more readable way.~
~90bbf5d: returns the result as a simple template instead of a concatenation of strings.~
~4b689e3: removes CSS classes that don't seem to be defined anywhere.~
e473b66: concatenates and returns the result as a simpler, more readable template.
b76317a: removes CSS classes that don't seem to be defined anywhere.