### PR TITLE
changes

### DIFF
--- a/ui/nuxeo-data-table/data-table-cell.js
+++ b/ui/nuxeo-data-table/data-table-cell.js
@@ -37,11 +37,8 @@ const RESIZE_ZONE = 8;
           /* header cells need relative positioning for the resizer */
           :host([header]) {
             position: relative;
+            overflow: visible;
             height: 48px;
-            min-width: 0;
-
-            /* critical: do NOT allow header content to expand outside the cell */
-            overflow: hidden;
           }
 
           :host([hidden]) {
@@ -146,6 +143,13 @@ const RESIZE_ZONE = 8;
           }
           :host([header][resize-enabled]) .resizer {
             display: block;
+          }
+
+          :host([header]) ::slotted(nuxeo-dropdown-aggregation) {
+            /* prevent dropdown from expanding to fit its content */
+            --selectivity-dropdown-min-width: 0;
+            /* also prevent it from becoming viewport-wide */
+            --selectivity-dropdown-max-width: 100%; /* pick a sane cap for header filters */
           }
         </style>
 

--- a/ui/nuxeo-data-table/data-table-cell.js
+++ b/ui/nuxeo-data-table/data-table-cell.js
@@ -147,33 +147,6 @@ const RESIZE_ZONE = 8;
           :host([header][resize-enabled]) .resizer {
             display: block;
           }
-
-          :host([header]) {
-            /* keep resizer working */
-            position: relative;
-            height: 48px;
-
-            /* must be hidden to prevent visual blowout */
-            overflow: hidden;
-
-            /* make sure the cell can shrink even if content is long */
-            min-width: 0;
-          }
-
-          :host([header]) ::slotted(nuxeo-dropdown-aggregation) {
-            /* make it participate in the cell flex sizing */
-            flex: 1 1 auto;
-
-            /* critical: allow shrink below content width */
-            min-width: 0;
-
-            /* clip any long selected token rendered inside nested shadow DOM */
-            overflow: hidden;
-
-            /* keep your dropdown fix */
-            --selectivity-dropdown-min-width: 0;
-            --selectivity-dropdown-max-width: 100%;
-          }
         </style>
 
         <template is="dom-if" if="[[header]]">

--- a/ui/nuxeo-data-table/data-table-cell.js
+++ b/ui/nuxeo-data-table/data-table-cell.js
@@ -37,8 +37,11 @@ const RESIZE_ZONE = 8;
           /* header cells need relative positioning for the resizer */
           :host([header]) {
             position: relative;
-            overflow: visible;
             height: 48px;
+            min-width: 0;
+
+            /* critical: do NOT allow header content to expand outside the cell */
+            overflow: hidden;
           }
 
           :host([hidden]) {
@@ -143,6 +146,33 @@ const RESIZE_ZONE = 8;
           }
           :host([header][resize-enabled]) .resizer {
             display: block;
+          }
+
+          :host([header]) {
+            /* keep resizer working */
+            position: relative;
+            height: 48px;
+
+            /* must be hidden to prevent visual blowout */
+            overflow: hidden;
+
+            /* make sure the cell can shrink even if content is long */
+            min-width: 0;
+          }
+
+          :host([header]) ::slotted(nuxeo-dropdown-aggregation) {
+            /* make it participate in the cell flex sizing */
+            flex: 1 1 auto;
+
+            /* critical: allow shrink below content width */
+            min-width: 0;
+
+            /* clip any long selected token rendered inside nested shadow DOM */
+            overflow: hidden;
+
+            /* keep your dropdown fix */
+            --selectivity-dropdown-min-width: 0;
+            --selectivity-dropdown-max-width: 100%;
           }
         </style>
 

--- a/ui/nuxeo-data-table/data-table-column.js
+++ b/ui/nuxeo-data-table/data-table-column.js
@@ -69,7 +69,7 @@ import './data-table-column-filter.js';
          */
         width: {
           type: String,
-          value: '100px',
+          value: '150px',
         },
 
         /**

--- a/ui/nuxeo-data-table/data-table-row.js
+++ b/ui/nuxeo-data-table/data-table-row.js
@@ -72,6 +72,10 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
             flex-direction: row;
             width: 100%;
           }
+
+          :host([header]) .cells ::slotted(nuxeo-data-table-settings) {
+            order: 999999;
+          }
         </style>
 
         <div class="cells">

--- a/ui/nuxeo-data-table/data-table-row.js
+++ b/ui/nuxeo-data-table/data-table-row.js
@@ -72,6 +72,18 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
             flex-direction: row;
             width: 100%;
           }
+
+          /* Header row: do not let long filter tokens increase row intrinsic width */
+          :host([header]) .cells {
+            min-width: 0;
+            max-width: 100%;
+            overflow: hidden;
+          }
+
+          /* Flex children (the header cells) must be allowed to shrink */
+          :host([header]) .cells ::slotted(*) {
+            min-width: 0;
+          }
         </style>
 
         <div class="cells">

