### PR TITLE
ELEMENTS-1368: make notification possible for disconnected elements

### DIFF
--- a/core/nuxeo-audit-page-provider.js
+++ b/core/nuxeo-audit-page-provider.js
@@ -17,9 +17,11 @@ limitations under the License.
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class';
 import './nuxeo-element.js';
 import './nuxeo-operation.js';
 import './nuxeo-resource.js';
+import { NotifyBehavior } from './nuxeo-notify-behavior.js';
 
 {
   /**
@@ -37,7 +39,7 @@ import './nuxeo-resource.js';
    *
    * @memberof Nuxeo
    */
-  class AuditPageProvider extends Nuxeo.Element {
+  class AuditPageProvider extends mixinBehaviors([NotifyBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style>
@@ -308,15 +310,7 @@ import './nuxeo-resource.js';
           return response;
         })
         .catch((error) => {
-          this.dispatchEvent(
-            new CustomEvent('notify', {
-              composed: true,
-              bubbles: true,
-              detail: {
-                error,
-              },
-            }),
-          );
+          this.notify({ error });
           throw error;
         });
     }

--- a/core/nuxeo-notify-behavior.js
+++ b/core/nuxeo-notify-behavior.js
@@ -1,0 +1,54 @@
+/**
+@license
+(C) Copyright Nuxeo Corp. (http://nuxeo.com/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import '@polymer/polymer/polymer-legacy.js';
+
+let fallback;
+
+/**
+ * Sets an element as the default fallback notification target. See `NotifyBehavior.notify` for more details.
+ *
+ * @param {*} el The element to be set as the fallback notification target.
+ */
+export const setFallbackNotificationTarget = (el) => {
+  fallback = el;
+};
+
+/**
+ * @polymerBehavior Nuxeo.NotifyBehavior
+ */
+export const NotifyBehavior = {
+  /**
+   * Fires a notification event. The event will be fired from the current element if it is attached to the DOM.
+   * Otherwise, it will be fired from the fallback notification target, if defined. It can be set with
+   * `setFallbackNotificationTarget`.
+   *
+   * @param {*} options the event options; these might vary according to who's handling the event.
+   */
+  notify(options) {
+    const target = this.isConnected ? this : fallback;
+    if (!target) {
+      return;
+    }
+    target.dispatchEvent(
+      new CustomEvent('notify', {
+        composed: true,
+        bubbles: true,
+        detail: options,
+      }),
+    );
+  },
+};

--- a/core/test/nuxeo-notify-behavior.test.js
+++ b/core/test/nuxeo-notify-behavior.test.js
@@ -1,0 +1,98 @@
+/**
+@license
+(C) Copyright Nuxeo Corp. (http://nuxeo.com/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+import { fixture, flush, html } from '@nuxeo/testing-helpers';
+import '@polymer/polymer/lib/elements/dom-if.js';
+import * as polymer from '@polymer/polymer/lib/utils/html-tag.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import '../nuxeo-element.js';
+import { NotifyBehavior, setFallbackNotificationTarget } from '../nuxeo-notify-behavior.js';
+
+suite('nuxeo-notify-behavior', () => {
+  customElements.define(
+    'inner-element',
+    class extends mixinBehaviors([NotifyBehavior], Nuxeo.Element) {
+      static get is() {
+        return 'inner-element';
+      }
+    },
+  );
+
+  customElements.define(
+    'outer-element',
+    class extends mixinBehaviors([NotifyBehavior], Nuxeo.Element) {
+      static get is() {
+        return 'outer-element';
+      }
+
+      static get template() {
+        return polymer.html`
+          <slot></slot>
+        `;
+      }
+    },
+  );
+
+  suite('When notify is called', async () => {
+    test('Should fire "notify" event', async () => {
+      const message = 'message';
+      const outer = await fixture(html`
+        <outer-element>
+          <inner-element></inner-element>
+        </outer-element>
+      `);
+
+      // wait for the notify event to be fired
+      const inner = outer.querySelector('inner-element');
+      const notifyReceived = new Promise((resolve) => {
+        document.addEventListener('notify', (e) => resolve(e));
+      });
+      inner.notify({ message });
+
+      // make sure the message was the expected and that the target was the inner element
+      const evt = await notifyReceived;
+      expect(evt.detail.message).to.equal('message');
+      expect(evt.target).to.equal(inner);
+    });
+
+    test('Should fire "notify" event from fallback target when element is not connected', async () => {
+      const message = 'message';
+      const outer = await fixture(html`
+        <outer-element>
+          <inner-element></inner-element>
+        </outer-element>
+      `);
+      setFallbackNotificationTarget(outer);
+
+      // disconnect inner element
+      const inner = outer.querySelector('inner-element');
+      outer.removeChild(inner);
+      await flush();
+      expect(inner.isConnected).to.be.false;
+
+      // wait for the notify event to be fired
+      const notifyReceived = new Promise((resolve) => {
+        document.addEventListener('notify', (e) => resolve(e));
+      });
+      inner.notify({ message });
+
+      // make sure the message was the expected and that the target was the outer element
+      const evt = await notifyReceived;
+      expect(evt.detail.message).to.equal(message);
+      expect(evt.target).to.equal(outer);
+    });
+  });
+});

--- a/ui/actions/nuxeo-lock-toggle-button.js
+++ b/ui/actions/nuxeo-lock-toggle-button.js
@@ -23,6 +23,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { FiltersBehavior } from '../nuxeo-filters-behavior.js';
 import { FormatBehavior } from '../nuxeo-format-behavior.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
@@ -45,7 +46,10 @@ import '../nuxeo-button-styles.js';
    * @memberof Nuxeo
    * @demo demo/nuxeo-lock-toggle-button/index.html
    */
-  class LockToggleButton extends mixinBehaviors([I18nBehavior, FiltersBehavior, FormatBehavior], Nuxeo.Element) {
+  class LockToggleButton extends mixinBehaviors(
+    [NotifyBehavior, I18nBehavior, FiltersBehavior, FormatBehavior],
+    Nuxeo.Element,
+  ) {
     static get template() {
       return html`
         <style include="nuxeo-action-button-styles nuxeo-button-styles">
@@ -191,13 +195,7 @@ import '../nuxeo-button-styles.js';
         default:
           message = this.i18n(`${errorKey}.unexpectedError`);
       }
-      this.dispatchEvent(
-        new CustomEvent('notify', {
-          composed: true,
-          bubbles: true,
-          detail: { message },
-        }),
-      );
+      this.notify({ message });
     }
 
     _computeTooltip(locked) {

--- a/ui/actions/nuxeo-move-documents-down-button.js
+++ b/ui/actions/nuxeo-move-documents-down-button.js
@@ -20,6 +20,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import '../nuxeo-icons.js';
 import '../widgets/nuxeo-tooltip.js';
@@ -34,7 +35,7 @@ import '../nuxeo-button-styles.js';
    * @memberof Nuxeo
    * @demo demo/nuxeo-move-documents-down-button/index.html
    */
-  class MoveDocumentsDown extends mixinBehaviors([I18nBehavior], Nuxeo.Element) {
+  class MoveDocumentsDown extends mixinBehaviors([NotifyBehavior, I18nBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style include="nuxeo-action-button-styles nuxeo-button-styles">
@@ -129,13 +130,7 @@ import '../nuxeo-button-styles.js';
           );
         })
         .catch(() => {
-          this.dispatchEvent(
-            new CustomEvent('notify', {
-              composed: true,
-              bubbles: true,
-              detail: { message: this.i18n('moveDocumentButton.error') },
-            }),
-          );
+          this.notify({ message: this.i18n('moveDocumentButton.error') });
         });
     }
 

--- a/ui/actions/nuxeo-move-documents-up-button.js
+++ b/ui/actions/nuxeo-move-documents-up-button.js
@@ -20,6 +20,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import '../nuxeo-icons.js';
 import '../widgets/nuxeo-tooltip.js';
@@ -34,7 +35,7 @@ import '../nuxeo-button-styles.js';
    * @memberof Nuxeo
    * @demo demo/nuxeo-move-documents-up-button/index.html
    */
-  class MoveDocumentsUp extends mixinBehaviors([I18nBehavior], Nuxeo.Element) {
+  class MoveDocumentsUp extends mixinBehaviors([NotifyBehavior, I18nBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style include="nuxeo-action-button-styles nuxeo-button-styles">
@@ -129,13 +130,7 @@ import '../nuxeo-button-styles.js';
           );
         })
         .catch(() => {
-          this.dispatchEvent(
-            new CustomEvent('notify', {
-              composed: true,
-              bubbles: true,
-              detail: { message: this.i18n('moveDocumentButton.error') },
-            }),
-          );
+          this.notify({ message: this.i18n('moveDocumentButton.error') });
         });
     }
 

--- a/ui/actions/nuxeo-share-button.js
+++ b/ui/actions/nuxeo-share-button.js
@@ -27,6 +27,7 @@ import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/paper-input/paper-input.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import '../nuxeo-icons.js';
 import '../widgets/nuxeo-dialog.js';
@@ -47,7 +48,7 @@ import '../nuxeo-button-styles.js';
    * @memberof Nuxeo
    * @demo demo/nuxeo-share-button/index.html
    */
-  class ShareButton extends mixinBehaviors([I18nBehavior], Nuxeo.Element) {
+  class ShareButton extends mixinBehaviors([NotifyBehavior, I18nBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style include="nuxeo-action-button-styles nuxeo-button-styles">
@@ -179,7 +180,7 @@ import '../nuxeo-button-styles.js';
 
       shareButton.set('icon', 'check');
       shareButton.classList.add('selected');
-      this.fire('notify', { message: this.i18n('shareButton.operation.copied'), duration: 2000 });
+      this.notify({ message: this.i18n('shareButton.operation.copied'), duration: 2000 });
     }
   }
 

--- a/ui/nuxeo-document-comments/nuxeo-document-comment-thread.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment-thread.js
@@ -20,6 +20,7 @@ import '@polymer/polymer/lib/elements/dom-if.js';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '../widgets/nuxeo-tooltip.js';
 // eslint-disable-next-line import/no-cycle
 import './nuxeo-document-comment.js';
@@ -41,7 +42,7 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
  * @demo https://nuxeo.github.io/nuxeo-elements/?path=/story/ui-nuxeo-document-comments--nuxeo-document-comment-thread
  */
 {
-  class DocumentCommentThread extends mixinBehaviors([FormatBehavior], Nuxeo.Element) {
+  class DocumentCommentThread extends mixinBehaviors([NotifyBehavior, FormatBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style include="nuxeo-document-comments-styles"></style>
@@ -227,21 +228,9 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
         })
         .catch((error) => {
           if (error.status === 404) {
-            this.dispatchEvent(
-              new CustomEvent('notify', {
-                composed: true,
-                bubbles: true,
-                detail: { message: this._computeTextLabel(this.level, 'notFound') },
-              }),
-            );
+            this.notify({ message: this._computeTextLabel(this.level, 'notFound') });
           } else {
-            this.dispatchEvent(
-              new CustomEvent('notify', {
-                composed: true,
-                bubbles: true,
-                detail: { message: this._computeTextLabel(this.level, 'fetch.error') },
-              }),
-            );
+            this.notify({ message: this._computeTextLabel(this.level, 'fetch.error') });
             throw error;
           }
         });
@@ -310,21 +299,9 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
         })
         .catch((error) => {
           if (error.status === 404) {
-            this.dispatchEvent(
-              new CustomEvent('notify', {
-                composed: true,
-                bubbles: true,
-                detail: { message: this._computeTextLabel(this.level, 'notFound') },
-              }),
-            );
+            this.notify({ message: this._computeTextLabel(this.level, 'notFound') });
           } else {
-            this.dispatchEvent(
-              new CustomEvent('notify', {
-                composed: true,
-                bubbles: true,
-                detail: { message: this._computeTextLabel(this.level, 'creation.error') },
-              }),
-            );
+            this.notify({ message: this._computeTextLabel(this.level, 'creation.error') });
             throw error;
           }
         });

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -26,6 +26,7 @@ import '@polymer/polymer/lib/elements/dom-if.js';
 import '@nuxeo/nuxeo-elements/nuxeo-connection.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '../widgets/nuxeo-dialog.js';
 import '../widgets/nuxeo-tooltip.js';
 // eslint-disable-next-line import/no-cycle
@@ -50,7 +51,7 @@ import '../nuxeo-button-styles.js';
  * @demo https://nuxeo.github.io/nuxeo-elements/?path=/story/ui-nuxeo-document-comments--nuxeo-document-comment
  */
 {
-  class DocumentComment extends mixinBehaviors([FormatBehavior], Nuxeo.Element) {
+  class DocumentComment extends mixinBehaviors([NotifyBehavior, FormatBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style include="nuxeo-document-comments-styles nuxeo-button-styles">
@@ -385,21 +386,9 @@ import '../nuxeo-button-styles.js';
         })
         .catch((error) => {
           if (error.status === 404) {
-            this.dispatchEvent(
-              new CustomEvent('notify', {
-                composed: true,
-                bubbles: true,
-                detail: { message: this._computeTextLabel(this.level, 'notFound') },
-              }),
-            );
+            this.notify({ message: this._computeTextLabel(this.level, 'notFound') });
           } else {
-            this.dispatchEvent(
-              new CustomEvent('notify', {
-                composed: true,
-                bubbles: true,
-                detail: { message: this._computeTextLabel(this.level, 'deletion.error') },
-              }),
-            );
+            this.notify({ message: this._computeTextLabel(this.level, 'deletion.error') });
             throw error;
           }
         });
@@ -469,21 +458,9 @@ import '../nuxeo-button-styles.js';
         })
         .catch((error) => {
           if (error.status === 404) {
-            this.dispatchEvent(
-              new CustomEvent('notify', {
-                composed: true,
-                bubbles: true,
-                detail: { message: this._computeTextLabel(this.level, 'notFound') },
-              }),
-            );
+            this.notify({ message: this._computeTextLabel(this.level, 'notFound') });
           } else {
-            this.dispatchEvent(
-              new CustomEvent('notify', {
-                composed: true,
-                bubbles: true,
-                detail: { message: this._computeTextLabel(this.level, 'edition.error') },
-              }),
-            );
+            this.notify({ message: this._computeTextLabel(this.level, 'edition.error') });
             throw error;
           }
         });

--- a/ui/search/nuxeo-results-view.js
+++ b/ui/search/nuxeo-results-view.js
@@ -19,6 +19,7 @@ import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class';
 import '@polymer/iron-flex-layout/iron-flex-layout.js';
 import '@polymer/iron-collapse/iron-collapse.js';
 import '@nuxeo/nuxeo-elements/nuxeo-page-provider.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import './nuxeo-search-form-layout.js';
 import './nuxeo-search-results-layout.js';
@@ -30,7 +31,7 @@ import './nuxeo-search-results-layout.js';
    * @appliesMixin Nuxeo.I18nBehavior
    * @element nuxeo-results-view
    */
-  class ResultsView extends mixinBehaviors([I18nBehavior], Nuxeo.Element) {
+  class ResultsView extends mixinBehaviors([NotifyBehavior, I18nBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style include="nuxeo-styles iron-flex iron-flex-alignment">
@@ -371,13 +372,8 @@ import './nuxeo-search-results-layout.js';
     }
 
     _onError(e) {
-      this.dispatchEvent(
-        new CustomEvent('notify', {
-          composed: true,
-          bubbles: true,
-          detail: e.detail.error,
-        }),
-      );
+      // XXX fix me later: we are firing an error object instead an object with { message: ...}
+      this.notify(e.detail.error);
       e.stopPropagation();
     }
 

--- a/ui/widgets/nuxeo-operation-button.js
+++ b/ui/widgets/nuxeo-operation-button.js
@@ -21,6 +21,7 @@ import '@polymer/iron-icon/iron-icon.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
+import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import './nuxeo-tooltip.js';
 import '../actions/nuxeo-action-button-styles.js';
@@ -40,7 +41,7 @@ import '../actions/nuxeo-action-button-styles.js';
    * @memberof Nuxeo
    * @demo demo/nuxeo-operation-button/index.html
    */
-  class OperationButton extends mixinBehaviors([I18nBehavior], Nuxeo.Element) {
+  class OperationButton extends mixinBehaviors([NotifyBehavior, I18nBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style include="nuxeo-action-button-styles"></style>
@@ -176,13 +177,7 @@ import '../actions/nuxeo-action-button-styles.js';
         .execute()
         .then((response) => {
           if (this.notification) {
-            this.dispatchEvent(
-              new CustomEvent('notify', {
-                composed: true,
-                bubbles: true,
-                detail: { message: this.i18n(this.notification) },
-              }),
-            );
+            this.notify({ message: this.i18n(this.notification) });
           }
           let detail = { response };
           if (this.detail) {
@@ -202,13 +197,7 @@ import '../actions/nuxeo-action-button-styles.js';
           }
         })
         .catch((error) => {
-          this.dispatchEvent(
-            new CustomEvent('notify', {
-              composed: true,
-              bubbles: true,
-              detail: { message: this.errorLabel ? this.i18n(this.errorLabel, error) : error },
-            }),
-          );
+          this.notify({ message: this.errorLabel ? this.i18n(this.errorLabel, error) : error });
           if (error.status !== 404) {
             throw error;
           }


### PR DESCRIPTION
The goal of this WIP is to prototype the feature of making notification possible for elements that are disconnected from the DOM. Currently, notification corresponds to firing a `notify` event from the current element, which won't work as soon as this element is no longer attached to the DOM. The proposed solution consists of introducing a polymer behavior with two methods:

1. one to fire the event from the current element if it is attached to the DOM, or from a fallback target otherwise
2. one to define the fallback target

Discussion points:

- I exposed it as a behavior just so that this functionally can be used in designer without any issues, but this could be changed in favour of something more modern.
- We could also add to the behavior dedicated methods to abstract the fact that we are dealing with events, which would encapsulate `addEventListener('notify', ...)` and `removeEventListener('notify', ...)`
- The name of the methods is totally up for discussion.
- Alternative approaches?
- This is required by [ELEMENTS-1339](https://jira.nuxeo.com/browse/ELEMENTS-1339), but perhaps we should create a dedicated ticket for this?
- Instead of having a single fallback target, we could have several. Not sure it would have any use, though.