### PR TITLE
ELEMENTS-1374: allow html editor height to be set at host level

### DIFF
--- a/ui/widgets/nuxeo-html-editor.js
+++ b/ui/widgets/nuxeo-html-editor.js
@@ -33,10 +33,16 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
     static get template() {
       return html`
         <style include="quill-snow">
+          :host {
+            display: flex;
+            flex-direction: column;
+            min-height: 30em;
+          }
+
           #editor {
             outline: none;
+            overflow: hidden;
             height: 100%;
-            min-height: 30em;
           }
 
           div#editor > * {


### PR DESCRIPTION
Before this change, setting an height on the element would create a bunch of visual artefacts, resulting from a few overflow problems. The proposed solution fixes a few problems:

- prevents **#editor** from overflowing the parent and prevents it from being overflown by its children.
- prevents **#editor** from overflowing the parent when height is too short (moving min-height to the host)

You can now do something like this:
```css
nuxeo-html-editor {
    height: calc(80vh - 132px);
}
```