### PR TITLE
ELEMENTS-1401: Add dry run step for publish to npmjs.com

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -60,6 +60,13 @@ jobs:
         run: |
           npx lerna exec --ignore @nuxeo/nuxeo-elements-storybook -- npm publish --@nuxeo:registry=https://packages.nuxeo.com/repository/npm-public/
 
+      - name: Publish to https://registry.npmjs.org (dry run)
+        if: ${{ github.event.inputs.dryRun }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+        run: |
+          npx lerna exec --ignore @nuxeo/nuxeo-elements-storybook -- npm publish --@nuxeo:registry=https://registry.npmjs.org/ --access public --dry-run
+
       - name: Publish to https://registry.npmjs.org
         continue-on-error: true
         if: ${{ !github.event.inputs.dryRun }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -53,6 +53,13 @@ jobs:
           tag_name: v${{ env.VERSION }}
           release_name: Release ${{ env.VERSION }}
 
+      - name: Publish to https://packages.nuxeo.com/repository/npm-public/ (dry run)
+        if: ${{ github.event.inputs.dryRun }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+        run: |
+          npx lerna exec --ignore @nuxeo/nuxeo-elements-storybook -- npm publish --@nuxeo:registry=https://packages.nuxeo.com/repository/npm-public/ --dry-run
+
       - name: Publish to https://packages.nuxeo.com/repository/npm-public/
         if: ${{ !github.event.inputs.dryRun }}
         env:


### PR DESCRIPTION
- According to the documentation on [npm-publish](https://docs.npmjs.com/cli/v7/commands/npm-publish), we need to add a new step with a `--dry-run` option.
- This step works just like the original one (practically the same command, same auth token), except it should be triggered only when the `dryRun` input is passed (the inverse of the original one).
- I couldn’t find a way to make this cleaner (like reusing the same step and adding the flag only if the `dryRun` input is passed), so the only option was to duplicate the original step.