### PR TITLE
ELEMENTS-1434: fix display of empty results label when page provider is still updating properties

### DIFF
--- a/ui/nuxeo-page-provider-display-behavior.js
+++ b/ui/nuxeo-page-provider-display-behavior.js
@@ -512,17 +512,19 @@ export const PageProviderDisplayBehavior = [
     },
 
     _computeLabel() {
-      this._computeLabelDebouncer = Debouncer.debounce(this._computeLabelDebouncer, timeOut.after(500), () => {
-        if (this.loading) {
-          this._computedEmptyLabel = this.i18n('label.loading');
-        } else if (this.filters && this.filters.length > 0) {
-          this._computedEmptyLabel = this.emptyLabelWhenFiltered
-            ? this.emptyLabelWhenFiltered
-            : this.i18n('label.noResultsWhenFiltered');
-        } else {
-          this._computedEmptyLabel = this.emptyLabel ? this.emptyLabel : this.i18n('label.noResults');
-        }
-      });
+      if (this.loading) {
+        this._computedEmptyLabel = this.i18n('label.loading');
+      } else {
+        this._computeLabelDebouncer = Debouncer.debounce(this._computeLabelDebouncer, timeOut.after(500), () => {
+          if (this.filters && this.filters.length > 0) {
+            this._computedEmptyLabel = this.emptyLabelWhenFiltered
+              ? this.emptyLabelWhenFiltered
+              : this.i18n('label.noResultsWhenFiltered');
+          } else if ((this.nxProvider && this.nxProvider.resultsCount === 0) || !this.nxProvider) {
+            this._computedEmptyLabel = this.emptyLabel ? this.emptyLabel : this.i18n('label.noResults');
+          }
+        });
+      }
     },
 
     _quickFilterChanged() {


### PR DESCRIPTION
Considerations:

- if the `nxProvider` is loading, we update the empty label with loading information, otherwise
- Debounce the label update as we did before, but
- If the `nxProvider` has finished loading (or is not available) and no results are available, then update the empty label accordingly.

Feedback is very welcome.
10.10 backport - https://github.com/nuxeo/nuxeo-ui-elements/pull/545