### PR TITLE
ELEMENTS-1267: unlock @open-wc/scoped-elements storybook dependency

### DIFF
--- a/storybook/package.json
+++ b/storybook/package.json
@@ -39,7 +39,7 @@
     "deploy": "storybook-to-ghpages"
   },
   "devDependencies": {
-    "@open-wc/scoped-elements": "1.2.4",
+    "@open-wc/scoped-elements": "^1.3.3",
     "@open-wc/webpack-import-meta-loader": "^0.4.1",
     "@storybook/storybook-deployer": "^2.8.1"
   }


### PR DESCRIPTION
It seems that unlocking to the last 1.3.x version is working (this is the last version for the 1.x)