### PR TITLE
ELEMENTS-1452: run tests locally in headless chrome

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -8,6 +8,17 @@
       ],
       "exclude": []
     },
+    "local": {
+      "browsers": [
+        "chrome"
+      ],
+      "browserOptions": {
+        "chrome": [
+          "no-sandbox",
+          "headless"
+        ]
+      }
+    },
     "sauce": {
       "disabled": true,
       "browsers": [


### PR DESCRIPTION
Needed because 10.10 GH actions runner needs to run tests in headless mode and without sandbox.
Besides, this makes the 2.4.x code consistent with what we already have in 3.0.x branch.