### PR TITLE
ELEMENTS-1599: fix position of the hyperlink tooltip in the HTML editor

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -28,7 +28,7 @@
     "@nuxeo/moment": "^2.24.0-nx.0",
     "@nuxeo/nuxeo-elements": "^3.0.22-SNAPSHOT",
     "@nuxeo/paper-typeahead": "^0.6.0-nx.0",
-    "@nuxeo/quill": "^2.0.0-dev.3-nx.2",
+    "@nuxeo/quill": "^2.0.0-dev.3-nx.3",
     "@polymer/iron-autogrow-textarea": "^3.0.1",
     "@polymer/iron-collapse": "^3.0.0",
     "@polymer/iron-flex-layout": "^3.0.0",

--- a/ui/widgets/nuxeo-html-editor.js
+++ b/ui/widgets/nuxeo-html-editor.js
@@ -47,6 +47,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 
           div#editor > * {
             margin-top: 0;
+            margin-bottom: 28px;
           }
 
           iron-icon {


### PR DESCRIPTION
https://jira.nuxeo.com/browse/ELEMENTS-1599

https://user-images.githubusercontent.com/113914009/235662598-bd9598ab-de20-4c94-83d3-1ae121739388.mp4

