### PR TITLE
ELEMENTS-1224: use npm-public as the default repo for nuxeo scoped packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@nuxeo:registry=https://packages.nuxeo.com/repository/npm-public/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,7 +246,7 @@ pipeline {
             """
             def token = sh(script: 'jx step credential -s public-npm-token -k token', returnStdout: true).trim()
             sh "echo '//packages.nuxeo.com/repository/npm-public/:_authToken=${token}' >> ~/.npmrc"
-            sh "npx lerna exec --ignore @nuxeo/nuxeo-elements-storybook -- npm publish --registry=https://packages.nuxeo.com/repository/npm-public/ --tag SNAPSHOT"
+            sh "npx lerna exec --ignore @nuxeo/nuxeo-elements-storybook -- npm publish --tag SNAPSHOT"
           }
         }
       }


### PR DESCRIPTION
Depends on https://github.com/nuxeo/jx-webui-env/pull/21.
Related to https://github.com/nuxeo/nuxeo-web-ui/pull/1001.