### PR TITLE
ELEMENTS-1683-BACKPORT: Fix nuxeo-directory-radio-group missing mutlivalued complex sub-property value selected at doc creation

### DIFF
--- a/ui/widgets/nuxeo-directory-radio-group.js
+++ b/ui/widgets/nuxeo-directory-radio-group.js
@@ -140,6 +140,7 @@ import { DirectoryWidgetBehavior } from './nuxeo-directory-widget-behavior.js';
       if (this.value && this.value.length > 0 && this.value !== this._selected) {
         this._selected = this.value;
       }
+      this._entries.forEach((entry) => this._isChecked(entry));
     }
 
     /* Override method from Polymer.IronValidatableBehavior. */


### PR DESCRIPTION
https://jira.nuxeo.com/browse/ELEMENTS-1683