### PR TITLE
ELEMENTS-1506: Able to click 'Add' Button when no Collection selected

### DIFF
--- a/ui/actions/nuxeo-add-to-collection-button.js
+++ b/ui/actions/nuxeo-add-to-collection-button.js
@@ -256,7 +256,7 @@ import '../nuxeo-button-styles.js';
     }
 
     _isValid() {
-      return this.collection !== '';
+      return this.collection;
     }
 
     _isNew() {


### PR DESCRIPTION
https://jira.nuxeo.com/browse/WEBUI-786

The Add button is disabled since no collection is selected

<img width="611" alt="Screenshot 2022-07-14 at 1 15 33 PM" src="https://user-images.githubusercontent.com/105918630/178972084-fa37356a-c132-4080-a6d3-d792ae259ea6.png">

