### PR TITLE
(WIP) ELEMENTS-1188: show expandable content on iron-data-table

### DIFF
--- a/ui/nuxeo-data-table/data-table-row-detail.js
+++ b/ui/nuxeo-data-table/data-table-row-detail.js
@@ -25,8 +25,11 @@ import './data-table-templatizer-behavior.js';
         <style>
           :host {
             padding: 0 24px 0 24px;
-            display: flex;
+            display: block;
             align-items: center;
+            flex: 10 10 100%;
+            flex-grow: 100;
+            flex-basis: 1000px;
           }
         </style>
         <slot></slot>
@@ -34,6 +37,10 @@ import './data-table-templatizer-behavior.js';
     }
 
     _beforeBind(beforeBind, item, index, selected, expanded) {
+      if (!beforeBind) {
+        return;
+      }
+
       beforeBind(
         {
           index,

--- a/ui/nuxeo-data-table/data-table-row.js
+++ b/ui/nuxeo-data-table/data-table-row.js
@@ -10,6 +10,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
         <style>
           :host {
             display: flex;
+            flex-wrap: wrap;
             flex-direction: column;
             opacity: 1;
             cursor: pointer;
@@ -93,6 +94,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
         expanded: {
           type: Boolean,
           reflectToAttribute: true,
+          value: false,
         },
         index: Number,
         item: Object,

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -310,6 +310,18 @@ import '../nuxeo-button-styles.js';
                       ></nuxeo-data-table-cell>
                     </template>
                   </dom-repeat>
+                  <div style$="[[_computeActionsStyle(editable, orderable)]]">
+                    <nuxeo-data-table-row-actions
+                      index="[[index]]"
+                      editable="[[editable]]"
+                      orderable="[[orderable]]"
+                      template="[[rowForm]]"
+                      item="[[item]]"
+                      size="[[items.length]]"
+                      table="[[_this]]"
+                    >
+                    </nuxeo-data-table-row-actions>
+                  </div>
                   <dom-if if="[[_isExpanded(item, _expandedItems)]]" on-dom-change="_updateSizeForItem">
                     <template>
                       <nuxeo-data-table-row-detail
@@ -323,18 +335,6 @@ import '../nuxeo-button-styles.js';
                       ></nuxeo-data-table-row-detail>
                     </template>
                   </dom-if>
-                  <div style$="[[_computeActionsStyle(editable, orderable)]]">
-                    <nuxeo-data-table-row-actions
-                      index="[[index]]"
-                      editable="[[editable]]"
-                      orderable="[[orderable]]"
-                      template="[[rowForm]]"
-                      item="[[item]]"
-                      size="[[items.length]]"
-                      table="[[_this]]"
-                    >
-                    </nuxeo-data-table-row-actions>
-                  </div>
                 </nuxeo-data-table-row>
               </div>
             </template>
@@ -533,7 +533,11 @@ import '../nuxeo-button-styles.js';
         }
 
         if (info.addedNodes.filter(hasDetails).length > 0) {
-          this.set('rowDetail', this.getContentChildren('[select="template[is=row-detail]"]')[0]);
+          this.set(
+            'rowDetail',
+            this.getContentChildren('[select="template[is=row-detail]"]')[0] ||
+              this.querySelector('template[is=row-detail]'),
+          );
 
           // assuming parent element is always a Polymer element.
           // set dataHost to the same context the template was declared in


### PR DESCRIPTION
PR open for feedback - need to modify iron-data-table to "fix" the expandable row functionality - the specific use-case is to display extended info on audit history.