### PR TITLE
ELEMENTS-1342: do not include deleted documents by default in distribution chart

### DIFF
--- a/ui/dataviz/nuxeo-document-distribution-chart.js
+++ b/ui/dataviz/nuxeo-document-distribution-chart.js
@@ -277,7 +277,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
          */
         includeDeleted: {
           type: Boolean,
-          value: true,
+          value: false,
         },
 
         /**


### PR DESCRIPTION
It is required by https://github.com/nuxeo/nuxeo-web-ui/pull/1199