### PR TITLE
Detach Connection and Operation logics

### DIFF
--- a/core/nuxeo-operation.js
+++ b/core/nuxeo-operation.js
@@ -16,7 +16,241 @@ limitations under the License.
 */
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import './nuxeo-element.js';
-import './nuxeo-connection.js';
+import { Connection, ConnectionMixin } from './nuxeo-connection.js';
+
+export class Operation extends EventTarget {
+  constructor(opts) {
+    super();
+    this.operation = opts && opts.operation;
+    this.async = (opts && opts.async) || false;
+    this.pollInterval = (opts && opts.pollInterval) || 1000;
+    this.connection = (opts && opts.connection) || new Connection();
+  }
+
+  execute(opts) {
+    let { input } = opts;
+    const { params, schemas, headers, signal } = opts;
+
+    // support page provider as input to operations
+    // relies on parameters naming convention until provider marshaller is available
+    if (Nuxeo.PageProvider && input instanceof Nuxeo.PageProvider) {
+      params.providerName = input.provider;
+      Object.assign(params, input._params);
+      // ELEMENTS-1318 - commas would need to be escaped, as queryParams are mapped to stringlists by the server
+      // But passing queryParams as an array will map directly to the server stringlist
+      if (!Array.isArray(params.queryParams)) {
+        params.queryParams = [params.queryParams];
+      }
+      input = undefined;
+    }
+
+    const options = { signal, schemas, headers };
+
+    return this.connection
+      .operation(this.operation)
+      .then((operation) => this._doExecute(operation, input, params, options));
+  }
+
+  _doExecute(operation, input, params, options) {
+    if (params.context) {
+      operation = operation.context(params.context);
+    }
+
+    if (this.async) {
+      options.url = `${operation._computeRequestURL()}/@async`;
+      options.resolveWithFullResponse = true;
+    }
+
+    let promise = operation
+      .params(params)
+      .input(input)
+      .execute(options);
+
+    if (this.async) {
+      promise = promise.then((res) => {
+        if (res.status === 202) {
+          this.dispatchEvent(
+            new CustomEvent('poll-start', {
+              bubbles: true,
+              composed: true,
+            }),
+          );
+          return this._poll(res.headers.get('location'));
+        }
+        return res;
+      });
+    }
+
+    return promise;
+  }
+
+  _isRunning(status) {
+    if (status['entity-type'] === 'bulkStatus') {
+      const { state } = status.value;
+      return state !== 'ABORTED' && state !== 'COMPLETED';
+    }
+    return status === 'RUNNING';
+  }
+
+  _poll(url) {
+    return new Promise((resolve, reject) => {
+      const fn = () => {
+        this.connection
+          .http(url)
+          .then((res) => {
+            if (this._isRunning(res)) {
+              window.setTimeout(() => fn(), this.pollInterval, url);
+            } else {
+              resolve(res);
+            }
+          })
+          .catch((error) => {
+            reject(error);
+          });
+      };
+      fn();
+    });
+  }
+}
+
+export const OperationMixin = (superClass) =>
+  class extends ConnectionMixin(superClass) {
+    static get properties() {
+      return {
+        /** The id the operation to call. */
+        operation: {
+          type: String,
+          value: '',
+        },
+
+        /** The parameters to send. */
+        params: {
+          type: Object,
+          value: {},
+        },
+
+        /** The operation input. */
+        input: {
+          type: Object,
+        },
+
+        /** The headers of the request. */
+        headers: {
+          type: Object,
+          value: null,
+        },
+
+        /**
+         * List of comma separated values of the document schemas to be returned.
+         * All document schemas are returned by default.
+         */
+        schemas: {
+          type: String,
+          value: '',
+        },
+
+        /**
+         * If true, documents changed by the call will be reindexed synchronously server side.
+         */
+        syncIndexing: Boolean,
+
+        /**
+         * If true, execute the operation asynchronously.
+         */
+        async: {
+          type: Boolean,
+          value: false,
+        },
+
+        /**
+         * Poll interval in ms.
+         */
+        pollInterval: {
+          type: Number,
+          value: 1000,
+        },
+
+        /** Indicates if the request behind this operation cannot be canceled.
+         * By default a request is cancelable, which means that if on the same `nuxeo-operation`
+         * we perform two sequential requests: Request A & Request B. The first one will be
+         * aborted and we keep the last one (in our case request B). This is done to avoid
+         * an obsolete responses.
+         * */
+        uncancelable: {
+          type: Boolean,
+        },
+      };
+    }
+
+    execute(opts) {
+      const options = Object.assign(
+        {
+          input: this.input,
+          params: !this.params || typeof this.params === 'object' ? this.params : JSON.parse(this.params),
+          schemas: this.schemas && this.schemas.length > 1 && this.schemas.trim().split(/[\s,]+/),
+          headers: this.headers || {},
+        },
+        opts,
+      );
+
+      if (this.syncIndexing) {
+        options.headers['nx-es-sync'] = true;
+      }
+
+      // Manage the way to abort the request
+      if (!this.uncancelable) {
+        if (this._controller) {
+          this._controller.abort();
+        }
+        // For the next request
+        this._controller = new AbortController();
+        options.signal = this._controller.signal;
+      }
+
+      if (!this._operation || this.uncancelable) {
+        this._operation = new Operation({ connection: this.connection });
+        this._operation.addEventListener('poll-start', () =>
+          this.dispatchEvent(
+            new CustomEvent('poll-start', {
+              bubbles: true,
+              composed: true,
+            }),
+          ),
+        );
+      }
+
+      this._operation.operation = this.operation;
+      this._operation.async = this.async;
+      this._operation.pollInterval = this.pollInterval;
+
+      return this._operation
+        .execute(options)
+        .then((data) => {
+          this.dispatchEvent(
+            new CustomEvent('response', {
+              bubbles: true,
+              composed: true,
+              detail: {
+                response: data,
+              },
+            }),
+          );
+          return data;
+        })
+        .catch((error) => {
+          if (error.response.status === 401) {
+            this.dispatchEvent(
+              new CustomEvent('unauthorized-request', {
+                bubbles: true,
+                composed: true,
+                detail: error,
+              }),
+            );
+          }
+          throw error;
+        });
+    }
+  };
 
 {
   /**
@@ -38,7 +272,7 @@ import './nuxeo-connection.js';
    *
    * @memberof Nuxeo
    */
-  class Operation extends Nuxeo.Element {
+  class OperationElement extends OperationMixin(Nuxeo.Element) {
     static get template() {
       return html`
         <style>
@@ -46,7 +280,6 @@ import './nuxeo-connection.js';
             display: none;
           }
         </style>
-        <nuxeo-connection id="nx" connection-id="{{connectionId}}"></nuxeo-connection>
       `;
     }
 
@@ -56,12 +289,14 @@ import './nuxeo-connection.js';
 
     static get properties() {
       return {
-        /** The id of a nuxeo-connection to use. */
-        connectionId: {
+        /** The id the operation to call.
+         *
+         * @deprecated use `operation` instead-
+         */
+        op: {
           type: String,
           value: '',
         },
-
         /** The success response status */
         success: {
           type: Boolean,
@@ -72,33 +307,6 @@ import './nuxeo-connection.js';
         error: {
           type: String,
           notify: true,
-        },
-
-        /** Indicates if the request behind this operation cannot be canceled.
-         * By default a request is cancelable, which means that if on the same `nuxeo-operation`
-         * we perform two sequential requests: Request A & Request B. The first one will be
-         * aborted and we keep the last one (in our case request B). This is done to avoid
-         * an obsolete responses.
-         * */
-        uncancelable: {
-          type: Boolean,
-        },
-
-        /** The id the operation to call. */
-        op: {
-          type: String,
-          value: '',
-        },
-
-        /** The parameters to send. */
-        params: {
-          type: Object,
-          value: {},
-        },
-
-        /** The operation input. */
-        input: {
-          type: Object,
         },
 
         /** If true, automatically execute the operation when either `op` or `params` changes. */
@@ -112,12 +320,6 @@ import './nuxeo-connection.js';
           type: Object,
           value: null,
           notify: true,
-        },
-
-        /** The headers of the request. */
-        headers: {
-          type: Object,
-          value: null,
         },
 
         /**
@@ -137,15 +339,6 @@ import './nuxeo-connection.js';
         },
 
         /**
-         * List of comma separated values of the document schemas to be returned.
-         * All document schemas are returned by default.
-         */
-        schemas: {
-          type: String,
-          value: '',
-        },
-
-        /**
          * Active request count.
          */
         activeRequests: {
@@ -156,33 +349,12 @@ import './nuxeo-connection.js';
         },
 
         /**
-         * If true, documents changed by the call will be reindexed synchronously server side.
-         */
-        syncIndexing: Boolean,
-
-        /**
          * True while requests are in flight.
          */
         loading: {
           type: Boolean,
           notify: true,
           readOnly: true,
-        },
-
-        /**
-         * If true, execute the operation asynchronously.
-         */
-        async: {
-          type: Boolean,
-          value: false,
-        },
-
-        /**
-         * Poll interval in ms.
-         */
-        pollInterval: {
-          type: Number,
-          value: 1000,
         },
       };
     }
@@ -196,36 +368,11 @@ import './nuxeo-connection.js';
      *
      * @event response
      */
-    execute() {
+    async execute() {
       this._setActiveRequests(this.activeRequests + 1);
 
-      const params = !this.params || typeof this.params === 'object' ? this.params : JSON.parse(this.params);
-
-      let { input } = this;
-
-      // support page provider as input to operations
-      // relies on parameters naming convention until provider marshaller is available
-      if (Nuxeo.PageProvider && input instanceof Nuxeo.PageProvider) {
-        params.providerName = input.provider;
-        Object.assign(params, input._params);
-        // ELEMENTS-1318 - commas would need to be escaped, as queryParams are mapped to stringlists by the server
-        // But passing queryParams as an array will map directly to the server stringlist
-        if (!Array.isArray(params.queryParams)) {
-          params.queryParams = [params.queryParams];
-        }
-        input = undefined;
-      }
-
       const options = {};
-      // Look up document schemas to be returned
-      if (this.schemas && this.schemas.length > 1) {
-        options.schemas = this.schemas.trim().split(/[\s,]+/);
-      }
-      options.headers = this.headers || {};
-      // Force sync indexing
-      if (this.syncIndexing) {
-        options.headers['nx-es-sync'] = true;
-      }
+
       // Look up content enrichers parameter
       if (this.enrichers) {
         let enrich = {};
@@ -243,85 +390,17 @@ import './nuxeo-connection.js';
         });
       }
 
-      // Manage the way to abort the request
-      if (!this.uncancelable) {
-        if (this._controller) {
-          this._controller.abort();
-        }
+      this.operation = this.op;
 
-        // For the next request
-        this._controller = new AbortController();
-        options.signal = this._controller.signal;
-      }
-
-      return this.$.nx.operation(this.op).then((operation) => {
-        this._operation = operation;
-        return this._doExecute(input, params, options);
-      });
-    }
-
-    _autoExecute() {
-      if (this.auto) {
-        this.execute();
-      }
-    }
-
-    _doExecute(input, params, options) {
-      if (params.context) {
-        this._operation = this._operation.context(params.context);
-      }
-
-      if (this.async) {
-        options.url = `${this._operation._computeRequestURL()}/@async`;
-        options.resolveWithFullResponse = true;
-      }
-
-      let promise = this._operation
-        .params(params)
-        .input(input)
-        .execute(options);
-
-      if (this.async) {
-        promise = promise.then((res) => {
-          if (res.status === 202) {
-            this.dispatchEvent(
-              new CustomEvent('poll-start', {
-                bubbles: true,
-                composed: true,
-              }),
-            );
-            return this._poll(res.headers.get('location'));
-          }
-          return res;
-        });
-      }
-
-      return promise
+      return super
+        .execute(options)
         .then((data) => {
-          this.dispatchEvent(
-            new CustomEvent('response', {
-              bubbles: true,
-              composed: true,
-              detail: {
-                response: data,
-              },
-            }),
-          );
           this.response = data;
           this.success = true;
           this._setActiveRequests(this.activeRequests - 1);
           return this.response;
         })
         .catch((error) => {
-          if (error.response.status === 401) {
-            this.dispatchEvent(
-              new CustomEvent('unauthorized-request', {
-                bubbles: true,
-                composed: true,
-                detail: error,
-              }),
-            );
-          }
           this.success = false;
           this.error = error;
           console.warn(`Operation request failed: ${error}`);
@@ -330,32 +409,10 @@ import './nuxeo-connection.js';
         });
     }
 
-    _isRunning(status) {
-      if (status['entity-type'] === 'bulkStatus') {
-        const { state } = status.value;
-        return state !== 'ABORTED' && state !== 'COMPLETED';
+    _autoExecute() {
+      if (this.auto) {
+        this.execute();
       }
-      return status === 'RUNNING';
-    }
-
-    _poll(url) {
-      return new Promise((resolve, reject) => {
-        const fn = () => {
-          this.$.nx
-            .http(url)
-            .then((res) => {
-              if (this._isRunning(res)) {
-                window.setTimeout(() => fn(), this.pollInterval, url);
-              } else {
-                resolve(res);
-              }
-            })
-            .catch((error) => {
-              reject(error);
-            });
-        };
-        fn();
-      });
     }
 
     _isLoading() {
@@ -363,6 +420,6 @@ import './nuxeo-connection.js';
     }
   }
 
-  customElements.define(Operation.is, Operation);
-  Nuxeo.Operation = Operation;
+  customElements.define(OperationElement.is, OperationElement);
+  Nuxeo.Operation = OperationElement;
 }

--- a/core/test/nuxeo-connection.test.js
+++ b/core/test/nuxeo-connection.test.js
@@ -26,7 +26,7 @@ const loginResponse = [200, responseHeaders.json, '{"entity-type":"login","usern
 
 const userResponse = [200, responseHeaders.json, '{"entity-type":"user","username":"Administrator"}'];
 
-const cmisResponse = [200, responseHeaders.json, '{}'];
+const cmisResponse = [200, responseHeaders.json, '{"default": {"productVersion": "1.2.3"}}'];
 
 suite('nuxeo-connection', () => {
   let server;
@@ -48,22 +48,29 @@ suite('nuxeo-connection', () => {
     });
 
     test('should run the next', async () => {
+      const connected = new Promise((resolve) => {
+        document.addEventListener('connected', (e) => resolve(e));
+      });
       const connection = await fixture(
         html`
           <nuxeo-connection connection-id="nxc-ok"></nuxeo-connection>
         `,
       );
-
       try {
         // Return current connection
         await connection.connect();
 
-        // Test if component succeeded to log in
-        expect(connection.connected).to.be.equal(true);
+        // Wait for the 'connected' event to be fired
+        await connected;
       } catch (_) {
         // We shouldn't be there
         throw new Error('Expected to run something after a succeeded connection!');
       }
+
+      // Test if component succeeded to log in
+      expect(connection.connected).to.be.equal(true);
+      expect(connection.user.username).to.be.equal('Administrator');
+      expect(connection.platformVersion).to.be.equal('1.2.3');
     });
   });
 
@@ -114,7 +121,7 @@ suite('nuxeo-connection', () => {
     test('first connection should succeed', async () => {
       const connection = await fixture(
         html`
-          <nuxeo-connection></nuxeo-connection>
+          <nuxeo-connection connection-id="nxu"></nuxeo-connection>
         `,
       );
 
@@ -129,7 +136,7 @@ suite('nuxeo-connection', () => {
     test('similar connections should not issue requests', async () => {
       const connection = await fixture(
         html`
-          <nuxeo-connection></nuxeo-connection>
+          <nuxeo-connection connection-id="nxu"></nuxeo-connection>
         `,
       );
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,7 +38,7 @@ if (process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY) {
     sl_latest_safari: {
       base: 'SauceLabs',
       browserName: 'safari',
-      platform: 'macOS 10.13',
+      platform: 'macOS 11',
       version: 'latest',
     },
   };

--- a/ui/widgets/nuxeo-operation-button.js
+++ b/ui/widgets/nuxeo-operation-button.js
@@ -19,7 +19,7 @@ import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 import '@polymer/iron-icon/iron-icon.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
-import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
+import { OperationMixin } from '@nuxeo/nuxeo-elements/nuxeo-operation.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
@@ -41,21 +41,10 @@ import '../actions/nuxeo-action-button-styles.js';
    * @memberof Nuxeo
    * @demo demo/nuxeo-operation-button/index.html
    */
-  class OperationButton extends mixinBehaviors([NotifyBehavior, I18nBehavior], Nuxeo.Element) {
+  class OperationButton extends mixinBehaviors([NotifyBehavior, I18nBehavior], OperationMixin(Nuxeo.Element)) {
     static get template() {
       return html`
         <style include="nuxeo-action-button-styles"></style>
-
-        <nuxeo-operation
-          id="op"
-          op="[[operation]]"
-          input="[[input]]"
-          params="[[params]]"
-          sync-indexing$="[[syncIndexing]]"
-          async$="[[async]]"
-          poll-interval="[[pollInterval]]"
-        >
-        </nuxeo-operation>
 
         <div class="action" on-click="_execute">
           <paper-icon-button id="bt" icon="[[icon]]" aria-labelledby="label"></paper-icon-button>
@@ -173,8 +162,7 @@ import '../actions/nuxeo-action-button-styles.js';
     }
 
     _execute() {
-      this.$.op
-        .execute()
+      this.execute()
         .then((response) => {
           if (this.notification) {
             this.notify({ message: this.i18n(this.notification) });


### PR DESCRIPTION
This is a proposal to decouple the logics that rely on the JS client from the custom elements `nuxeo-connection`, `nuxeo-operation` and `nuxeo-resource`. This would allow other elements to reuse these logics without having to add a dedicated custom element to it's local DOM.

For the sake of brevity, I didn't decouple `nuxeo-resource` yet. I focused on `nuxeo-operation` and `nuxeo-connection` as they are used by `nuxeo-operation-button`, which consists of an interesting use case.

 Please let me know what you think. Unit tests are passing but there are still some functional tests failing, so some changes might still be needed.