### PR TITLE
feat: add Dependabot auto-fix agent and workflow

### DIFF
--- a/.github/agents/dependabot-fixer.agent.md
+++ b/.github/agents/dependabot-fixer.agent.md
@@ -1,0 +1,152 @@
+---
+name: dependabot-fixer
+description: Review and fix Dependabot version update PRs for nuxeo-elements. Checks
+  out the PR branch, runs lint and tests, identifies breaking changes from dependency
+  upgrades, and pushes fixes. Use when Dependabot PRs fail CI or need manual review.
+tools:
+  - bash
+  - view
+  - edit
+  - create
+  - grep
+  - glob
+  - io_github_github_github-mcp-server-list_pull_requests
+  - io_github_github_github-mcp-server-pull_request_read
+  - io_github_github_github-mcp-server-get_file_contents
+  - io_github_github_github-mcp-server-search_code
+---
+
+# Dependabot Fixer Agent
+
+You are a specialized agent for reviewing and fixing Dependabot version update PRs
+in the `nuxeo-elements` repository. Your goal is to ensure dependency upgrades don't
+break the build, lint, or tests — and to fix any breaking changes automatically.
+
+## Repository Context
+
+- **Monorepo**: Lerna workspaces (`core`, `ui`, `dataviz`, `testing-helpers`, `storybook`)
+- **Framework**: Polymer 3 web components
+- **Branches**: `maintenance-3.1.x` (default), `lts-2025`
+- **Registry**: `@nuxeo` packages from `https://packages.nuxeo.com/repository/npm-public/`
+- **Node**: 22 (CI), ≥18 (local)
+
+## Workflow
+
+### Step 1: Identify Dependabot PRs
+
+List open Dependabot PRs:
+
+```bash
+gh pr list --repo nuxeo/nuxeo-elements --author "dependabot[bot]" --state open --json number,title,headRefName,baseRefName
+```
+
+Or if the user specifies a PR number, use that directly.
+
+### Step 2: Check Out the PR Branch
+
+```bash
+gh pr checkout <PR_NUMBER>
+```
+
+### Step 3: Install and Run CI
+
+```bash
+npm install --no-package-lock
+npm run bootstrap
+npm run lint
+npm test
+```
+
+### Step 4: Analyze Failures
+
+If lint or tests fail:
+
+1. **Read the error output carefully** — identify which package/file/line failed
+2. **Check the dependency changelog** — look at what changed in the upgraded package:
+   ```bash
+   # Check what was upgraded
+   gh pr diff <PR_NUMBER> --name-only
+   gh pr diff <PR_NUMBER> -- package.json */package.json
+   ```
+3. **Identify the root cause**:
+   - API breaking change (method renamed, removed, signature changed)
+   - Import path change (module restructured)
+   - Config format change (ESLint, Karma, Polymer CLI)
+   - Type change (property type changed)
+   - Peer dependency conflict
+
+### Step 5: Fix Breaking Changes
+
+Common fix patterns for this repo:
+
+#### ESLint / Prettier Upgrades
+- Check `eslint.config.mjs` and `ui/eslint.config.mjs` for config changes
+- Run `npm run format` to auto-fix formatting issues
+- Update rule names if they were renamed
+
+#### Polymer / Web Components Upgrades
+- Check import paths: `@polymer/*` packages may restructure
+- Check API changes: property observers, lifecycle callbacks
+- Update `polymer.json` if needed
+
+#### Testing Framework Upgrades (Karma, Mocha, Chai, Sinon)
+- Check `karma.conf.js` for config changes
+- Check `test/setup.js` for assertion API changes
+- Update sinon stub/spy API calls if sinon was upgraded
+- Check chai assertion syntax changes
+
+#### Build Tool Upgrades (Lerna, npm-run-all)
+- Check `package.json` scripts still work
+- Update lerna config in `lerna.json` if needed
+
+#### General Fixes
+- Run `npm run format` to fix any formatting issues
+- Check if `package-lock.json` needs regeneration
+- Verify all workspace packages still resolve correctly
+
+### Step 6: Validate Fixes
+
+After making changes:
+
+```bash
+npm run format    # Auto-fix formatting
+npm run lint      # Must pass
+npm test          # Must pass
+```
+
+### Step 7: Commit and Push
+
+```bash
+git add -A
+git commit -m "fix: resolve breaking changes from dependency upgrade
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push
+```
+
+## Rules
+
+- **DO NOT** modify vendored code: `ui/viewers/pdfjs/`, `ui/js-interpreter/`
+- **DO NOT** edit translated i18n files (only `ui/i18n/messages.json`)
+- **DO NOT** convert between Polymer legacy and class-based patterns
+- **ALWAYS** run `npm run format` before committing
+- **ALWAYS** run full lint + test suite to validate
+- Keep fixes minimal — only change what's needed to fix the breakage
+- If a fix requires significant refactoring, comment on the PR explaining the situation
+  and suggest closing the Dependabot PR in favor of a manual upgrade
+
+## Handling Multiple Branches
+
+Dependabot creates separate PRs for `maintenance-3.1.x` and `lts-2025`. Process them
+independently — fixes for one branch may not apply cleanly to the other due to
+codebase differences between branches.
+
+## Escalation
+
+If you cannot fix the breaking changes automatically:
+1. Comment on the PR with a detailed analysis of what broke and why
+2. Label the PR with `needs-manual-review`
+3. Suggest whether to:
+   - Pin the dependency to the previous version
+   - Close the PR and create a manual upgrade PR
+   - Wait for an upstream fix

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -101,3 +101,5 @@ test/                → Shared test setup
 - **Registry**: `@nuxeo` packages come from `https://packages.nuxeo.com/repository/npm-public/`
 - **Cross-repo**: Changes can trigger nuxeo-web-ui builds
 - **Translations**: Crowdin sync runs daily
