### PR TITLE
ELEMENTS-1360: add ui configuration registry

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -1,0 +1,43 @@
+/**
+@license
+(C) Copyright Nuxeo Corp. (http://nuxeo.com/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+Nuxeo = Nuxeo || {};
+Nuxeo.UI = Nuxeo.UI || {};
+Nuxeo.UI.config = Nuxeo.UI.config || {};
+const { config } = Nuxeo.UI;
+
+Object.assign(config, {
+  get(path) {
+    return path.split('.').reduce((a, b) => a && a[b], this);
+  },
+  set(path, value) {
+    const parentPath = path.substring(0, path.lastIndexOf('.'));
+    let parent = this.get(parentPath);
+    if (!parent) {
+      parent = path
+        .split('.')
+        .slice(0, -1)
+        .reduce((a, b) => {
+          a[b] = a[b] || {};
+          return a[b];
+        }, this);
+    }
+    parent[path.substring(path.lastIndexOf('.') + 1)] = value;
+  },
+});
+
+export default config;

--- a/core/config.js
+++ b/core/config.js
@@ -21,9 +21,39 @@ Nuxeo.UI.config = Nuxeo.UI.config || {};
 const { config } = Nuxeo.UI;
 
 Object.assign(config, {
-  get(path) {
-    return path.split('.').reduce((a, b) => a && a[b], this);
+  /**
+   * Returns a property for a given `path`. If it is not defined, `fallback` is returned instead.
+   * If `fallback` is defined, the method will try to convert the property value to the same data type of `fallback`.
+   */
+  get(path, fallback) {
+    let val = path.split('.').reduce((a, b) => a && a[b], this);
+    if (val !== undefined && typeof val !== typeof fallback) {
+      let type;
+      switch (typeof fallback) {
+        case 'boolean':
+          type = Boolean;
+          break;
+        case 'number':
+          type = Number;
+          break;
+        case 'string':
+          type = String;
+          break;
+        case 'bigint':
+          // eslint-disable-next-line no-undef
+          type = BigInt;
+          break;
+        default:
+          break;
+      }
+      val = (type && type(val)) || val;
+    }
+    return val || fallback;
   },
+  /**
+   * Sets the `value` for property identified by a given `path`. All intermediate path segments will be created if they
+   * don't exist already.
+   */
   set(path, value) {
     const parentPath = path.substring(0, path.lastIndexOf('.'));
     let parent = this.get(parentPath);

--- a/core/nuxeo-elements.js
+++ b/core/nuxeo-elements.js
@@ -22,3 +22,5 @@ import './nuxeo-page-provider.js';
 import './nuxeo-audit-page-provider.js';
 import './nuxeo-task-page-provider.js';
 import './nuxeo-search.js';
+
+export { default as config } from './config.js';

--- a/core/nuxeo-page-provider.js
+++ b/core/nuxeo-page-provider.js
@@ -302,7 +302,7 @@ import config from './config.js';
         method: {
           type: String,
           value() {
-            return config.get('pageprovider.method') || 'get';
+            return config.get('pageprovider.method', 'get');
           },
         },
       };

--- a/core/nuxeo-page-provider.js
+++ b/core/nuxeo-page-provider.js
@@ -20,6 +20,7 @@ import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 import './nuxeo-element.js';
 import './nuxeo-operation.js';
 import './nuxeo-resource.js';
