### PR TITLE
ELEMENTS-1411: send error details in notify event for bulk actions

### DIFF
--- a/ui/i18n/messages.json
+++ b/ui/i18n/messages.json
@@ -9,6 +9,7 @@
   "addToCollectionButton.dialog.select": "Select a Collection...",
   "addToCollectionButton.tooltip": "Add to Collection",
   "aggregation.format.document.field.unknown": "No {0} field in document. Define your own label formatter.",
+  "bulk.errorDetails.message": "Bulk action {0} run by {1} on {2}, completed at {3}\nNumber of documents processed: {4} / {5}\nNumber of errors: {6}\nError message: {7}\n\nFor additional information, please reach out to an administrator and provide the following bulk command id: {8}",
   "checkboxAggregation.noResults": "No available results",
   "checkboxAggregation.showLess": "Show less",
   "checkboxAggregation.showAll": "Show all",

--- a/ui/widgets/nuxeo-operation-button.js
+++ b/ui/widgets/nuxeo-operation-button.js
@@ -221,6 +221,21 @@ import '../actions/nuxeo-action-button-styles.js';
                 dismissible: true,
                 duration: 0,
                 commandId,
+                errorDetails:
+                  errorCount > 0
+                    ? this.i18n(
+                        'bulk.errorDetails.message',
+                        this.operation,
+                        response.username,
+                        response.submitted,
+                        response.completed,
+                        response.processed,
+                        total,
+                        errorCount,
+                        response.errorMessage,
+                        commandId,
+                      )
+                    : '',
               });
             }
             return response;
@@ -241,6 +256,21 @@ import '../actions/nuxeo-action-button-styles.js';
               dismissible: true,
               duration: 0,
               commandId,
+              errorDetails:
+                errorCount > 0
+                  ? this.i18n(
+                      'bulk.errorDetails.message',
+                      this.operation,
+                      error.username,
+                      error.submitted,
+                      error.completed,
+                      error.processed,
+                      total,
+                      errorCount,
+                      error.errorMessage,
+                      commandId,
+                    )
+                  : '',
             });
           } else {
             this.notify({ message: this.errorLabel ? this.i18n(this.errorLabel, error) : error });


### PR DESCRIPTION
Required by https://github.com/nuxeo/nuxeo-web-ui/pull/1300

My first approach was to send the error details as a message directly, but I also though about sending the details as an object: feedback is very welcome.