### PR TITLE
fix: nuxeo-selectivity Tab focus trap in multiple mode [LTS-2023]

### DIFF
--- a/ui/test/nuxeo-selectivity.test.js
+++ b/ui/test/nuxeo-selectivity.test.js
@@ -185,6 +185,25 @@ suite('nuxeo-selectivity keyboard accessibility (Tab)', () => {
       input.removeAttribute('tabindex');
     });
 
+    test('Tab while open skips tabbable elements inside the widget shadow tree', async () => {
+      // A focusable element living inside the widget's shadow DOM must not capture
+      // focus. findAdjacentTabbable uses a composed-tree check that crosses shadow
+      // boundaries, so the injected button is skipped and focus lands on nextButton.
+      const input = dom(selectivityWidget.root).querySelector('input.selectivity-multiple-input');
+      const innerButton = document.createElement('button');
+      innerButton.textContent = 'inner';
+      selectivityWidget.shadowRoot.appendChild(innerButton);
+      selectivityWidget._selectivity.open();
+      await flush();
+
+      pressAndReleaseKeyOn(input, KEY_TAB);
+      await Promise.resolve();
+
+      expect(document.activeElement).to.equal(nextButton);
+
+      innerButton.remove();
+    });
+
     test('Tab while open returns null from findAdjacentTabbable when there is no following tabbable element', async () => {
       // Remove nextButton from the tabbable order so findAdjacentTabbable
       // reaches the end of the list without finding a suitable target.

--- a/ui/widgets/nuxeo-selectivity.js
+++ b/ui/widgets/nuxeo-selectivity.js
@@ -3047,6 +3047,21 @@ typedArrayTags[weakMapTag] = false;
         return all;
       }
 
+      // True when `node` is `host` itself or lives anywhere inside its (possibly
+      // nested) shadow tree. Unlike Node.contains(), this walks up through shadow
+      // roots via ShadowRoot.host, so it reliably matches every element that
+      // belongs to a custom element — including content in its shadow DOM.
+      function composedContains(host, node) {
+        let current = node;
+        while (current) {
+          if (current === host) {
+            return true;
+          }
+          current = current.parentNode || current.host;
+        }
+        return false;
+      }
+
       // Returns the next sequentially focusable element after `current`, skipping
       // any element that is a descendant of `excludeRoot` (including itself).
       // Used to advance focus out of a multiple-mode selectivity widget when the
@@ -3060,7 +3075,7 @@ typedArrayTags[weakMapTag] = false;
           if (excludeRoot) {
             for (let i = 0; i < all.length; i++) {
               if (
-                !excludeRoot.contains(all[i]) &&
+                !composedContains(excludeRoot, all[i]) &&
                 excludeRoot.compareDocumentPosition(all[i]) & Node.DOCUMENT_POSITION_FOLLOWING
               ) {
                 return all[i];
@@ -3071,7 +3086,7 @@ typedArrayTags[weakMapTag] = false;
         }
         let i = idx + 1;
         while (i < all.length) {
-          if (!excludeRoot || !excludeRoot.contains(all[i])) {
+          if (!excludeRoot || !composedContains(excludeRoot, all[i])) {
             return all[i];
           }
           i++;
@@ -3490,7 +3505,13 @@ typedArrayTags[weakMapTag] = false;
           if (this.dropdown) {
             event.preventDefault();
             const inputEl = this.input;
-            const wrapperEl = this.el;
+            // Exclude the whole host element (including its shadow content), not just
+            // this.el (the inner `#input` div). this.el lives inside the widget's shadow
+            // tree, so excluding only it lets findAdjacentTabbable land on a sibling
+            // element still inside the widget — trapping focus. Climbing to the shadow
+            // host makes focus advance past the entire widget.
+            const rootNode = this.el.getRootNode && this.el.getRootNode();
+            const wrapperEl = (rootNode && rootNode.host) || this.el;
             this._beginTabbingOut();
             this.close();
             // Defer the focus advance to a microtask so any synchronous focus

--- a/ui/widgets/nuxeo-selectivity.js
+++ b/ui/widgets/nuxeo-selectivity.js
@@ -3086,7 +3086,7 @@ typedArrayTags[weakMapTag] = false;
         }
         let i = idx + 1;
         while (i < all.length) {
-          if (!excludeRoot || !composedContains(excludeRoot, all[i])) {
+          if (!composedContains(excludeRoot, all[i])) {
             return all[i];
           }
           i++;
@@ -3510,8 +3510,7 @@ typedArrayTags[weakMapTag] = false;
             // tree, so excluding only it lets findAdjacentTabbable land on a sibling
             // element still inside the widget — trapping focus. Climbing to the shadow
             // host makes focus advance past the entire widget.
-            const rootNode = this.el.getRootNode && this.el.getRootNode();
-            const wrapperEl = (rootNode && rootNode.host) || this.el;
+            const wrapperEl = this.el.getRootNode().host;
             this._beginTabbingOut();
             this.close();
             // Defer the focus advance to a microtask so any synchronous focus


### PR DESCRIPTION
## Problem
In `ui/widgets/nuxeo-selectivity.js`, `_handleForwardTab` passed `this.el` (the inner `#input` div, which lives *inside* the widget's shadow tree) as the exclusion root to `findAdjacentTabbable`, and `Element.contains()` does not cross shadow boundaries.

On the `idx < 0` fallback path (multiple-input not in the tab order), focus advanced to an element still inside the widget instead of leaving it — a keyboard focus trap. The unit test *"Tab while open uses idx<0 fallback…"* then failed its `document.activeElement` assertion, and chai's serialization of the DOM element on failure hung the browser (Karma disconnected after 5 min).

## Fix
- Add a `composedContains(host, node)` helper that walks up through shadow roots via `ShadowRoot.host`.
- `_handleForwardTab` now excludes the whole shadow **host** (`this.el.getRootNode().host`) instead of just `this.el`.
- `findAdjacentTabbable` uses `composedContains` in both branches.

Focus now reliably advances past the entire widget to the next tabbable element.

## Testing
Isolated run of `nuxeo-selectivity.test.js`: **117 passed, 0 failed**, no hang.