### PR TITLE
ELEMENTS-1389: property parsing fix when type is available

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -46,7 +46,7 @@ Object.assign(config, {
           default:
             break;
         }
-        val = (type && type(val)) || val;
+        val = (type && type(val)) != null ? type(val) : val;
       }
     }
     return val != null ? val : fallback;

--- a/core/test/config.test.js
+++ b/core/test/config.test.js
@@ -44,6 +44,8 @@ suite('config', () => {
     test('non-existent number property', () => expect(config.get('nonExistentNumberProperty', 101)).to.equal(101));
     test('non-existent bigint property', () =>
       expect(config.get('nonExistentBigIntProperty', 9007199254740992)).to.equal(9007199254740992));
+
+    test('non-existent number property with 0 fallback', () => expect(config.get('integerProperty', 0)).to.equal(0));
   });
   suite('boolean properties with default values', () => {
     setup(() => {


### PR DESCRIPTION
Reopened the ticket to fix a regression introduce for the use case of having a non existent property with a 0 default fallback value.