### PR TITLE
ELEMENTS-1348: expose hrefBase in nuxeo-html-editor

### DIFF
--- a/ui/search/nuxeo-search-results-layout.js
+++ b/ui/search/nuxeo-search-results-layout.js
@@ -103,6 +103,9 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
     }
 
     _resultsHref(searchName, hrefBase) {
+      if (!searchName) {
+        return '';
+      }
       const name = searchName.toLowerCase();
       const base = hrefBase || pathFromUrl(this.__dataHost.importPath || this.importPath);
       return `${base}${name}/${['nuxeo', name, 'search-results'].join('-')}.html`;

--- a/ui/widgets/nuxeo-html-editor.js
+++ b/ui/widgets/nuxeo-html-editor.js
@@ -57,6 +57,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
           enrichers="thumbnail,permissions,highlight"
           search-name="document_picker"
           on-picked="_onPickerSelected"
+          href-base="[[hrefBase]]"
         ></nuxeo-document-picker>
 
         <div id="toolbar">
@@ -160,6 +161,11 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
         _editor: {
           type: Object,
         },
+        /**
+         * The base url to be used for loading layouts. Right now, it is only used by the
+         * "Insert images from existing documents" button.
+         */
+        hrefBase: String,
       };
     }
 


### PR DESCRIPTION
This is required by https://github.com/nuxeo/nuxeo-web-ui/pull/1322. I don't particularly like to expose hrefBase in the `nuxeo-html-editor`. I'm open to suggestions.