+import config from './config.js';
 
 {
   /**
@@ -301,10 +302,7 @@ import './nuxeo-resource.js';
         method: {
           type: String,
           value() {
-            return (
-              (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.pageprovider && Nuxeo.UI.config.pageprovider.method) ||
-              'get'
-            );
+            return config.get('pageprovider.method') || 'get';
           },
         },
       };

--- a/ui/nuxeo-filter.js
+++ b/ui/nuxeo-filter.js
@@ -184,7 +184,7 @@ import Interpreter from './js-interpreter/interpreter.js';
       let res = false;
 
       try {
-        if (String(config.get('expressions.eval')) === 'false') {
+        if (!config.get('expressions.eval', false)) {
           const js = new Interpreter(expression, (interpreter, scope) => {
             // set scope
             interpreter.setProperty(scope, 'this', interpreter.nativeToPseudo(FiltersBehavior));

--- a/ui/nuxeo-filter.js
+++ b/ui/nuxeo-filter.js
@@ -17,6 +17,7 @@ limitations under the License.
 import '@polymer/polymer/polymer-legacy.js';
 
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { microTask } from '@polymer/polymer/lib/utils/async.js';
 import { enqueueDebouncer } from '@polymer/polymer/lib/utils/flush.js';
@@ -183,12 +184,7 @@ import Interpreter from './js-interpreter/interpreter.js';
       let res = false;
 
       try {
-        if (
-          Nuxeo.UI &&
-          Nuxeo.UI.config &&
-          Nuxeo.UI.config.expressions &&
-          String(Nuxeo.UI.config.expressions.eval) === 'false'
-        ) {
+        if (String(config.get('expressions.eval')) === 'false') {
           const js = new Interpreter(expression, (interpreter, scope) => {
             // set scope
             interpreter.setProperty(scope, 'this', interpreter.nativeToPseudo(FiltersBehavior));

--- a/ui/nuxeo-format-behavior.js
+++ b/ui/nuxeo-format-behavior.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 import moment from '@nuxeo/moment';
 
+import { config } from '@nuxeo/nuxeo-elements';
 import { I18nBehavior } from './nuxeo-i18n-behavior.js';
 
 /**
@@ -64,11 +65,7 @@ export const FormatBehavior = [
      *     - Etc/UTC: time specified by the user is assumed to be in UTC
      */
     formatDate(date, format, timezone) {
-      return this._formatDate(
-        date,
-        format || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.dateFormat) || 'LL',
-        timezone || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.timezone),
-      );
+      return this._formatDate(date, format || config.get('dateFormat') || 'LL', timezone || config.get('timezone'));
     },
 
     /**
@@ -85,8 +82,8 @@ export const FormatBehavior = [
     formatDateTime(date, format, timezone) {
       return this._formatDate(
         date,
-        format || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.dateTimeFormat) || 'LLL',
-        timezone || (Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.timezone),
+        format || config.get('dateTimeFormat') || 'LLL',
+        timezone || config.get('timezone'),
       );
     },
 

--- a/ui/nuxeo-format-behavior.js
+++ b/ui/nuxeo-format-behavior.js
@@ -65,7 +65,7 @@ export const FormatBehavior = [
      *     - Etc/UTC: time specified by the user is assumed to be in UTC
      */
     formatDate(date, format, timezone) {
-      return this._formatDate(date, format || config.get('dateFormat') || 'LL', timezone || config.get('timezone'));
+      return this._formatDate(date, format || config.get('dateFormat', 'LL'), timezone || config.get('timezone'));
     },
 
     /**
@@ -80,11 +80,7 @@ export const FormatBehavior = [
      *     - Etc/UTC: time specified by the user is assumed to be in UTC
      */
     formatDateTime(date, format, timezone) {
-      return this._formatDate(
-        date,
-        format || config.get('dateTimeFormat') || 'LLL',
-        timezone || config.get('timezone'),
-      );
+      return this._formatDate(date, format || config.get('dateTimeFormat', 'LLL'), timezone || config.get('timezone'));
     },
 
     /**

--- a/ui/nuxeo-page-provider-display-behavior.js
+++ b/ui/nuxeo-page-provider-display-behavior.js
@@ -19,6 +19,7 @@ import '@polymer/polymer/polymer-legacy.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import { I18nBehavior } from './nuxeo-i18n-behavior.js';
 
 /**
@@ -143,7 +144,7 @@ export const PageProviderDisplayBehavior = [
       maxItems: {
         type: Number,
         value() {
-          return (Nuxeo.UI && Nuxeo.UI.config && Number(Nuxeo.UI.config.listingMaxItems)) || 10000;
+          return Number(config.get('listingMaxItems')) || 10000;
         },
       },
 

--- a/ui/nuxeo-page-provider-display-behavior.js
+++ b/ui/nuxeo-page-provider-display-behavior.js
@@ -144,7 +144,7 @@ export const PageProviderDisplayBehavior = [
       maxItems: {
         type: Number,
         value() {
-          return Number(config.get('listingMaxItems')) || 10000;
+          return config.get('listingMaxItems', 10000);
         },
       },
 

--- a/ui/nuxeo-routing-behavior.js
+++ b/ui/nuxeo-routing-behavior.js
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@polymer/polymer/polymer-legacy.js';
+import { config } from '@nuxeo/nuxeo-elements';
 
 /**
  * `Nuxeo.RoutingBehavior` provides a `urlFor` helper function for reverse routing.
@@ -144,13 +145,7 @@ export const RoutingBehavior = {
         throw new Error(`cannot resolve route: object does not have an "entity-type"`);
       }
     }
-    let routeKey =
-      Nuxeo &&
-      Nuxeo.UI &&
-      Nuxeo.UI.config &&
-      Nuxeo.UI.config.router &&
-      Nuxeo.UI.config.router.key &&
-      Nuxeo.UI.config.router.key[entityType];
+    let routeKey = config.get(`router.key.${entityType}`);
     let fn = this.router[entityType];
     if (entityType === 'document') {
       routeKey = routeKey || 'path';

--- a/ui/test/nuxeo-date.test.js
+++ b/ui/test/nuxeo-date.test.js
@@ -16,14 +16,8 @@ limitations under the License.
 */
 import { html, fixture } from '@nuxeo/testing-helpers';
 import moment from '@nuxeo/moment';
