### PR TITLE
fix(ci): use GIT_ADMIN_TOKEN for storybook gh-pages deploy

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,6 +33,7 @@ jobs:
     uses: nuxeo/nuxeo-elements/.github/workflows/storybook.yaml@maintenance-3.1.x
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+      GIT_ADMIN_TOKEN: ${{ secrets.GIT_ADMIN_TOKEN }}
     with:
       branch: maintenance-3.1.x
 

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -15,6 +15,9 @@ on:
       NPM_PACKAGES_TOKEN:
         description: 'NPM_PACKAGES_TOKEN'
         required: true
+      GIT_ADMIN_TOKEN:
+        description: 'GIT_ADMIN_TOKEN'
+        required: false
 
 permissions:
   contents: write
@@ -54,6 +57,6 @@ jobs:
       - name: Deploy
         if: ${{ env.BRANCH_NAME == 'maintenance-3.1.x' }}
         env:
-          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: nuxeo-webui-jx-bot:${{ secrets.GIT_ADMIN_TOKEN }}
         working-directory: storybook
         run: npm run deploy -- --ci --existing-output-dir=dist


### PR DESCRIPTION
## Problem

The Storybook deploy step fails with:

```
remote: error: GH013: Repository rule violations found for refs/heads/gh-pages.
remote: - Commits must have verified signatures.
```

The `@storybook/storybook-deployer` pushes commits as `GH Pages Bot <hello@ghbot.com>`, which is not exempt from the branch protection rule requiring signed commits.

## Fix

Use `GIT_ADMIN_TOKEN` (PAT for `nuxeo-webui-jx-bot`) in the `GH_TOKEN` env variable so that the push is attributed to the exempt bot user.

### Changes
- **storybook.yaml**: Added `GIT_ADMIN_TOKEN` as an optional workflow_call secret, set `GH_TOKEN` to `nuxeo-webui-jx-bot:${{ secrets.GIT_ADMIN_TOKEN }}`
- **main.yaml**: Pass `GIT_ADMIN_TOKEN` secret to the storybook workflow call