### PR TITLE
ELEMENTS-1312: simplify nuxeo-path-suggestion validation

### DIFF
--- a/ui/nuxeo-path-suggestion/nuxeo-path-suggestion.js
+++ b/ui/nuxeo-path-suggestion/nuxeo-path-suggestion.js
@@ -23,7 +23,6 @@ import '@nuxeo/paper-typeahead/paper-typeahead.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
 import { IronFormElementBehavior } from '@polymer/iron-form-element-behavior';
 import { IronValidatableBehavior } from '@polymer/iron-validatable-behavior/iron-validatable-behavior';
-import { IronMeta } from '@polymer/iron-meta/iron-meta.js';
 import { FormatBehavior } from '../nuxeo-format-behavior.js';
 
 {
@@ -108,7 +107,7 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
           value="{{value}}"
           data="[[data]]"
           allowed-pattern="[[allowedPattern]]"
-          auto-validate="[[autoValidate]]"
+          invalid="[[invalid]]"
           on-focus="_onFocus"
           disabled$="[[disabled]]"
           no-label-float
@@ -174,24 +173,6 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
       };
     }
 
-    ready() {
-      super.ready();
-      const validateFn = this._validate.bind(this);
-      const validator = {
-        validatorName: `${PathSuggestion.is}-validator`,
-        validatorType: 'validator',
-        validate: validateFn,
-      };
-
-      /* eslint-disable no-new */
-      new IronMeta({
-        type: validator.validatorType,
-        key: validator.validatorName,
-        value: validator,
-      });
-      this.$.typeahead.validator = validator.validatorName;
-    }
-
     displayResults() {
       this.$.typeahead.tryDisplayResults();
     }
@@ -230,6 +211,9 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
                 this.children = [];
               }
             });
+        }
+        if (this.autoValidate) {
+          this.validate();
         }
       }
     }
@@ -272,18 +256,14 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
       }
     }
 
-    _validate() {
+    /* Override method from Polymer.IronValidatableBehavior. */
+    _getValidity() {
+      // XXX - paper-typeahead doesn't implement the IronValidatableBehavior, so there is no validate() method.
       const valid =
         (this.value && this.value === '/') ||
         (this.parent ? this.value.replace(/(.+)\/$/, '$1') === this.parent.path : false) ||
         (this.children ? this.children.some((child) => this.value.replace(/(.+)\/$/, '$1') === child.path) : false);
       return valid;
-    }
-
-    /* Override method from Polymer.IronValidatableBehavior. */
-    _getValidity() {
-      // XXX - paper-typeahead doesn't implement the IronValidatableBehavior, so there is no validate() method.
-      return this._validate();
     }
   }
 


### PR DESCRIPTION
Simplified the validation mechanism in the path suggester (handling the validation directly here and passing it to the typeahead element).
Removed the validator approach and trigger the validation in the `nuxeo-path-suggestion` if `autoValidate` is `true`.