+- **Dependabot**: Weekly version update PRs for both `maintenance-3.1.x` and `lts-2025` branches; auto-fix workflow runs lint/tests and assigns Copilot on failure
+- **Agent mode**: Use `dependabot-fixer` agent to manually review/fix Dependabot PRs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,19 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "maintenance-3.1.x"
+    reviewers:
+      - "nuxeo/ui"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
     groups:
       gha:
         patterns:
@@ -23,6 +31,11 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[lts-2025]"
+    labels:
+      - "dependencies"
+      - "lts-2025"
+    reviewers:
+      - "nuxeo/ui"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -31,6 +44,9 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[lts-2025]"
+    labels:
+      - "dependencies"
+      - "github-actions"
     groups:
       gha:
         patterns:

--- a/.github/skills/fix-dependabot-pr/SKILL.md
+++ b/.github/skills/fix-dependabot-pr/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: fix-dependabot-pr
+description: Fix breaking changes in Dependabot version update PRs for Nuxeo Elements.
+  Use this skill when a Dependabot PR fails CI (lint or tests) due to a dependency
+  upgrade introducing breaking changes. Analyzes the upgrade diff, identifies root
+  causes, and applies targeted fixes. Also use when the user mentions fixing dependency
+  upgrades, resolving version bumps, or handling breaking changes from automated PRs.
+---
+
+# Fix Dependabot PR
+
+Fix CI failures caused by dependency version upgrades in Dependabot PRs.
+
+## Workflow
+
+1. Identify which dependency was upgraded and what changed
+2. Run lint and tests to reproduce failures
+3. Analyze error output to identify root cause
+4. Apply targeted fixes
+5. Validate with full CI suite
+6. Commit and push fixes
+
+## Identifying the Upgrade
+
+```bash
+# See what files changed in the Dependabot PR
+gh pr diff <PR_NUMBER> --name-only
+
+# See the actual dependency version changes
+gh pr diff <PR_NUMBER> -- package.json core/package.json ui/package.json dataviz/package.json testing-helpers/package.json storybook/package.json
+
+# Check the dependency's changelog/release notes
+# Look at the GitHub releases page for the upgraded package
+```
+
+## Common Failure Categories
+
+### 1. ESLint Rule Changes
+
+**Symptoms**: `npm run lint` fails with unknown rule or deprecated rule errors.
+
+**Diagnosis**:
+```bash
+npm run lint:eslint 2>&1 | head -50
+```
+
+**Fixes**:
+- Update rule names in `eslint.config.mjs` and `ui/eslint.config.mjs`
+- Remove deprecated rules
+- Add new required rules
+- Update plugin imports if plugin API changed
+
+### 2. Prettier Formatting Changes
+
+**Symptoms**: `npm run lint:prettier` shows files not formatted.
+
+**Fix**:
+```bash
+npm run format:prettier
+```
+
+### 3. Karma / Test Runner Changes
+
+**Symptoms**: `npm test` fails before tests even run (config errors).
+
+**Diagnosis**:
+```bash
+npm run test:core 2>&1 | head -30
+```
+
+**Fixes**:
+- Update `karma.conf.js` for config format changes
+- Update browser launcher config
+- Check `@open-wc/karma-esm` compatibility
+
+### 4. Mocha API Changes
+
+**Symptoms**: Tests fail with `TypeError` or `ReferenceError` in test setup.
+
+**Fixes**:
+- Check `test/setup.js` for API changes
+- Update `suite`/`test`/`setup`/`teardown` usage if interface changed
+- Verify `mocha` options in `karma.conf.js`
+
+### 5. Chai Assertion Changes
+
+**Symptoms**: Tests fail with assertion method errors.
+
+**Fixes**:
+- Check if assertion methods were renamed or removed
+- Update `expect`/`assert` calls in test files
+- Check `sinon-chai` plugin compatibility with new chai version
+
+### 6. Sinon Stub/Spy API Changes
+
+**Symptoms**: Tests fail with sinon-related errors (stub creation, spy assertions).
+
+**Fixes**:
+- Update `sinon.stub()` / `sinon.spy()` calls if API changed
+- Check `sinon.createSandbox()` usage in `testing-helpers/nuxeo-mock-client.js`
+- Update `sinon-chai` if needed for compatibility
+
+### 7. Polymer / Web Component Changes
+
+**Symptoms**: Components fail to register or render.
+
+**Fixes**:
+- Check import paths for `@polymer/*` packages
+- Update lifecycle callback names if changed
+- Check `polymer.json` for config compatibility
+- Verify `@webcomponents/webcomponentsjs` polyfill compatibility
+
+### 8. Lerna / Workspace Changes
+
+**Symptoms**: `npm run bootstrap` or workspace resolution fails.
+
+**Fixes**:
+- Update `lerna.json` for config changes
+- Check `package.json` workspace config
+- Update npm scripts that invoke lerna
+
+### 9. Peer Dependency Conflicts
+
+**Symptoms**: `npm install` warns about peer dependency mismatches.
+
+**Fixes**:
+- Check if other dependencies need upgrading too
+- Update `package.json` to align peer dependency versions
+- Use `--legacy-peer-deps` only as last resort
+
+## Fix Procedure
+
+### Step 1: Reproduce
+
+```bash
+npm install --no-package-lock
+npm run bootstrap
+npm run lint      # Check lint first
+npm test          # Then tests
+```
+
+### Step 2: Fix Lint Issues
+
+```bash
+# Auto-fix what can be auto-fixed
+npm run format
+
+# Re-check
+npm run lint
+```
+
+If `npm run format` doesn't fix everything, manually fix the remaining issues
+based on the error output.
+
+### Step 3: Fix Test Issues
+
+Read test error output carefully. Common patterns:
+
+```
+# Single package test for faster iteration
+npm run test:core     # If core tests fail
+npm run test:ui       # If UI tests fail
+npm run test:dataviz  # If dataviz tests fail
+```
+
+### Step 4: Validate
+
+```bash
+npm run format    # Final formatting pass
+npm run lint      # Must pass clean
+npm test          # All tests must pass
+```
+
+### Step 5: Commit
+
+```bash
+git add -A
+git commit -m "fix: resolve breaking changes from <package>@<version> upgrade
+
+- <describe what broke>
+- <describe what was fixed>
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push
+```
+
+## Files You May Need to Modify
+
+| File | When |
+|------|------|
+| `eslint.config.mjs` | ESLint/plugin upgrades |
+| `ui/eslint.config.mjs` | ESLint/plugin upgrades (UI-specific rules) |
+| `karma.conf.js` | Karma/test runner upgrades |
+| `test/setup.js` | Chai/sinon/mocha upgrades |
+| `polymer.json` | Polymer CLI upgrades |
+| `lerna.json` | Lerna upgrades |
+| `package.json` | Any dependency upgrade (scripts, config) |
+| `testing-helpers/*.js` | Test framework upgrades |
+| `core/test/*.test.js` | Test API changes |
+| `ui/test/*.test.js` | Test API changes |
+| `dataviz/test/*.test.js` | Test API changes |
+
+## Files You Must NOT Modify
+
+- `ui/viewers/pdfjs/**` — Vendored PDF.js fork
+- `ui/js-interpreter/**` — Vendored JS interpreter
+- `ui/i18n/messages-*.json` — Crowdin-managed translations (only edit `messages.json`)
+
+## When to Escalate
+
+If the upgrade requires changes that go beyond fixing breaking API calls:
+
+1. **Major version bumps with extensive breaking changes** — Comment on the PR suggesting
+   a manual upgrade PR instead
+2. **Incompatible peer dependencies** — May need coordinated upgrades across multiple packages
+3. **Fundamental architecture changes** — e.g., a testing framework dropping support for
+   the TDD interface this project uses
+
+In these cases, comment on the PR with your analysis and recommend closing it in favor
+of a planned manual upgrade.

