### PR TITLE
ELEMENTS-1348: Set search layout base url fallback on Web UI import path

### DIFF
--- a/ui/search/nuxeo-search-form-layout.js
+++ b/ui/search/nuxeo-search-form-layout.js
@@ -120,7 +120,8 @@ import { RoutingBehavior } from '../nuxeo-routing-behavior.js';
 
     _formHref(provider, searchName, hrefBase) {
       const name = (searchName || provider).toLowerCase();
-      const base = hrefBase || pathFromUrl(this.__dataHost.importPath || this.importPath);
+      const appImportPath = window.Nuxeo && window.Nuxeo.UI && window.Nuxeo.UI.app && window.Nuxeo.UI.app.importPath;
+      const base = hrefBase || pathFromUrl(appImportPath ? `${appImportPath}search/` : this.importPath);
       return `${base}${name}/${['nuxeo', name, 'search-form'].join('-')}.html`;
     }
 

--- a/ui/search/nuxeo-search-results-layout.js
+++ b/ui/search/nuxeo-search-results-layout.js
@@ -104,7 +104,8 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 
     _resultsHref(searchName, hrefBase) {
       const name = searchName.toLowerCase();
-      const base = hrefBase || pathFromUrl(this.__dataHost.importPath || this.importPath);
+      const appImportPath = window.Nuxeo && window.Nuxeo.UI && window.Nuxeo.UI.app && window.Nuxeo.UI.app.importPath;
+      const base = hrefBase || pathFromUrl(appImportPath ? `${appImportPath}search/` : this.importPath);
       return `${base}${name}/${['nuxeo', name, 'search-results'].join('-')}.html`;
     }
 


### PR DESCRIPTION
# Problem
When serving Web UI locally, the URLs for the search form and results layouts are sometimes malformed, causing the layouts to not be loaded.

Currently, the base URL of these layouts is computed based on three parts:
- `hrefBase`: Can be passed to both the `<nuxeo-search-form-layout>` and `<nuxeo-search-results-layout>` elements, forcing the base URL for the layouts. If not provided, the base URL is computed based on the next part.
- `__dataHost.importPath`: The `importPath` of the element directly using either `<nuxeo-search-form-layout>` or `<nuxeo-search-results-layout>`. If not provided, the base URL is computed based on the next part.
- `importPath`: The `importPath` of either `<nuxeo-search-form-layout>` or `<nuxeo-search-results-layout>`.

Based on this information, we can see that these elements rely on the `hrefBase` property (if it exists), or on the `importPath` of the element using them (if it exists), or on their own `importPath`. Therefore, if `hrefBase` is not provided, it's hard to ensure a consistent base URL for all the loaded search layouts.

Take for example the layouts for `default_search` (`nuxeo-elements` `npm` installed, not symlinked):
- `form` layout: Loads correctly 👍 . There's no `hrefBase` provided, so it'll rely on the `importPath` of the element using `<nuxeo-search-form-layout>`, in this case, `<nuxeo-search-form>`. Since this element resides on the `search` directory of the Web UI elements, the base path is built to load the search form layout from that same path structure (where it finds the `default_search` form layout).
- `results` layout: Fails to load 👎 . There's no `hrefBase` provided, so it'll rely on the `importPath` of the element using `<nuxeo-search-results-layout>`, in this case, `__dataHost` is a `TemplateInstance` object that has no `importPath`, so it'll will end up relying on `<nuxeo-search-results-layout>`'s `importPath`. Since this element resides on the `search` directory of the Nuxeo elements, the base path is built to load the search results layout from that same path structure (where it won't find the `default_search` results layout).

Obviously, there are other implications with this mechanism. If any of these elements are being used inside an Elements element (instead of a Web UI one), it will still try to build a base path that points to the Elements directory (where the search layouts do not reside).

# Proposed Solution

Instead of having to rely in `importPath` of either the element that contains these elements or on their own `importPath`, rely on the `importPath` of `<nuxeo-app>`. This ensures that the base URL is always consistent, regardless of where these elements are used in the DOM, unless an `hrefBase` is provided.

This solution is based on the following assumptions:
- Whenever `<nuxeo-search-form-layout>` and `<nuxeo-search-results-layout>` are used, there is a `<nuxeo-app>` instance (unless `hrefBase` is provided). If the import path cannot be computed from `<nuxeo-app>`, then we rely on whatever the import path of the element is (just like we did before).
- All the layouts that are loaded through these elements reside in a `search` directory on the Web UI elements side. This should be already established via [the tree described in the documentation on overriding search layouts](https://doc.nuxeo.com/nxdoc/web-ui-search/#overriding-existing-nuxeo-web-ui-search). (`hrefBase` should also offer the flexibility to set a different base if these elements are being used outside of a Web UI context)

# Other Solutions

One other solution that was explored was to recursively check for the `__dataHost` (instead of only checking the direct one), but it's difficult to find a stopping condition that makes sense to know whether or not a Web UI element has been reached. One could assume that we want to go all the way back to `<nuxeo-app>` through this method, but this ends up being problematic in the context of slots, as you'll end up reaching the `<html>` node of the DOM before getting to `<nuxeo-app>`.

# Notes

As it is currently, this solution would also fix ELEMENTS-1333.