### PR TITLE
ELEMENTS-1348: expose hrefBase for search layouts as config properties

### DIFF
--- a/ui/search/nuxeo-search-form-layout.js
+++ b/ui/search/nuxeo-search-form-layout.js
@@ -120,6 +120,9 @@ import { RoutingBehavior } from '../nuxeo-routing-behavior.js';
     }
 
     _formHref(provider, searchName, hrefBase) {
+      if (provider == null) {
+        return '';
+      }
       const name = (searchName || provider).toLowerCase();
       const base = hrefBase || pathFromUrl(this.__dataHost.importPath || this.importPath);
       return `${base}${name}/${['nuxeo', name, 'search-form'].join('-')}.html`;

--- a/ui/search/nuxeo-search-form-layout.js
+++ b/ui/search/nuxeo-search-form-layout.js
@@ -19,6 +19,7 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { pathFromUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import '../nuxeo-layout.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import { RoutingBehavior } from '../nuxeo-routing-behavior.js';
@@ -95,7 +96,12 @@ import { RoutingBehavior } from '../nuxeo-routing-behavior.js';
         /**
          * The base url for the layout href.
          */
-        hrefBase: String,
+        hrefBase: {
+          type: String,
+          value() {
+            return config.get('layouts.search.hrefBase');
+          },
+        },
       };
     }
 

--- a/ui/search/nuxeo-search-results-layout.js
+++ b/ui/search/nuxeo-search-results-layout.js
@@ -103,6 +103,9 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
     }
 
     _resultsHref(searchName, hrefBase) {
+      if (!searchName) {
+        return '';
+      }
       const name = searchName.toLowerCase();
       const base = hrefBase || pathFromUrl(this.__dataHost.importPath || this.importPath);
       return `${base}${name}/${['nuxeo', name, 'search-results'].join('-')}.html`;

--- a/ui/search/nuxeo-search-results-layout.js
+++ b/ui/search/nuxeo-search-results-layout.js
@@ -19,6 +19,7 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { pathFromUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
+import { config } from '@nuxeo/nuxeo-elements';
 import '../nuxeo-layout.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
@@ -80,7 +81,12 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
         /**
          * The base url for the layout href.
          */
-        hrefBase: String,
+        hrefBase: {
+          type: String,
+          value() {
+            return config.get('layouts.search.hrefBase');
+          },
+        },
       };
     }
 


### PR DESCRIPTION
This is another take on the problem described by nuxeo/nuxeo-elements#427. This is an alternative to https://github.com/nuxeo/nuxeo-elements/pull/479. This is required by https://github.com/nuxeo/nuxeo-web-ui/pull/1323.