### PR TITLE
ELEMENTS-1281: handle errors on bulk action

### DIFF
--- a/core/nuxeo-operation.js
+++ b/core/nuxeo-operation.js
@@ -321,7 +321,7 @@ import './nuxeo-connection.js';
           this.error = error;
           console.warn(`Operation request failed: ${error}`);
           this._setActiveRequests(this.activeRequests - 1);
-          throw error;
+          throw this.error;
         });
     }
 
@@ -334,15 +334,20 @@ import './nuxeo-connection.js';
     }
 
     _poll(url) {
-      return new Promise((resolve) => {
+      return new Promise((resolve, reject) => {
         const fn = () => {
-          this.$.nx.http(url).then((res) => {
-            if (this._isRunning(res)) {
-              window.setTimeout(() => fn(), this.pollInterval, url);
-            } else {
-              resolve(res);
-            }
-          });
+          this.$.nx
+            .http(url)
+            .then((res) => {
+              if (this._isRunning(res)) {
+                window.setTimeout(() => fn(), this.pollInterval, url);
+              } else {
+                resolve(res);
+              }
+            })
+            .catch((error) => {
+              reject(error);
+            });
         };
         fn();
       });


### PR DESCRIPTION
I updated the requirements, This PR depends now on the platform one [PR#4606](https://github.com/nuxeo/nuxeo/pull/4606)


**Note for the reviewers **  :)

Initially I have used the `error` event name, [Here](https://github.com/nuxeo/nuxeo-elements/pull/345/files#diff-22158a82217a91b6c61a0761e1426283dfe8d0ed47e2b3335c33df55347460e6R313) But I got some errors on the unit tests, mainly on the `nuxeo-audit-page-provider.test.js` where the two tests below failed: 

`Should fire an event when an error occurs in the Operation call` and `Should return an error when occurs in the Operation call` as they expect to get the `notify` event, but it failed. That's the main reason why I have changed the name to `failure`, before that I have tried different approche to try to fix it by keeping the `error` event name. Finally I used the `failure` let me know wdyt

thx