### PR TITLE
ELEMENTS-1459: pr check split

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,47 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - maintenance-3.0.x
+  pull_request:
+    branches:
+      - maintenance-3.0.x
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The current branch'
+        default: maintenance-3.0.x
+        type: string
+        required: false
+    secrets:
+      NPM_PACKAGES_TOKEN:
+        description: 'NPM_PACKAGES_TOKEN'
+        required: true
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || inputs.branch || 'maintenance-3.0.x' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
+          scope: '@nuxeo'
+
+      - name: Install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+        run: |
+          npm install --no-package-lock
+          npm run bootstrap
+
+      - name: Lint
+        run: npm run lint

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - maintenance-3.0.x
   pull_request:
     branches:
       - maintenance-3.0.x

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   lint:
-    uses: nuxeo/nuxeo-elements/.github/workflows/lint.yaml@ELEMENTS-1459-pr-check-split
+    uses: nuxeo/nuxeo-elements/.github/workflows/lint.yaml@maintenance-3.0.x
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
 
   test:
-    uses: nuxeo/nuxeo-elements/.github/workflows/test.yaml@ELEMENTS-1459-pr-check-split
+    uses: nuxeo/nuxeo-elements/.github/workflows/test.yaml@maintenance-3.0.x
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -20,7 +20,7 @@ jobs:
       branch: maintenance-3.0.x
 
   storybook:
-    uses: nuxeo/nuxeo-elements/.github/workflows/storybook.yaml@ELEMENTS-1459-pr-check-split
+    uses: nuxeo/nuxeo-elements/.github/workflows/storybook.yaml@maintenance-3.0.x
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
     with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - maintenance-3.0.x
-  pull_request:
 
 jobs:
   build:
@@ -21,16 +20,9 @@ jobs:
     - name: Prepare environment
       run: |
         git config user.name "nuxeo-web-ui-jx-bot" && git config user.email "ui+jx-bot@nuxeo.com"
-        echo "BRANCH_NAME=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV
         echo "PACKAGE_VERSION=$(npx -c 'echo "$npm_package_version"')" >> $GITHUB_ENV
 
-    - name: Get pull request version
-      if: github.event_name == 'pull_request'
-      run: |
-        echo "VERSION=$PACKAGE_VERSION-$BRANCH_NAME" >> $GITHUB_ENV
-
     - name: Get prerelease version
-      if: github.event_name == 'push'
       run: |
         git fetch origin --tags
         RC_VERSION=$(git tag --sort=taggerdate --list "v${PACKAGE_VERSION/-SNAPSHOT}*" | tail -1 | tr -d '\n')
@@ -41,46 +33,13 @@ jobs:
         npm version $VERSION --no-git-tag-version
         npx lerna version $VERSION --no-push --force-publish --no-git-tag-version --yes
 
-    - name: Install
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
-      run: |
-        npm install --no-package-lock
-        npm run bootstrap
-
-    - name: Lint
-      run: npm run lint
-
-    - name: Test
-      env:
-        SAUCE_USERNAME: nuxeo-elements
-        SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-      run: npm run test
-
-    - name: Run analysis
-      run: npx lerna run analysis --parallel
-
-    - name: Build storybook
-      working-directory: storybook
-      run: |
-        npx build-storybook -o dist -s ./public
-
-    - name: Deploy
-      if: github.ref == 'refs/heads/maintenance-3.0.x'
-      env:
-        GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
-      working-directory: storybook
-      run: npm run deploy -- --ci
-
     - name: Tag
-      if: github.event_name == 'push'
       run: |
         git commit -a -m "Release ${VERSION}"
         git tag -a v${VERSION} -m "Release ${VERSION}"
         git push origin v${VERSION}
 
     - name: Publish
-      if: github.event_name == 'push'
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
       run: npx lerna exec --ignore @nuxeo/nuxeo-elements-storybook -- npm publish --tag SNAPSHOT

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,8 +6,29 @@ on:
       - maintenance-3.0.x
 
 jobs:
+  lint:
+    uses: nuxeo/nuxeo-elements/.github/workflows/lint.yaml@ELEMENTS-1459-pr-check-split
+    secrets:
+      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+
+  test:
+    uses: nuxeo/nuxeo-elements/.github/workflows/test.yaml@ELEMENTS-1459-pr-check-split
+    secrets:
+      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+    with:
+      branch: maintenance-3.0.x
+
+  storybook:
+    uses: nuxeo/nuxeo-elements/.github/workflows/storybook.yaml@ELEMENTS-1459-pr-check-split
+    secrets:
+      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+    with:
+      branch: maintenance-3.0.x
+
   build:
     runs-on: ubuntu-latest
+    needs: [ lint, test, storybook ]
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -49,7 +49,7 @@ jobs:
           npx build-storybook -o dist -s ./public
 
       - name: Deploy
-        if: github.event_name == 'push'
+        if: ${{ env.BRANCH_NAME == 'maintenance-3.0.x' }}
         env:
           GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
         working-directory: storybook

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -1,9 +1,6 @@
 name: Storybook
 
 on:
-  push:
-    branches:
-      - maintenance-3.0.x
   pull_request:
     branches:
       - maintenance-3.0.x

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -1,0 +1,59 @@
+name: Storybook
+
+on:
+  push:
+    branches:
+      - maintenance-3.0.x
+  pull_request:
+    branches:
+      - maintenance-3.0.x
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The current branch'
+        default: maintenance-3.0.x
+        type: string
+        required: false
+    secrets:
+      NPM_PACKAGES_TOKEN:
+        description: 'NPM_PACKAGES_TOKEN'
+        required: true
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || inputs.branch || 'maintenance-3.0.x' }}
+
+jobs:
+  storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
+          scope: '@nuxeo'
+
+      - name: Install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+        run: |
+          npm install --no-package-lock
+          npm run bootstrap
+
+      - name: Run analysis
+        run: npx lerna run analysis --parallel
+
+      - name: Build storybook
+        working-directory: storybook
+        run: |
+          npx build-storybook -o dist -s ./public
+
+      - name: Deploy
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+        working-directory: storybook
+        run: npm run deploy -- --ci

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - maintenance-3.0.x
   pull_request:
     branches:
       - maintenance-3.0.x

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,53 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - maintenance-3.0.x
+  pull_request:
+    branches:
+      - maintenance-3.0.x
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The current branch'
+        default: maintenance-3.0.x
+        type: string
+        required: false
+    secrets:
+      NPM_PACKAGES_TOKEN:
+        description: 'NPM_PACKAGES_TOKEN'
+        required: true
+      SAUCE_ACCESS_KEY:
+        description: 'SAUCE_ACCESS_KEY'
+        required: true
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || inputs.branch || 'maintenance-3.0.x' }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
+          scope: '@nuxeo'
+
+      - name: Install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+        run: |
+          npm install --no-package-lock
+          npm run bootstrap
+
+      - name: Test
+        env:
+          SAUCE_USERNAME: nuxeo-elements
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        run: npm run test


### PR DESCRIPTION
Added in the PR:
- split of the PR checks into single reusable workflow files
- refactor of the main workflow to use the pr checks only on the push event, before creating a new tag and publishing the RC