### PR TITLE
ELEMENTS-1398: add support for select all in justified grid

### DIFF
--- a/ui/nuxeo-justified-grid/nuxeo-justified-grid.js
+++ b/ui/nuxeo-justified-grid/nuxeo-justified-grid.js
@@ -337,15 +337,6 @@ import { RoutingBehavior } from '../nuxeo-routing-behavior.js';
     }
 
     // overridden from Nuxeo.PageProviderDisplayBehavior
-    selectAll() {
-      if (this.selectionEnabled && this.selectAllEnabled) {
-        this._isSelectAllActive = true;
-        this.items.forEach((item) => this.$.selector.select(item));
-        this._updateFlags();
-      }
-    }
-
-    // overridden from Nuxeo.PageProviderDisplayBehavior
     clearSelection() {
       this._isSelectAllActive = false;
       this.$.selector.clearSelection();
@@ -430,38 +421,40 @@ import { RoutingBehavior } from '../nuxeo-routing-behavior.js';
       let currentRowWidth = 0;
       let currentRow = [];
       // filter out items that were not loaded yet
-      items.filter((item) => Object.keys(item).length !== 0).forEach((item, idx) => {
-        const clone = Object.assign({}, item);
-        // fallback to square dimensions if item doesn't have a size object in it's model
-        clone.size = clone.properties['picture:info'] || { width: 1, height: 1 };
-        clone.size.width = clone.size.width || 1;
-        clone.size.height = clone.size.height || 1;
-        clone._view = {};
-        clone._view.index = this.items.indexOf(item);
+      items
+        .filter((item) => Object.keys(item).length !== 0)
+        .forEach((item, idx) => {
+          const clone = Object.assign({}, item);
+          // fallback to square dimensions if item doesn't have a size object in it's model
+          clone.size = clone.properties['picture:info'] || { width: 1, height: 1 };
+          clone.size.width = clone.size.width || 1;
+          clone.size.height = clone.size.height || 1;
+          clone._view = {};
+          clone._view.index = this.items.indexOf(item);
 
-        // compute item width to fit a row with `rowHeight`
-        // new width = original width * rowHeight / original height
-        clone._view.width = (clone.size.width * this.rowHeight) / clone.size.height;
-        clone._view.height = this.rowHeight;
+          // compute item width to fit a row with `rowHeight`
+          // new width = original width * rowHeight / original height
+          clone._view.width = (clone.size.width * this.rowHeight) / clone.size.height;
+          clone._view.height = this.rowHeight;
 
-        // if item fits, add it to current row
-        if (currentRowWidth + clone._view.width <= gridWidth) {
-          currentRow.push(clone);
-          currentRowWidth += clone._view.width;
-        } else {
-          // current item doesn't fit in current row
-          // fit items do width and push current row to rows
-          rows.push(this._fitItemsToWidth(currentRow, currentRowWidth, gridWidth));
-          // append current item (that didn't fit in current row) to a new row
-          currentRow = [clone];
-          currentRowWidth = clone._view.width;
-        }
+          // if item fits, add it to current row
+          if (currentRowWidth + clone._view.width <= gridWidth) {
+            currentRow.push(clone);
+            currentRowWidth += clone._view.width;
+          } else {
+            // current item doesn't fit in current row
+            // fit items do width and push current row to rows
+            rows.push(this._fitItemsToWidth(currentRow, currentRowWidth, gridWidth));
+            // append current item (that didn't fit in current row) to a new row
+            currentRow = [clone];
+            currentRowWidth = clone._view.width;
+          }
 
-        if (idx === items.length - 1) {
-          // fit items do width and push current row to rows
-          rows.push(this._fitItemsToWidth(currentRow, currentRowWidth, gridWidth));
-        }
-      });
+          if (idx === items.length - 1) {
+            // fit items do width and push current row to rows
+            rows.push(this._fitItemsToWidth(currentRow, currentRowWidth, gridWidth));
+          }
+        });
       return rows;
     }
 

--- a/ui/nuxeo-page-provider-display-behavior.js
+++ b/ui/nuxeo-page-provider-display-behavior.js
@@ -373,7 +373,10 @@ export const PageProviderDisplayBehavior = [
      */
     _pushSelectedItems(indexStart, limit) {
       for (let index = indexStart; index < limit; index++) {
-        this.selectedItems.push(this.items[index]);
+        // skip entries that are already in the selectedItems list
+        if (!this._isIndexSelected(index)) {
+          this.selectedItems.push(this.items[index]);
+        }
       }
       this.notifySplices('selectedItems');
     },
@@ -386,7 +389,12 @@ export const PageProviderDisplayBehavior = [
     },
 
     _isSelected(item) {
-      return !!(this.selectedItems && this.selectedItems.length && this.selectedItems.indexOf(item) > -1);
+      const index = this.selectedItems && this.selectedItems.length && this.selectedItems.indexOf(item);
+      return index > -1 && this._isIndexSelected(index);
+    },
+
+    _isIndexSelected(index) {
+      return !!(this.selectedItems && this.selectedItems.length && this.selectedItems.indexOf(this.items[index]) > -1);
     },
 
     _toggleSelectAll() {
@@ -606,10 +614,16 @@ export const PageProviderDisplayBehavior = [
             this.reset(count);
           }
           for (let entryIndex = (page - 1) * response.pageSize, i = 0; i < response.entries.length; entryIndex++, i++) {
+            const isSelected = this._isIndexSelected(entryIndex);
+
             this.set(`items.${entryIndex}`, response.entries[i]);
             // if select all is active we need to select the new loaded `item`
             if (this.selectAllActive) {
-              this.selectIndex(entryIndex);
+              if (isSelected) {
+                this.set(`selectedItems.${entryIndex}`, this.items[entryIndex]);
+              } else {
+                this.selectIndex(entryIndex);
+              }
             }
           }
           return response;


### PR DESCRIPTION
The goal of the PR is to add support for select all in the justified grid.
To this extent, I tried to mimic the same approach we have for the other elements (grid, data table and data list):
- We always have a complete list of the items
- Items not loaded are empty (`{}`) and we fill them when a page is loaded
- Loading happens on scroll, and for that I matched the `fetch` method with the behavior of the remaining elements (introduced a new method for functionality parity)
- Select all happens at the `nuxeo-page-provider-display-behavior` so we can take advantage of the `lazy selection` mechanism

This strategy implies a certain amount of changes, and for that your review is more than welcome and necessary. Meanwhile, I'll try to clean up the code a bit.