### PR TITLE
ELEMENTS-1364: make nuxeo-user-tag accessible

### DIFF
--- a/ui/widgets/nuxeo-user-avatar.js
+++ b/ui/widgets/nuxeo-user-avatar.js
@@ -65,7 +65,7 @@ import '../nuxeo-icons.js';
 
         <nuxeo-resource id="getUserProfile" enrichers="userprofile" enrichers-entity="user"></nuxeo-resource>
 
-        <div id="container">
+        <div id="container" aria-hidden="true">
           <span id="character" hidden$="[[!_isInTheAlphabet]]">{{_output}}</span>
           <iron-icon hidden$="[[_isInTheAlphabet]]" icon="nuxeo:user"></iron-icon>
         </div>

--- a/ui/widgets/nuxeo-user-tag.js
+++ b/ui/widgets/nuxeo-user-tag.js
@@ -65,7 +65,7 @@ import './nuxeo-tooltip.js';
           }
         </style>
         <nuxeo-tag>
-          <div class="tag">
+          <div class="tag" role="button">
             <nuxeo-user-avatar
               user="[[user]]"
               border-radius="50"


### PR DESCRIPTION
https://jira.nuxeo.com/browse/ELEMENTS-1364

To make nuxeo-user-tag accessible, added role="button" for the specific div

Hence the First Letter(Avatar) is accessible by screen-reader so added aria-hidden="true" to the specific div so that the the Screen reader will hide the First letter

For accessibility check fails, new ticket created in WEB-UI
https://jira.nuxeo.com/browse/WEBUI-873