### PR TITLE
ELEMENTS-1394: change headers property type to object

### DIFF
--- a/ui/search/nuxeo-results-view.js
+++ b/ui/search/nuxeo-results-view.js
@@ -200,7 +200,7 @@ import './nuxeo-search-results-layout.js';
          * Already set by default are 'fetch-document': 'properties' and 'translate-directoryEntry': 'label'.
          */
         headers: {
-          type: String,
+          type: Object,
           value: { 'fetch-document': 'properties', 'translate-directoryEntry': 'label' },
         },
         /**


### PR DESCRIPTION
It seems that the property headers has always been of type String, but it was an object. 
See [Web UI 10.10](https://github.com/nuxeo/nuxeo-web-ui/commit/95921c92a620dffc4376e08c2f7507163931e689#diff-5f2d55d640c1ff242426eae4c96d6aaf41414625d1854817036a27c78618fe7dR198) when Gabriel introduced the element.