### PR TITLE
ELEMENTS-1477: fix nuxeo-group-tag error with null value

### DIFF
--- a/ui/test/nuxeo-group-tag.test.js
+++ b/ui/test/nuxeo-group-tag.test.js
@@ -1,0 +1,101 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved. 
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { fixture, html } from '@nuxeo/testing-helpers';
+import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import '../widgets/nuxeo-group-tag.js';
+
+suite('nuxeo-group-tag', () => {
+  suite('Null/Undefined group handling', () => {
+    test('Should not throw when group is null', async () => {
+      const el = await fixture(html` <nuxeo-group-tag disabled></nuxeo-group-tag> `);
+      el.group = null;
+
+      expect(el._label(null)).to.equal('');
+      expect(el._name(null)).to.equal('');
+      expect(el._href(null)).to.equal('');
+    });
+
+    test('Should not throw when group is undefined', async () => {
+      const el = await fixture(html` <nuxeo-group-tag disabled></nuxeo-group-tag> `);
+
+      expect(el._label(undefined)).to.equal('');
+      expect(el._name(undefined)).to.equal('');
+      expect(el._href(undefined)).to.equal('');
+    });
+
+    test('Should render empty content when group is null', async () => {
+      const el = await fixture(html` <nuxeo-group-tag disabled></nuxeo-group-tag> `);
+      el.group = null;
+
+      // The tag should render without errors and have no meaningful text content
+      const tag = dom(el.root).querySelector('nuxeo-tag');
+      expect(tag).to.exist;
+    });
+  });
+
+  suite('String group', () => {
+    test('Should display group name from a plain string', async () => {
+      const el = await fixture(html` <nuxeo-group-tag disabled group="administrators"></nuxeo-group-tag> `);
+
+      expect(dom(el.root).querySelector('nuxeo-tag').innerText).to.have.string('administrators');
+    });
+
+    test('Should strip group: prefix from a string', async () => {
+      const el = await fixture(html` <nuxeo-group-tag disabled group="group:admins"></nuxeo-group-tag> `);
+
+      expect(el._label('group:admins')).to.equal('admins');
+      expect(el._name('group:admins')).to.equal('admins');
+    });
+  });
+
+  suite('Entity group', () => {
+    test('Should display grouplabel when available', async () => {
+      const group = {
+        'entity-type': 'group',
+        groupname: 'admins',
+        grouplabel: 'Administrators',
+        properties: {
+          'group:groupname': 'admins',
+          'group:grouplabel': 'Administrators',
+        },
+      };
+
+      const el = await fixture(html`
+        <nuxeo-group-tag disabled group="${JSON.stringify(group)}"></nuxeo-group-tag>
+      `);
+
+      expect(dom(el.root).querySelector('nuxeo-tag').innerText).to.have.string('Administrators');
+    });
+
+    test('Should fall back to groupname when grouplabel is missing', async () => {
+      const group = {
+        'entity-type': 'group',
+        groupname: 'admins',
+        properties: {
+          'group:groupname': 'admins',
+        },
+      };
+
+      const el = await fixture(html`
+        <nuxeo-group-tag disabled group="${JSON.stringify(group)}"></nuxeo-group-tag>
+      `);
+
+      expect(dom(el.root).querySelector('nuxeo-tag').innerText).to.have.string('admins');
+    });
+  });
+});

--- a/ui/widgets/nuxeo-group-tag.js
+++ b/ui/widgets/nuxeo-group-tag.js
@@ -105,6 +105,9 @@ import './nuxeo-tag.js';
     }
 
     _name(group) {
+      if (!group) {
+        return '';
+      }
       if (this._isEntity(group)) {
         return group.groupname || group.properties['group:groupname'];
       }
@@ -115,6 +118,9 @@ import './nuxeo-tag.js';
     }
 
     _label(group) {
+      if (!group) {
+        return '';
+      }
       if (this._isEntity(group)) {
         return group.grouplabel || group.properties['group:grouplabel'] || this._name(group);
       }
@@ -125,6 +131,9 @@ import './nuxeo-tag.js';
     }
 
     _href(group) {
+      if (!group) {
+        return '';
+      }
       return this.urlFor('group', this._name(group));
     }
 


### PR DESCRIPTION
## Summary

Fixes [ELEMENTS-1477](https://hyland.atlassian.net/browse/ELEMENTS-1477): `nuxeo-group-tag` throws `TypeError: Cannot read properties of null (reading 'label')` when the `group` property is `null`.

## Changes

- Add null guards to `_name()`, `_label()`, and `_href()` in `nuxeo-group-tag.js`
- Return empty string for null/undefined group values for graceful rendering
- Add unit tests for null, undefined, string, and entity group scenarios

## How to test

1. Use `<nuxeo-group-tag group="[[document.properties.my:group]]"></nuxeo-group-tag>` where `my:group` is null
2. Verify no console error is thrown
3. Verify the component renders without visible text