--- a/.github/skills/update-ai-context/SKILL.md
+++ b/.github/skills/update-ai-context/SKILL.md
@@ -46,6 +46,13 @@ evolves with the codebase.
 | `.github/skills/add-i18n-keys/SKILL.md` | Add/update i18n message keys |
 | `.github/skills/write-unit-test/SKILL.md` | Generate unit tests |
 | `.github/skills/update-ai-context/SKILL.md` | Audit and update all AI context files |
+| `.github/skills/fix-dependabot-pr/SKILL.md` | Fix breaking changes in Dependabot PRs |
+
+### Tier 3b: Agent Modes (specialized agent configurations)
+
+| File | Purpose |
+|---|---|
+| `.github/agents/dependabot-fixer.agent.md` | Review and fix Dependabot version update PRs |
 
 ### Tier 4: Human-Facing Docs (also read by AI for context)
 

--- a/.github/workflows/dependabot-auto-fix.yaml
+++ b/.github/workflows/dependabot-auto-fix.yaml
@@ -103,16 +103,7 @@ jobs:
           gh pr review "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --approve \
-            --body "✅ **Dependabot Auto-Fix**: Lint and tests passed. Auto-approved."
-
-      - name: Enable auto-merge
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr merge "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" \
-            --auto \
-            --squash
+            --body "✅ **Dependabot Auto-Fix**: Lint and tests passed. Auto-approved. A human reviewer must still merge this PR."
 
   # When lint or test fails, assign Copilot coding agent to fix the PR
   assign-copilot:

