### PR TITLE
ELEMENTS-1596: fix keyboard navigation trap when using overflow actions menu

### DIFF
--- a/ui/widgets/nuxeo-actions-menu.js
+++ b/ui/widgets/nuxeo-actions-menu.js
@@ -94,7 +94,7 @@ import './nuxeo-tooltip.js';
             slot="dropdown-trigger"
             aria-labelledby="iconButtonTooltip"
           ></paper-icon-button>
-          <paper-listbox slot="dropdown-content" role="list">
+          <paper-listbox slot="dropdown-content" role="list" tabindex="0">
             <slot id="dropdown" name="dropdown"></slot>
           </paper-listbox>
         </paper-menu-button>


### PR DESCRIPTION
https://jira.nuxeo.com/browse/ELEMENTS-1596

Kindly find the attached recording with solution

https://user-images.githubusercontent.com/107453632/231161238-6ab5f46d-a565-441b-be7f-61081f659a09.mov

