### PR TITLE
ELEMENTS-1211: allow cross repo navigation

### DIFF
--- a/ui/actions/nuxeo-workflow-button.js
+++ b/ui/actions/nuxeo-workflow-button.js
@@ -190,7 +190,7 @@ import '../nuxeo-button-styles.js';
       if (this.document) {
         this.processes = this.document.contextParameters.runnableWorkflows;
         this.workflows = this.document.contextParameters.runningWorkflows;
-        this.selectedProcess = this.processes.length > 0 ? this.processes[0].workflowModelName : null;
+        this.selectedProcess = this.processes && this.processes.length > 0 ? this.processes[0].workflowModelName : null;
       }
     }
   }

--- a/ui/test/nuxeo-routing-behavior.test.js
+++ b/ui/test/nuxeo-routing-behavior.test.js
@@ -168,5 +168,56 @@ suite('Nuxeo.RoutingBehavior', () => {
         expect(router.document.calledOnce).to.be.true;
       });
     });
+
+    suite('with one repository available', async () => {
+      setup(async () => {
+        Nuxeo.UI.repositories = [{ name: 'repo', href: '/nuxeo/repo/repo/ui/' }];
+      });
+
+      teardown(async () => {
+        Nuxeo.UI.repositories = [];
+      });
+
+      test('should generate document url without repository', async () => {
+        router.useHashbang = true;
+        router.baseUrl = 'base';
+        expect(
+          el.urlFor({
+            'entity-type': 'document',
+            uid: 'abc123',
+            path: '/default-domain/workspaces/ws',
+            repository: 'repo',
+          }),
+        ).to.equal(`base/#!/path/default-domain/workspaces/ws`);
+        expect(router.document.calledOnce).to.be.true;
+      });
+    });
+
+    suite('with more than one repository available', async () => {
+      setup(async () => {
+        Nuxeo.UI.repositories = [
+          { name: 'repo1', href: '/nuxeo/repo/repo1/ui/' },
+          { name: 'repo2', href: '/nuxeo/repo/repo2/ui/' },
+        ];
+      });
+
+      teardown(async () => {
+        Nuxeo.UI.repositories = [];
+      });
+
+      test('should generate document url with repository', async () => {
+        router.useHashbang = true;
+        router.baseUrl = 'base';
+        expect(
+          el.urlFor({
+            'entity-type': 'document',
+            uid: 'abc123',
+            path: '/default-domain/workspaces/ws',
+            repository: 'repo1',
+          }),
+        ).to.equal(`${window.origin}/nuxeo/repo/repo1/ui/#!/path/default-domain/workspaces/ws`);
+        expect(router.document.calledOnce).to.be.true;
+      });
+    });
   });
 });


### PR DESCRIPTION
The solution consists of:
1) allowing entity resolution on the router to identify a repository object, if applicable; this would only be applicable for resolving document entity types
2) update the `urlFor` method to use this repository object to generate the appropriate URL
3) update the `navigateTo` method so that it can pass along the repository object to the `navigate` method, which is defined at the application level; this is required because navigating to a different repository might require some logic at the application level

Pending questions:
1) This solution assumes that if we have more than one repository available, we always generate the the url with the repository part, even for the default repository (which is not needed). However, this promotes consistency and fixes [ELEMENTS-253](https://jira.nuxeo.com/browse/ELEMENTS-253) for free.