+import { config } from '@nuxeo/nuxeo-elements';
 import '../widgets/nuxeo-date.js';
-
-function setNuxeoConfigDateFormat(format, value) {
-  window.Nuxeo = window.Nuxeo || {};
-  window.Nuxeo.UI = window.Nuxeo.UI || {};
-  window.Nuxeo.UI.config = window.Nuxeo.UI.config || {};
-  window.Nuxeo.UI.config[format] = window.Nuxeo.UI.config[format] || value;
-}
 
 suite('nuxeo-date', async () => {
   test('Should hide the nuxeo-tooltip when provided format and tooltipFormat are equal', async () => {
@@ -38,7 +32,7 @@ suite('nuxeo-date', async () => {
   });
 
   test('Should hide the nuxeo-tooltip if provided format matches globalconfig tooltipFormat', async () => {
-    setNuxeoConfigDateFormat('dateTimeFormat', 'LLL');
+    config.set('dateTimeFormat', 'LLL');
     const element = await fixture(
       html`
         <nuxeo-date datetime=${moment()} format="LLL"></nuxeo-date>
@@ -50,7 +44,7 @@ suite('nuxeo-date', async () => {
   });
 
   test('Should hide the nuxeo-tooltip if provided tooltipFormat matches globalconfig format', async () => {
-    setNuxeoConfigDateFormat('dateFormat', 'LLL');
+    config.set('dateFormat', 'LLL');
     const element = await fixture(
       html`
         <nuxeo-date datetime=${moment()} tooltipFormat="LLL"></nuxeo-date>
@@ -62,8 +56,8 @@ suite('nuxeo-date', async () => {
   });
 
   test('Should hide the nuxeo-tooltip if globalconfig dateFormat and dateTimeFormat are same', async () => {
-    setNuxeoConfigDateFormat('dateFormat', 'LLL');
-    setNuxeoConfigDateFormat('dateTimeFormat', 'LLL');
+    config.set('dateFormat', 'LLL');
+    config.set('dateTimeFormat', 'LLL');
     const element = await fixture(
       html`
         <nuxeo-date datetime=${moment()}></nuxeo-date>

--- a/ui/test/nuxeo-document-suggestion.test.js
+++ b/ui/test/nuxeo-document-suggestion.test.js
@@ -16,6 +16,7 @@ limitations under the License.
 */
 import { fixture, flush, html, login } from '@nuxeo/testing-helpers';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import '../widgets/nuxeo-document-suggestion.js';
 
 // Return Selectivity Entries
@@ -45,13 +46,7 @@ const router = {
 };
 
 function setNuxeoRouterKey(entityType, value) {
-  window.Nuxeo = window.Nuxeo || {};
-  window.Nuxeo.UI = window.Nuxeo.UI || {};
-  window.Nuxeo.UI.config = window.Nuxeo.UI.config || {};
-  window.Nuxeo.UI.config.router = window.Nuxeo.UI.config.router || {};
-  window.Nuxeo.UI.config.router.key = window.Nuxeo.UI.config.router.key || {};
-  window.Nuxeo.UI.config.router.key = window.Nuxeo.UI.config.router.key || {};
-  window.Nuxeo.UI.config.router.key[entityType] = value;
+  config.set(`router.key.${entityType}`, value);
 }
 
 suite('nuxeo-document-suggestion', () => {

--- a/ui/test/nuxeo-routing-behavior.test.js
+++ b/ui/test/nuxeo-routing-behavior.test.js
@@ -17,16 +17,11 @@ limitations under the License.
 import { fixture, html } from '@nuxeo/testing-helpers';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import { RoutingBehavior, setRouter } from '../nuxeo-routing-behavior.js';
 
 function setNuxeoRouterKey(entityType, value) {
-  window.Nuxeo = window.Nuxeo || {};
-  window.Nuxeo.UI = window.Nuxeo.UI || {};
-  window.Nuxeo.UI.config = window.Nuxeo.UI.config || {};
-  window.Nuxeo.UI.config.router = window.Nuxeo.UI.config.router || {};
-  window.Nuxeo.UI.config.router.key = window.Nuxeo.UI.config.router.key || {};
-  window.Nuxeo.UI.config.router.key = window.Nuxeo.UI.config.router.key || {};
-  window.Nuxeo.UI.config.router.key[entityType] = value;
+  config.set(`router.key.${entityType}`, value);
 }
 
 suite('Nuxeo.RoutingBehavior', () => {

--- a/ui/widgets/nuxeo-date-picker.js
+++ b/ui/widgets/nuxeo-date-picker.js
@@ -22,6 +22,7 @@ import '@vaadin/vaadin-date-picker/vaadin-date-picker.js';
 import moment from '@nuxeo/moment/min/moment-with-locales.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 
 {
@@ -100,7 +101,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
         timezone: {
           type: String,
           value() {
-            return Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.timezone;
+            return config.get('timezone');
           },
         },
 
@@ -192,10 +193,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
       this.$.date.set('i18n.today', this.i18n('today'));
       this.$.date.set(
         'i18n.firstDayOfWeek',
-        this.firstDayOfWeek ||
-          (Nuxeo.UI && Nuxeo.UI.config && parseInt(Nuxeo.UI.config.firstDayOfWeek, 10)) ||
-          moment.localeData().firstDayOfWeek() ||
-          0,
+        this.firstDayOfWeek || parseInt(config.get('firstDayOfWeek'), 10) || moment.localeData().firstDayOfWeek() || 0,
       );
     }
 

--- a/ui/widgets/nuxeo-date-picker.js
+++ b/ui/widgets/nuxeo-date-picker.js
@@ -193,7 +193,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
       this.$.date.set('i18n.today', this.i18n('today'));
       this.$.date.set(
         'i18n.firstDayOfWeek',
-        this.firstDayOfWeek || parseInt(config.get('firstDayOfWeek'), 10) || moment.localeData().firstDayOfWeek() || 0,
+        this.firstDayOfWeek || config.get('firstDayOfWeek', moment.localeData().firstDayOfWeek() || 0),
       );
     }
 

--- a/ui/widgets/nuxeo-date.js
+++ b/ui/widgets/nuxeo-date.js
@@ -17,6 +17,7 @@ limitations under the License.
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import { FormatBehavior } from '../nuxeo-format-behavior.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import './nuxeo-tooltip.js';
@@ -80,7 +81,7 @@ import './nuxeo-tooltip.js';
         timezone: {
           type: String,
           value() {
-            return Nuxeo.UI && Nuxeo.UI.config && Nuxeo.UI.config.timezone;
+            return config.get('timezone');
           },
         },
       };


### PR DESCRIPTION
This PR adds a ui configuration service. By importing `config.js`, the configuration service is exposed in `Nuxeo.UI.config`. For convenience, it is also exported as an object by the module, so you can do `import config from '@nuxeo/nuxeo-elements/config.js';` instead of accessing to the global namespace.

The configuration service has two methods, `get` and `set`, which allows you to read and write property values. For compatibility with what we currently use, the properties are read and written to the `Nuxeo.UI.config` object itself. 
```
Nuxeo.UI.config.get('my.property'); // returns the value of Nuxeo.UI.config.my.property
Nuxeo.UI.config.set('my.property', value); // same as Nuxeo.UI.config.my.property = value
```
The `get` method returns `undefined` if the path is invalid. The `set` method creates the required middle segments to make the path valid.

### To consider

We don't need it yet, but we could have a helper on `nuxeo-filters-behavior` to assert whether or not a given property is set or has a specific value. It could look something like this:
```
  /**
   * Checks if a configuration property is set with a given value. If value is undefined, it returns true if the value
   * is not falsy.
   */
  hasConfig(key, value) {
    if (value !== undefined) {
      return config.get(key) === value;
    }
    return !!config.get(key);
  },
```

### Experiments

Experiment A: Adding a fallback to the get helper, which tries to evaluate the result based on the fallback data type (see https://github.com/nuxeo/nuxeo-elements/pull/407/commits/d06e5aac292de4c4d58555f2d2e20ee29a6ee844).