--- a/ui/nuxeo-data-table/data-table-row.js
+++ b/ui/nuxeo-data-table/data-table-row.js
@@ -72,18 +72,6 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
             flex-direction: row;
             width: 100%;
           }
-
-          /* Header row: do not let long filter tokens increase row intrinsic width */
-          :host([header]) .cells {
-            min-width: 0;
-            max-width: 100%;
-            overflow: hidden;
-          }
-
-          /* Flex children (the header cells) must be allowed to shrink */
-          :host([header]) .cells ::slotted(*) {
-            min-width: 0;
-          }
         </style>
 
         <div class="cells">

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -257,6 +257,16 @@ import '../nuxeo-button-styles.js';
             position: relative;
             top: -20px;
           }
+
+          /* Critical: allow header grid children to shrink instead of contributing huge intrinsic widths */
+          #header > * {
+            min-width: 0;
+          }
+
+          /* Also ensure the header row itself clips long content */
+          #header > nuxeo-data-table-row {
+            overflow: hidden;
+          }
         </style>
 
         <div id="container">

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -175,9 +175,6 @@ import '../nuxeo-button-styles.js';
             bottom: 0;
             display: flex;
             flex-direction: column;
-            min-width: 100%;
-            width: 100%;
-            max-width: 100%;
           }
 
           #header {
@@ -230,7 +227,7 @@ import '../nuxeo-button-styles.js';
 
           #header {
             display: grid;
-            grid-template-columns: 1fr auto;
+            grid-template-columns: minmax(0, 1fr) auto;
             height: 48px;
             align-items: stretch;
           }
@@ -247,6 +244,7 @@ import '../nuxeo-button-styles.js';
             align-items: center;
             height: 100%;
           }
+
           #header-fixed {
             grid-column: 2;
             position: relative;
@@ -256,16 +254,6 @@ import '../nuxeo-button-styles.js';
           :host([settings-enabled]) ::slotted(nuxeo-data-table-row[header]) {
             position: relative;
             top: -20px;
-          }
-
-          /* Critical: allow header grid children to shrink instead of contributing huge intrinsic widths */
-          #header > * {
-            min-width: 0;
-          }
-
-          /* Also ensure the header row itself clips long content */
-          #header > nuxeo-data-table-row {
-            overflow: hidden;
           }
         </style>
 
@@ -820,22 +808,22 @@ import '../nuxeo-button-styles.js';
     }
 
     _resizeCellContainers() {
+      // reset header width first to make the cells and scroll width to reset their widths.
       this.$.container.style.width = '';
 
       microTask.run(() => {
-        const viewportWidth = this.clientWidth || this.offsetWidth || 0;
-        this.$.container.style.width = `${viewportWidth}px`;
+        this.$.container.style.width = `${Math.min(this.scrollWidth, this.clientWidth + this.scrollLeft)}px`;
+        // add scrollbar width as padding
         this.$.header.style.paddingRight = `${this.$.list.offsetWidth - this.$.list.clientWidth}px`;
       });
     }
 
     _onHorizontalScroll() {
       if (!this.isDebouncerActive('scrolling')) {
-        const viewportWidth = this.clientWidth || this.offsetWidth || 0;
-        this.$.container.style.width = `${viewportWidth}px`;
+        this.$.container.style.width = `${this.scrollWidth}px`;
         this._debouncer = Debouncer.debounce(this._debouncer, timeOut.after(1000), () => {
-          const w = this.clientWidth || this.offsetWidth || 0;
-          this.$.container.style.width = `${w}px`;
+          // long timeout here to prevent jerkiness with the rubberband effect on iOS especially.
+          this.$.container.style.width = `${Math.min(this.scrollWidth, this.clientWidth + this.scrollLeft)}px`;
         });
       }
     }

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -175,10 +175,9 @@ import '../nuxeo-button-styles.js';
             bottom: 0;
             display: flex;
             flex-direction: column;
