### PR TITLE
ELEMENTS-1389: fix loading of boolean properties with false value and true as fallback

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -49,7 +49,7 @@ Object.assign(config, {
         val = (type && type(val)) || val;
       }
     }
-    return val || fallback;
+    return val != null ? val : fallback;
   },
   /**
    * Sets the `value` for property identified by a given `path`. All intermediate path segments will be created if they

--- a/core/test/config.test.js
+++ b/core/test/config.test.js
@@ -58,6 +58,9 @@ suite('config', () => {
     test('existent false boolean property', () => expect(config.get('falseBooleanProperty', false)).to.be.false);
     test('existent true boolean property', () => expect(config.get('trueBooleanProperty', false)).to.be.true);
 
+    test('existent false boolean property with true fallback', () =>
+      expect(config.get('falseBooleanProperty', true)).to.be.false);
+
     test('existent property with false string', () =>
       expect(config.get('falseStringBooleanProperty', false)).to.be.false);
     test('existent property with true string', () => expect(config.get('trueStringBooleanProperty', false)).to.be.true);

--- a/ui/test/nuxeo-filter.test.js
+++ b/ui/test/nuxeo-filter.test.js
@@ -17,6 +17,7 @@ limitations under the License.
 import { fixture, html, flush } from '@nuxeo/testing-helpers';
 import * as polymer from '@polymer/polymer';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import '../nuxeo-filter.js';
 import '../nuxeo-slots.js';
 
@@ -457,6 +458,45 @@ suite('nuxeo-filter', () => {
     [myElement] = stamped(container, '.custom');
     expect(stamped(dom(myElement).node.shadowRoot, '#label').length).to.be.equal(1);
     expect(myElement.label).to.be.equal('A simple test');
+  });
+
+  test('expressions.eval should be true by default', async () => {
+    const filter = await fixture(html`
+      <div>
+        <nuxeo-filter expression="this.constructor.name === 'Filter'">
+          <template>
+            <div class="ok"></div>
+          </template>
+        </nuxeo-filter>
+        <nuxeo-filter expression="this.constructor.name === undefined">
+          <template>
+            <div class="notok"></div>
+          </template>
+        </nuxeo-filter>
+      </div>
+    `);
+    expect(stamped(filter, '.ok').length).to.be.equal(1);
+    expect(stamped(filter, '.notok').length).to.be.equal(0);
+  });
+
+  test('expressions.eval should be false', async () => {
+    config.set('expressions.eval', false);
+    const filter = await fixture(html`
+      <div>
+        <nuxeo-filter expression="this.constructor.name === undefined">
+          <template>
+            <div class="ok"></div>
+          </template>
+        </nuxeo-filter>
+        <nuxeo-filter expression="this.constructor.name === 'Filter'">
+          <template>
+            <div class="notok"></div>
+          </template>
+        </nuxeo-filter>
+      </div>
+    `);
+    expect(stamped(filter, '.ok').length).to.be.equal(1);
+    expect(stamped(filter, '.notok').length).to.be.equal(0);
   });
 
   suite('Host data', () => {


### PR DESCRIPTION
Note: detected an issue with the configuration registry when loading boolean properties with false value and the default set to true (they were always true).