### PR TITLE
ELEMENTS-1328: Fix Selectable story of <nuxeo-data-table>

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -15,7 +15,7 @@
     "serve": "polymer serve --npm -c ../node_modules"
   },
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
+    "@polymer/polymer": "3.3.1",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "nuxeo": "^3.2.1"
   },

--- a/dataviz/package.json
+++ b/dataviz/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@nuxeo/moment": "^2.24.0-nx.0",
     "@nuxeo/nuxeo-elements": "^3.1.0-SNAPSHOT",
-    "@polymer/polymer": "^3.0.0",
+    "@polymer/polymer": "3.3.1",
     "moment": "2.23.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@polymer/paper-toast": "^3.0.0",
     "@polymer/paper-toggle-button": "^3.0.0",
     "@polymer/paper-tooltip": "^3.0.0",
-    "@polymer/polymer": "^3.0.0",
+    "@polymer/polymer": "3.3.1",
     "@polymer/test-fixture": "^4.0.2",
     "@vaadin/vaadin-date-picker": "^3.0.0",
     "nuxeo": "^3.2.1"

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -13,7 +13,7 @@
     "@nuxeo/testing-helpers": "^3.1.0-SNAPSHOT",
     "@polymer/iron-icon": "^3.0.0",
     "@polymer/iron-meta": "^3.0.1",
-    "@polymer/polymer": "^3.0.0",
+    "@polymer/polymer": "3.3.1",
     "@storybook/addon-actions": "^5.1.11",
     "@storybook/addon-backgrounds": "^5.1.11",
     "@storybook/addon-knobs": "^5.1.11",

--- a/testing-helpers/package.json
+++ b/testing-helpers/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@open-wc/testing-helpers": "^1.6.2",
     "@polymer/iron-test-helpers": "^3.0.0",
-    "@polymer/polymer": "^3.0.0",
+    "@polymer/polymer": "3.3.1",
     "lit-html": "^1.0.0",
     "nuxeo": "^3.2.1",
     "sinon": "^9.0.1"

--- a/ui/package.json
+++ b/ui/package.json
@@ -69,7 +69,7 @@
     "@polymer/paper-toast": "^3.0.0",
     "@polymer/paper-toggle-button": "^3.0.0",
     "@polymer/paper-tooltip": "^3.0.0",
-    "@polymer/polymer": "^3.0.0",
+    "@polymer/polymer": "3.3.1",
     "@vaadin/vaadin-date-picker": "^3.0.0",
     "@webcomponents/html-imports": "^1.2.0",
     "acorn": "^6.0.7",


### PR DESCRIPTION
Locking the `polymer` version to `3.3.1`.