-            /* allow container to grow to full content width so :host overflow-x shows scrollbar */
-            /* vendor fallback */
-            min-width: -webkit-max-content;
-            min-width: max-content;
+            min-width: 100%;
+            width: 100%;
+            max-width: 100%;
           }
 
           #header {

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -224,37 +224,6 @@ import '../nuxeo-button-styles.js';
             overflow-y: scroll;
             position: relative;
           }
-
-          #header {
-            display: grid;
-            grid-template-columns: minmax(0, 1fr) auto;
-            height: 48px;
-            align-items: stretch;
-          }
-
-          #header > nuxeo-data-table-row {
-            display: flex;
-            height: 48px;
-            align-items: stretch;
-          }
-
-          #header nuxeo-data-table-cell,
-          #header-fixed {
-            display: flex;
-            align-items: center;
-            height: 100%;
-          }
-
-          #header-fixed {
-            grid-column: 2;
-            position: relative;
-            top: 12px;
-          }
-
-          :host([settings-enabled]) ::slotted(nuxeo-data-table-row[header]) {
-            position: relative;
-            top: -20px;
-          }
         </style>
 
         <div id="container">
@@ -298,13 +267,12 @@ import '../nuxeo-button-styles.js';
               <div style$="[[_computeActionsStyle(editable, orderable)]]">
                 <nuxeo-data-table-cell></nuxeo-data-table-cell>
               </div>
-            </nuxeo-data-table-row>
-            <div id="header-fixed">
+
               <nuxeo-data-table-settings
                 columns="{{columns}}"
                 hidden$="[[!settingsEnabled]]"
               ></nuxeo-data-table-settings>
-            </div>
+            </nuxeo-data-table-row>
           </div>
 
           <dom-if if="[[_isEmpty]]">

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -820,22 +820,22 @@ import '../nuxeo-button-styles.js';
     }
 
     _resizeCellContainers() {
-      // reset header width first to make the cells and scroll width to reset their widths.
       this.$.container.style.width = '';
 
       microTask.run(() => {
-        this.$.container.style.width = `${Math.min(this.scrollWidth, this.clientWidth + this.scrollLeft)}px`;
-        // add scrollbar width as padding
+        const viewportWidth = this.clientWidth || this.offsetWidth || 0;
+        this.$.container.style.width = `${viewportWidth}px`;
         this.$.header.style.paddingRight = `${this.$.list.offsetWidth - this.$.list.clientWidth}px`;
       });
     }
 
     _onHorizontalScroll() {
       if (!this.isDebouncerActive('scrolling')) {
-        this.$.container.style.width = `${this.scrollWidth}px`;
+        const viewportWidth = this.clientWidth || this.offsetWidth || 0;
+        this.$.container.style.width = `${viewportWidth}px`;
         this._debouncer = Debouncer.debounce(this._debouncer, timeOut.after(1000), () => {
-          // long timeout here to prevent jerkiness with the rubberband effect on iOS especially.
-          this.$.container.style.width = `${Math.min(this.scrollWidth, this.clientWidth + this.scrollLeft)}px`;
+          const w = this.clientWidth || this.offsetWidth || 0;
+          this.$.container.style.width = `${w}px`;
         });
       }
     }


### PR DESCRIPTION
Steps to reproduce:

1. Go to the workspace for the user with a very long name 
2. you will see a table view with columns - TItle, Type, Modified, Last contributor
3. Click the “Last Contributor” header filter dropdown. Select a very long value
4. Column/header expands to content width (regression)
Expected:
column/ header should not exapnd based on content width
Actual:
Column/header expands to content width 


Before:
<img width="1394" height="368" alt="image" src="https://github.com/user-attachments/assets/4682e17a-a322-4991-a719-9aacc65a5d89" />

After:
<img width="2600" height="404" alt="image" src="https://github.com/user-attachments/assets/50ae1e1f-ecf0-460d-bcba-fe9da1937ca7" />


CSS fix already applied for dropdown width:
--selectivity-dropdown-min-width: 0;
--selectivity-dropdown-max-width: 100%;
 remaining bug: selected token makes header/column expand.
 
 