### PR TITLE
ELEMENTS-1438: avoid showing focused style on header row

### DIFF
--- a/ui/nuxeo-data-table/data-table-row.js
+++ b/ui/nuxeo-data-table/data-table-row.js
@@ -49,7 +49,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
             @apply --iron-data-table-row-odd;
           }
 
-          :host(:focus) {
+          :host(:not([header]):focus) {
             outline: none;
             @apply --iron-data-table-row-focused;
           }


### PR DESCRIPTION
This fix might be worth a double check because the issue was identified as a regression but the fix suggests that the problem was always there.