### PR TITLE
ELEMENTS-1408: consider uploading property for nuxeo-file validation

### DIFF
--- a/ui/nuxeo-layout.js
+++ b/ui/nuxeo-layout.js
@@ -151,7 +151,7 @@ import './nuxeo-error.js';
 
     _isVisible(node) {
       // HACK - exclude fallback content from slots when not visible - see ELEMENTS-1393 for more details
-      return node && node.offsetParent && node.offsetHeight > 0 && node.offsetWidth > 0;
+      return node && node.offsetParent && (node.offsetHeight > 0 || node.offsetWidth > 0);
     }
 
     _stamp(href) {

--- a/ui/widgets/nuxeo-file.js
+++ b/ui/widgets/nuxeo-file.js
@@ -281,7 +281,7 @@ import { UploaderBehavior } from './nuxeo-uploader-behavior.js';
     }
 
     _getValidity() {
-      return !this.required || this._hasValue();
+      return !this.uploading && (!this.required || this._hasValue());
     }
 
     _hasSingleValue() {


### PR DESCRIPTION
Two things to consider in the PR:

- use of the `loading` property in the `getValidity` method (not sure why this was not considered in the first place)
- when `nuxeo-file` is uploading the file, its height is 0 and the `_isVisible` method was filtering out the element. We can either try to make the size of the element height than 0 (doesn't seem a good option), or we can relax a bit the constrain for the filter.

This doesn't introduce a regression for ELEMENTS-1393.