### PR TITLE
ELEMENTS-1407: use fulltext_all instead of title in document picker

### DIFF
--- a/ui/test/layouts/search/picker/nuxeo-picker-search-form.html
+++ b/ui/test/layouts/search/picker/nuxeo-picker-search-form.html
@@ -9,7 +9,7 @@
     <nuxeo-input
       role="widget"
       id="searchInput"
-      value="{{params.title}}"
+      value="{{params.fulltext_all}}"
       label="[[i18n('pickerSearch.title')]]"
       type="text"
       autofocus

--- a/ui/test/layouts/search/picker/nuxeo-picker-search-results.html
+++ b/ui/test/layouts/search/picker/nuxeo-picker-search-results.html
@@ -62,7 +62,7 @@
         };
         results.fetch = () => {
           // simulates a real fetch by populating the items of a table with an array of simplified filtered results
-          const searchTerm = results.nxProvider.params.title;
+          const searchTerm = results.nxProvider.params.fulltext_all;
           if (!searchTerm) {
             return results.setItems(results.defaultItems);
           }


### PR DESCRIPTION
This **can't** be merged before this https://github.com/nuxeo/nuxeo-lts/pull/238/files#diff-b8d9259ccea414353511fca16881e72d046a6d9806171a8f1cf35536efa9d912L11 gets into a release, otherwise we won't have any filtering in the document picker.