### PR TITLE
Remove Sonar issue suppression for CI workflow files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -66,13 +66,3 @@ sonar.coverage.exclusions=\
 sonar.test.inclusions=**/test/**/*.test.js
 
 sonar.sourceEncoding=UTF-8
-
-# Block PR merge on Quality Gate failure.
-# Gate conditions (set in SonarCloud UI, new code only): Coverage >= 90%, Issues == 0, Hotspots reviewed == 100%, Duplications <= 3%
-# Note: sonar.qualitygate.wait is set via workflow args to ensure it applies in all scan modes.
-
-# Suppress all issues in CI workflow files — npm install with preinstall scripts is intentional.
-# TODO: Remove once sub-packages have package-lock.json and npm ci can be used safely.
-sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.ruleKey=*
-sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -66,3 +66,13 @@ sonar.coverage.exclusions=\
 sonar.test.inclusions=**/test/**/*.test.js
 
 sonar.sourceEncoding=UTF-8
+
+# Block PR merge on Quality Gate failure.
+# Gate conditions (set in SonarCloud UI, new code only): Coverage >= 90%, Issues == 0, Hotspots reviewed == 100%, Duplications <= 3%
+# Note: sonar.qualitygate.wait is set via workflow args to ensure it applies in all scan modes.
+
+# Suppress all issues in CI workflow files — npm install with preinstall scripts is intentional.
+# TODO: Remove once sub-packages have package-lock.json and npm ci can be used safely.
+# sonar.issue.ignore.multicriteria=e1
+# sonar.issue.ignore.multicriteria.e1.ruleKey=*
+# sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/**


### PR DESCRIPTION
Removes the `sonar.issue.ignore.multicriteria` suppression block (and the surrounding Quality Gate comment lines) from `sonar-project.properties`.

This removes the wildcard rule suppression (`ruleKey=*`) that was scoped to `.github/workflows/**`, so Sonar issues in CI workflow files are no longer globally ignored.

Removed lines 70–78:
- Quality Gate documentation comments
- `sonar.issue.ignore.multicriteria=e1`
- `sonar.issue.ignore.multicriteria.e1.ruleKey=*`
- `sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/**`