### PR TITLE
ELEMENTS-1974: fix node-fetch v2 "Premature close" on Node >= 19

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,18 @@
 const path = require('path');
+const http = require('http');
+const https = require('https');
+
+/*
+ * Workaround for node-fetch v2 "Premature close" errors on Node >= 19 (CI runs Node 22).
+ * Since Node 19 the global HTTP/HTTPS agents enable keep-alive by default, so the node-fetch
+ * used by @open-wc/karma-esm to load `context.html` reuses a pooled socket that the peer has
+ * already closed, which surfaces as `FetchError: ... Premature close`. Forcing keep-alive off
+ * makes each request open a fresh socket. Remove once Karma/karma-esm is replaced by WTR.
+ */
+[http.globalAgent, https.globalAgent].forEach((agent) => {
+  agent.keepAlive = false;
+  agent.options.keepAlive = false;
+});
 
 const coverage = process.argv.find((arg) => arg.includes('coverage'));
 


### PR DESCRIPTION
## Problem

The Karma unit-test pipeline intermittently fails with:

```
FetchError: Invalid response body while trying to fetch http://127.0.0.1:9876/context.html?bypass-es-dev-server: Premature close
```

This is **not** a network issue. Since **Node 19** the global HTTP/HTTPS agents enable
keep-alive by default, and the **node-fetch v2** used internally by `es-dev-server` /
`@open-wc/karma-esm` reuses a pooled socket the peer has already closed, surfacing as
`Premature close`. CI runs Node 22, and the recent Node `22.23.x` `http.Agent` change
(CVE-2026-48931) altered socket-reuse timing, making this fire consistently.

## Change

- **`karma.conf.js`**: disable keep-alive on the global HTTP/HTTPS agents at the top of the
  Karma master process, so the `karma-esm` loopback fetch opens a fresh socket per request
  instead of reusing a closed one.

## Notes

This is a targeted mitigation. The permanent fix is the Karma → `@web/test-runner` migration,
which removes `es-dev-server`/node-fetch entirely; the workaround can be dropped at that point.
