### PR TITLE
ELEMENTS-1450: compute validity based on the current value

### DIFF
--- a/ui/widgets/nuxeo-date-picker.js
+++ b/ui/widgets/nuxeo-date-picker.js
@@ -203,7 +203,10 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
     }
 
     _getValidity() {
-      return this.$.date.validate() && (this.required ? !!this.value : true);
+      return (
+        this.$.date.validate(this.value ? this.$.date.i18n.formatDate(this.value) : this.value) &&
+        (this.required ? !!this.value : true)
+      );
     }
 
     _valueChanged() {


### PR DESCRIPTION
### Context
- On an `auto` search, the results are updated as the user tweaks the values of the widgets in the search form layout.
- When value is changed, the form is validated and, if successful, the appropriate results are shown.
- When using a `<nuxeo-date-picker>` the user is able to set a date and the results are updated automatically.
- However, when changing the date to another value, the elements shows itself as invalid and therefore the results are not updated.
- This seems to be caused to [the way `<vaadin-date-picker>` checks the validity of its value](https://github.com/vaadin/vaadin-date-picker/blob/v3.3.4/src/vaadin-date-picker-mixin.html#L677-L682):
  - As the user picks a second date, the change is picked up by the form layout and Web UI automatically tries to validate the form to present the new results.
  - While validating the form, `<vaadin-date-picker>` does its own validation but doesn't seem to be ready, as [at this moment](https://github.com/vaadin/vaadin-date-picker/blob/v3.3.4/src/vaadin-date-picker-mixin.html#L693-L694) there's still a difference between `value` (same as `this._inputValue`, still the first date the user picked) and `this._selectedDate` (which is already the second date picked).

### Proposed Solution
- By passing `this.value` in `this.$.date.validate()` it ensures that the comparison is done with the most up to date value, instead of relying on the outdated `this._inputValue`.
- Since the comparison is done with formatted date values and to ensure a smooth outcome, we should be using [the same formatting that `<vaadin-date-picker>` uses](https://github.com/vaadin/vaadin-date-picker/blob/v3.3.4/src/vaadin-date-picker-mixin.html#L694) (relies on locales), but since `<nuxeo-date-picker>` has no access to the `Vaadin` global variable and its helpers, ~I propose using the `moment` formatting (also based on locales) that is already used throughout `<nuxeo-date-picker>`~ we should just use `this.$.date.i18n.formatDate()`.