### PR TITLE
ELEMENTS-1216: add route resolver to nuxeo-routing-behavior

### DIFF
--- a/ui/test/nuxeo-routing-behavior.test.js
+++ b/ui/test/nuxeo-routing-behavior.test.js
@@ -1,0 +1,173 @@
+/**
+@license
+(C) Copyright Nuxeo Corp. (http://nuxeo.com/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { fixture, html } from '@nuxeo/testing-helpers';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import '@nuxeo/nuxeo-elements/nuxeo-element.js';
+import { RoutingBehavior } from '../nuxeo-routing-behavior.js';
+
+function setNuxeoRouterKey(entityType, value) {
+  window.Nuxeo = window.Nuxeo || {};
+  window.Nuxeo.UI = window.Nuxeo.UI || {};
+  window.Nuxeo.UI.config = window.Nuxeo.UI.config || {};
+  window.Nuxeo.UI.config.router = window.Nuxeo.UI.config.router || {};
+  window.Nuxeo.UI.config.router.key = window.Nuxeo.UI.config.router.key || {};
+  window.Nuxeo.UI.config.router.key = window.Nuxeo.UI.config.router.key || {};
+  window.Nuxeo.UI.config.router.key[entityType] = value;
+}
+
+suite('Nuxeo.RoutingBehavior', () => {
+  // define nuxeo-routed-element
+  customElements.define(
+    'nuxeo-routed-element',
+    class extends mixinBehaviors([RoutingBehavior], Nuxeo.Element) {
+      static get is() {
+        return 'nuxeo-routed-element';
+      }
+    },
+  );
+
+  setup(async () => {
+    await customElements.whenDefined('nuxeo-routed-element');
+  });
+
+  suite('urlFor', () => {
+    let el;
+    setup(async () => {
+      await customElements.whenDefined('nuxeo-routed-element');
+      // Mock router
+      RoutingBehavior.__router = {
+        document: (path, tab) => `${path.startsWith('/') ? 'path' : 'uid/'}${path}${tab ? `?p=${tab}` : ''}`,
+      };
+      sinon.spy(RoutingBehavior.__router, 'document');
+      el = await fixture(
+        html`
+          <nuxeo-routed-element></nuxeo-routed-element>
+        `,
+      );
+    });
+
+    test('should generate url for named route', async () => {
+      RoutingBehavior.__router.useHashbang = false;
+      RoutingBehavior.__router.baseUrl = '';
+      expect(el.urlFor('document', '/default-domain/workspaces/ws')).to.equal(`/path/default-domain/workspaces/ws`);
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate url for named route when using hashbang', async () => {
+      RoutingBehavior.__router.useHashbang = true;
+      RoutingBehavior.__router.baseUrl = '';
+      expect(el.urlFor('document', '/default-domain/workspaces/ws')).to.equal(`/#!/path/default-domain/workspaces/ws`);
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate url for named route when using base URL', async () => {
+      RoutingBehavior.__router.useHashbang = false;
+      RoutingBehavior.__router.baseUrl = 'base';
+      expect(el.urlFor('document', '/default-domain/workspaces/ws')).to.equal(`base/path/default-domain/workspaces/ws`);
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate url for named route when using hashbang and base URL', async () => {
+      RoutingBehavior.__router.useHashbang = true;
+      RoutingBehavior.__router.baseUrl = 'base';
+      expect(el.urlFor('document', '/default-domain/workspaces/ws')).to.equal(
+        `base/#!/path/default-domain/workspaces/ws`,
+      );
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate url for named route when passing a param', async () => {
+      RoutingBehavior.__router.useHashbang = false;
+      RoutingBehavior.__router.baseUrl = '';
+      expect(el.urlFor('document', '/default-domain/workspaces/ws', 'view')).to.equal(
+        `/path/default-domain/workspaces/ws?p=view`,
+      );
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate url from object', async () => {
+      RoutingBehavior.__router.useHashbang = false;
+      RoutingBehavior.__router.baseUrl = '';
+      expect(el.urlFor({ 'entity-type': 'document', uid: 'abc123', path: '/default-domain/workspaces/ws' })).to.equal(
+        `/path/default-domain/workspaces/ws`,
+      );
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate url from object when using hashbang', async () => {
+      RoutingBehavior.__router.useHashbang = true;
+      RoutingBehavior.__router.baseUrl = '';
+      expect(el.urlFor({ 'entity-type': 'document', uid: 'abc123', path: '/default-domain/workspaces/ws' })).to.equal(
+        `/#!/path/default-domain/workspaces/ws`,
+      );
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate url from object when using base URL', async () => {
+      RoutingBehavior.__router.useHashbang = false;
+      RoutingBehavior.__router.baseUrl = 'base';
+      expect(el.urlFor({ 'entity-type': 'document', uid: 'abc123', path: '/default-domain/workspaces/ws' })).to.equal(
+        `base/path/default-domain/workspaces/ws`,
+      );
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate url from object using hashbang and base URL', async () => {
+      RoutingBehavior.__router.useHashbang = true;
+      RoutingBehavior.__router.baseUrl = 'base';
+      expect(el.urlFor({ 'entity-type': 'document', uid: 'abc123', path: '/default-domain/workspaces/ws' })).to.equal(
+        `base/#!/path/default-domain/workspaces/ws`,
+      );
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate url from object when passing a param', async () => {
+      RoutingBehavior.__router.useHashbang = false;
+      RoutingBehavior.__router.baseUrl = '';
+      expect(
+        el.urlFor({ 'entity-type': 'document', uid: 'abc123', path: '/default-domain/workspaces/ws' }, 'view'),
+      ).to.equal(`/path/default-domain/workspaces/ws?p=view`);
+      expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+    });
+
+    test('should generate empty url from undefined route', async () => {
+      RoutingBehavior.__router.useHashbang = false;
+      RoutingBehavior.__router.baseUrl = '';
+      expect(el.urlFor()).to.equal('');
+      expect(RoutingBehavior.__router.document.notCalled).to.be.true;
+    });
+
+    suite('with route key for "document" entity-type set to "uid"', async () => {
+      setup(async () => {
+        setNuxeoRouterKey('document', 'uid');
+      });
+
+      teardown(async () => {
+        setNuxeoRouterKey('document'); // reset document key to undefined
+      });
+
+      test('should generate url from object', async () => {
+        RoutingBehavior.__router.useHashbang = false;
+        RoutingBehavior.__router.baseUrl = '';
+        expect(el.urlFor({ 'entity-type': 'document', uid: 'abc123', path: '/default-domain/workspaces/ws' })).to.equal(
+          `/uid/abc123`,
+        );
+        expect(RoutingBehavior.__router.document.calledOnce).to.be.true;
+      });
+    });
+  });
+});

--- a/ui/widgets/nuxeo-document-suggestion.js
+++ b/ui/widgets/nuxeo-document-suggestion.js
@@ -305,7 +305,7 @@ import { escapeHTML } from './nuxeo-selectivity.js';
       if (typeof doc === 'string') {
         return `<span>${escapeHTML(doc)}</span>`;
       }
-      return `<a href="${this.urlFor('browse', doc.path)}">${escapeHTML(doc.title)}</a>`;
+      return `<a href="${this.urlFor(doc)}">${escapeHTML(doc.title)}</a>`;
     }
 
     _resultFormatter(doc) {


### PR DESCRIPTION
Required by https://github.com/nuxeo/nuxeo-web-ui/pull/985.

This introduces a breaking change to people developing on top of the nuxeo-elements alone. People using on top of Web UI will not be affected. It can be fixed by either locking into a previous version or manually fixing their router.