### PR TITLE
ELEMENTS-1318: always send queryParams as an array to the server - 3.0.x

### DIFF
--- a/core/nuxeo-operation.js
+++ b/core/nuxeo-operation.js
@@ -208,6 +208,11 @@ import './nuxeo-connection.js';
       if (Nuxeo.PageProvider && input instanceof Nuxeo.PageProvider) {
         params.providerName = input.provider;
         Object.assign(params, input._params);
+        // ELEMENTS-1318 - commas would need to be escaped, as queryParams are mapped to stringlists by the server
+        // But passing queryParams as an array will map directly to the server stringlist
+        if (!Array.isArray(params.queryParams)) {
+          params.queryParams = [params.queryParams];
+        }
         input = undefined;
       }
 

--- a/core/test/nuxeo-operation.test.js
+++ b/core/test/nuxeo-operation.test.js
@@ -170,6 +170,7 @@ suite('nuxeo-operation', () => {
           namedParameters: {
             boolean: 'false',
           },
+          queryParams: [],
         },
         context: {},
       });


### PR DESCRIPTION
Backport of https://github.com/nuxeo/nuxeo-elements/pull/374