### PR TITLE
ELEMENTS-1244: add UTC mode to date widgets

### DIFF
--- a/ui/nuxeo-format-behavior.js
+++ b/ui/nuxeo-format-behavior.js
@@ -42,13 +42,14 @@ export const FormatBehavior = [
       return `${size.toString()} Bytes`;
     },
 
-    _formatDate(date, fmt) {
+    _formatDate(date, fmt, timezone) {
       if (!date) return;
       moment.locale(this._languageCode());
+      const fn = timezone === 'Etc/UTC' ? moment.utc : moment;
       if (fmt && fmt === 'relative') {
-        return moment().to(date);
+        return fn().to(date);
       }
-      return moment(date).format(fmt);
+      return fn(date).format(fmt);
     },
 
     /**
@@ -57,9 +58,17 @@ export const FormatBehavior = [
      *
      * @param {string} date the date
      * @param {string} format the format, falls back on Nuxeo.UI.config.dateFormat or 'MMM D, YYYY' if null.
+     * @param {string} timezone the name of the timezone of the date, according to the IANA tz database.
+     *     Currently valid values are:
+     *     - empty: local time will be used, as read from the browser (this is the default)
+     *     - Etc/UTC: time specified by the user is assumed to be in UTC
      */
-    formatDate(date, format) {
-      return this._formatDate(date, format || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.dateFormat) || 'LL');
+    formatDate(date, format, timezone) {
+      return this._formatDate(
+        date,
+        format || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.dateFormat) || 'LL',
+        timezone || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.timezone),
+      );
     },
 
     /**
@@ -68,9 +77,17 @@ export const FormatBehavior = [
      *
      * @param {string} date the date
      * @param {string} format the format, falls back on Nuxeo.UI.config.dateFormat or 'MMMM D, YYYY HH:mm' if null.
+     * @param {string} timezone the name of the timezone of the date, according to the IANA tz database.
+     *     Currently valid values are:
+     *     - empty: local time will be used, as read from the browser (this is the default)
+     *     - Etc/UTC: time specified by the user is assumed to be in UTC
      */
-    formatDateTime(date, format) {
-      return this._formatDate(date, format || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.dateTimeFormat) || 'LLL');
+    formatDateTime(date, format, timezone) {
+      return this._formatDate(
+        date,
+        format || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.dateTimeFormat) || 'LLL',
+        timezone || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.timezone),
+      );
     },
 
     /**

--- a/ui/widgets/nuxeo-date.js
+++ b/ui/widgets/nuxeo-date.js
@@ -39,9 +39,9 @@ import './nuxeo-tooltip.js';
   class Date extends mixinBehaviors([I18nBehavior, FormatBehavior], Nuxeo.Element) {
     static get template() {
       return html`
-        <span id="datetime" hidden$="[[!datetime]]">[[formatDate(datetime, format)]]</span>
-        <nuxeo-tooltip for="datetime" hidden$="[[_producesSameDateFormat(datetime,format,tooltipFormat)]]">
-          [[formatDateTime(datetime, tooltipFormat)]]
+        <span id="datetime" hidden$="[[!datetime]]">[[formatDate(datetime, format, timezone)]]</span>
+        <nuxeo-tooltip for="datetime" hidden$="[[_producesSameDateFormat(datetime, format, tooltipFormat, timezone)]]">
+          [[formatDateTime(datetime, tooltipFormat, timezone)]]
         </nuxeo-tooltip>
       `;
     }
@@ -70,11 +70,24 @@ import './nuxeo-tooltip.js';
          * [moment Format](http://momentjs.com/docs/#/displaying/format/).
          */
         tooltipFormat: String,
+
+        /**
+         * The name of the timezone where the user is considered to be, according to the IANA tz database.
+         * Currently valid values are:
+         * - empty: local time will be used, as read from the browser (this is the default)
+         * - Etc/UTC: time specified by the user is assumed to be in UTC
+         */
+        timezone: {
+          type: String,
+          value() {
+            return Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.timezone;
+          },
+        },
       };
     }
 
-    _producesSameDateFormat(datetime, format, tooltipFormat) {
-      return this.formatDate(datetime, format) === this.formatDateTime(datetime, tooltipFormat);
+    _producesSameDateFormat(datetime, format, tooltipFormat, timezone) {
+      return this.formatDate(datetime, format, timezone) === this.formatDateTime(datetime, tooltipFormat, timezone);
     }
   }
 


### PR DESCRIPTION
The ticket requires `nuxeo-date-picker` to stop converting user input (assumed to be in local time) to UTC and `nuxeo-date` from converting UTC to local time, and just display UTC as is.

The proposed solution consists of providing a `timezone` attribute on those to elements to specify a timezone, which will fallback to a `Nuxeo.UI.config.timezone` global config property. The date and datetime formatters on the format behavior were also updated accordingly.

In reality, we are just toggling between **local** and **utc** mode on moment, but a timezone property could be more convenient for the futurte. Alternatively, we could just use a boolean property named `utcMode`, for example.

An open question, for which I do not have a clear answer, is whether any of the other elements that make use of moment should take `Nuxeo.UI.config.timezone` into consideration or not (e.g. user and group management, acls, etc).