### PR TITLE
ELEMENTS-1495: fix shared copy of filters object

### DIFF
--- a/ui/nuxeo-page-provider-display-behavior.js
+++ b/ui/nuxeo-page-provider-display-behavior.js
@@ -86,7 +86,9 @@ export const PageProviderDisplayBehavior = [
       filters: {
         type: Array,
         notify: true,
-        value: [],
+        value() {
+          return [];
+        },
       },
 
       /**


### PR DESCRIPTION
The `filters` property was being shared across all elements that extend `nuxeo-page-provider-display-behavior`. For more details, please check https://polymer-library.polymer-project.org/2.0/docs/devguide/properties#configure-values.