--- a/.github/workflows/dependabot-auto-fix.yaml
+++ b/.github/workflows/dependabot-auto-fix.yaml
@@ -1,0 +1,208 @@
+name: Dependabot Auto-Fix
+
+on:
+  pull_request:
+    branches:
+      - maintenance-3.1.x
+      - lts-2025
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+env:
+  BRANCH_NAME: ${{ github.head_ref }}
+
+jobs:
+  # Gate: only run for Dependabot PRs
+  check-author:
+    runs-on: ubuntu-latest
+    outputs:
+      is-dependabot: ${{ steps.check.outputs.is-dependabot }}
+    steps:
+      - name: Check if PR is from Dependabot
+        id: check
+        run: |
+          if [[ "${{ github.actor }}" == "dependabot[bot]" || "${{ github.actor }}" == "dependabot" ]]; then
+            echo "is-dependabot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-dependabot=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  lint:
+    needs: check-author
+    if: needs.check-author.outputs.is-dependabot == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.lint.outcome }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
+          scope: '@nuxeo'
+
+      - name: Install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+        run: |
+          npm install --no-package-lock
+          npm run bootstrap
+
+      - name: Lint
+        id: lint
+        run: npm run lint
+
+  test:
+    needs: check-author
+    if: needs.check-author.outputs.is-dependabot == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.test.outcome }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.BRANCH_NAME }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
+          scope: '@nuxeo'
+
+      - name: Install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+        run: |
+          npm install --no-package-lock
+          npm run bootstrap
+
+      - name: Test
+        id: test
+        run: npm run test
+
+  # When both lint and test pass, auto-approve and enable auto-merge
+  auto-approve:
+    needs: [check-author, lint, test]
+    if: |
+      needs.check-author.outputs.is-dependabot == 'true' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-approve Dependabot PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --approve \
+            --body "✅ **Dependabot Auto-Fix**: Lint and tests passed. Auto-approved."
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --auto \
+            --squash
+
+  # When lint or test fails, assign Copilot coding agent to fix the PR
+  assign-copilot:
+    needs: [check-author, lint, test]
+    if: |
+      always() &&
+      needs.check-author.outputs.is-dependabot == 'true' &&
+      (needs.lint.result == 'failure' || needs.test.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment failure details on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LINT_STATUS="${{ needs.lint.result }}"
+          TEST_STATUS="${{ needs.test.result }}"
+
+          BODY="## 🔧 Dependabot Auto-Fix: CI Failure Detected
+
+          | Check | Status |
+          |-------|--------|
+          | Lint  | ${LINT_STATUS} |
+          | Test  | ${TEST_STATUS} |
+
+          **Branch**: \`${{ env.BRANCH_NAME }}\`
+          **Base**: \`${{ github.base_ref }}\`
+
+          ### Next Steps
+          The Copilot coding agent has been assigned to fix the breaking changes.
+          If automatic fixing fails, manually run the \`dependabot-fixer\` agent mode in VS Code:
+          1. Switch to the \`dependabot-fixer\` agent mode
+          2. Ask: *Fix the Dependabot PR #${{ github.event.pull_request.number }}*
+          "
+
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "$BODY"
+
+      - name: Create fix issue for Copilot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_BRANCH="${{ env.BRANCH_NAME }}"
+          BASE_BRANCH="${{ github.base_ref }}"
+          LINT_STATUS="${{ needs.lint.result }}"
+          TEST_STATUS="${{ needs.test.result }}"
+
+          ISSUE_BODY="## Fix Dependabot PR #${PR_NUMBER}
+
+          The Dependabot PR [#${PR_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}) has CI failures.
+
+          **PR**: ${PR_TITLE}
+          **Branch**: \`${PR_BRANCH}\` → \`${BASE_BRANCH}\`
+          **Lint**: ${LINT_STATUS}
+          **Test**: ${TEST_STATUS}
+
+          ### Instructions
+
+          1. Check out branch \`${PR_BRANCH}\`
+          2. Run \`npm install --no-package-lock && npm run bootstrap\`
+          3. Run \`npm run lint\` — fix any lint errors
+          4. Run \`npm test\` — fix any test failures
+          5. Common fixes for dependency upgrades:
+             - API changes: update call sites to match new API
+             - Import path changes: update import statements
+             - Config changes: update eslint/karma/polymer config
+             - Type changes: update property types or default values
+          6. Run \`npm run format\` before committing
+          7. Push fixes to the \`${PR_BRANCH}\` branch
+
+          ### Context
+          - This is a Polymer 3 monorepo (core, ui, dataviz, testing-helpers, storybook)
+          - Use \`npm run lint\` for linting and \`npm test\` for all tests
+          - Do NOT modify vendored code in \`ui/viewers/pdfjs/\` or \`ui/js-interpreter/\`
+          - Do NOT edit translated i18n files (only \`ui/i18n/messages.json\`)
+          "
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Fix CI failures in Dependabot PR #${PR_NUMBER}: ${PR_TITLE}" \
+            --body "$ISSUE_BODY" \
+            --label "dependencies,copilot" \
+            --assignee "@me" || true
+
+      - name: Label PR as needing fixes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "ci-failure,needs-fix" || true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - maintenance-3.1.x
+      - lts-2025
   workflow_call:
     inputs:
       branch:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - maintenance-3.1.x
+      - lts-2025
   workflow_call:
     inputs:
       branch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,17 @@ npm run test:dataviz  # Dataviz only
 
 Push to `maintenance-3.1.x` triggers: **lint → test → storybook → build (tag + publish)** (all must pass).
 
-PRs run lint and test workflows automatically.
+PRs run lint and test workflows automatically (both `maintenance-3.1.x` and `lts-2025`).
+
+### Dependabot Auto-Fix
+
+Dependabot creates weekly PRs for both branches. The `dependabot-auto-fix.yaml` workflow:
+1. Runs lint and tests on Dependabot PRs
+2. Auto-approves and enables auto-merge on success
+3. Assigns Copilot coding agent and labels PR on failure
+
+Use the `dependabot-fixer` agent mode in VS Code for manual review/fixing of Dependabot PRs.
+See `.github/skills/fix-dependabot-pr/SKILL.md` for detailed fixing instructions.
 
 ## Common Pitfalls
 


### PR DESCRIPTION
## Summary

Adds automated tooling to handle Dependabot version update PRs for both `maintenance-3.1.x` and `lts-2025` branches.

## Changes

### New: `dependabot-auto-fix.yaml` workflow
- Triggers on Dependabot PRs targeting `maintenance-3.1.x` or `lts-2025`
- Runs lint and tests in parallel
- **On success**: auto-approves the PR (human must still merge)
- **On failure**: comments with CI status details, creates an issue, and labels the PR with `ci-failure` + `needs-fix`

### New: `.github/agents/dependabot-fixer.agent.md`
- VS Code Copilot agent mode for manually reviewing and fixing Dependabot PRs
- Includes step-by-step workflow: check out branch → run CI → diagnose failures → apply fixes → push

### New: `.github/skills/fix-dependabot-pr/SKILL.md`
- Detailed skill with fix patterns for common dependency upgrade breakages:
  - ESLint/Prettier rule changes
  - Karma/Mocha/Chai/Sinon API changes
  - Polymer/Web Components import path changes
  - Lerna/workspace config changes

### Updated: `lint.yaml` + `test.yaml`
- Added `lts-2025` to PR triggers — Dependabot PRs targeting that branch now get full CI checks

### Updated: `dependabot.yml`
- Added `labels` and `reviewers` to all update configs for better PR organization

### Updated: AI context files
- `copilot-instructions.md`, `AGENTS.md`, `update-ai-context/SKILL.md` — reference the new agent and skill
