### PR TITLE
ELEMENTS-1303: update node requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To install the project's dependencies:
 npm install
 npm run bootstrap
 ```
+Note: This version of Nuxeo Elements requires node version >=10.23.0.
 
 ## Quickstart
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "version": "3.1.0-SNAPSHOT",
   "author": "Nuxeo",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=10.23.0"
+  },
   "scripts": {
+    "postinstall": "check-engine --ignore",
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean --yes && lerna bootstrap",
     "nuke": "rm -rf package-lock.json node_modules && npm install && lerna exec \"rm -f package-lock.json\" && lerna clean --yes && lerna bootstrap && lerna exec --stream -- \"test -f package-lock.json || npm install --package-lock-only\"",
@@ -40,6 +44,7 @@
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "babel-eslint": "^10.0.1",
     "chai": "^4.2.0",
+    "check-engine": "^1.10.0",
     "coveralls": "^3.0.2",
     "eslint": "^5.15.1",
     "eslint-plugin-html": "^5.0.3",


### PR DESCRIPTION
After each `npm install` we'll check if the installed node version is valid and display an appropriate warning.
If it satisfies the requirements:
```
Checking versions...
✔ node was validated with >=10.23.0.
 Environment looks good!
```
If it doesn't:
```
Checking versions...
✘ node version is incorrect! Expected >=10.23.0 but was v10.0.0.
 Environment is invalid!
```
Feedback and suggestions are very welcome!

(I had to lock the `check-engine` version to ensure it works on node `v6.0.0`)