### PR TITLE
ELEMENTS-1980: Add alpha build workflow for rebranding / work-in-progress deploys [LTS-2025]

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -46,7 +46,7 @@ jobs:
         # Alpha tags live in their own namespace WITHOUT the leading "v" prefix
         # (e.g. 2025.18.0-alpha.3) so they never match the rc pipeline's
         # "v${version}*" tag glob and cannot corrupt rc version numbering.
-        LAST_TAG=$(git tag --sort=taggerdate --list "${PACKAGE_VERSION/-SNAPSHOT}-${PREID}.*" | tail -1 | tr -d '\n')
+        LAST_TAG=$(git tag --list "${PACKAGE_VERSION/-SNAPSHOT}-${PREID}.*" | sort -V | tail -1 | tr -d '\n')
         echo "VERSION=$(npx semver -i prerelease --preid ${PREID} ${LAST_TAG:-$PACKAGE_VERSION} | tr -d '\n')" >> $GITHUB_ENV
 
     - name: Set version to ${{ env.VERSION }}

--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -10,47 +10,22 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
-  # This chages has been changed due to some version issue we will be removed it once we will resolve WEBUI-1266 and WEBUI-1267
   LERNA: lerna@9.0.7
   PREID: alpha
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yaml
-    secrets:
-      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
-
-  test:
-    uses: ./.github/workflows/test.yaml
-    secrets:
-      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
-      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-    with:
-      branch: ${{ github.ref_name }}
-
-  storybook:
-    uses: ./.github/workflows/storybook.yaml
-    secrets:
-      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
-      GIT_ADMIN_TOKEN: ${{ secrets.GIT_ADMIN_TOKEN }}
-    with:
-      branch: ${{ github.ref_name }}
-
-  sonar:
-    uses: ./.github/workflows/sonar.yaml
-    secrets:
-      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    with:
-      branch: ${{ github.ref_name }}
-
+  # No lint/test/storybook/sonar gates here on purpose: those already run on
+  # every push to the rebranding PR (each check has an `on: pull_request`
+  # trigger). Re-running them here would just duplicate the same checks on the
+  # same commit. Dispatch this workflow from a commit whose PR checks are green.
   build:
     runs-on: ubuntu-latest
-    # sonar runs in parallel for visibility but does not gate the publish
-    needs: [ lint, test, storybook ]
+    # Only this job needs write access, to create and push the alpha tag
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v6
 

--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -1,0 +1,93 @@
+name: Alpha build
+
+# Manually-triggered build used for rebranding / work-in-progress branches.
+# It is identical to the RC build (main.yaml) but produces `-alpha.N` prereleases
+# instead of `-rc.N`, so it never interferes with the RC pipeline on lts-2025.
+#
+# Dispatch it against the branch you want to build (ref selector in the Actions
+# tab, or: gh workflow run alpha.yaml --ref <your-branch>).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  # This chages has been changed due to some version issue we will be removed it once we will resolve WEBUI-1266 and WEBUI-1267
+  LERNA: lerna@9.0.7
+  PREID: alpha
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yaml
+    secrets:
+      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+
+  test:
+    uses: ./.github/workflows/test.yaml
+    secrets:
+      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+    with:
+      branch: ${{ github.ref_name }}
+
+  storybook:
+    uses: ./.github/workflows/storybook.yaml
+    secrets:
+      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+      GIT_ADMIN_TOKEN: ${{ secrets.GIT_ADMIN_TOKEN }}
+    with:
+      branch: ${{ github.ref_name }}
+
+  sonar:
+    uses: ./.github/workflows/sonar.yaml
+    secrets:
+      NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    with:
+      branch: ${{ github.ref_name }}
+
+  build:
+    runs-on: ubuntu-latest
+    # sonar runs in parallel for visibility but does not gate the publish
+    needs: [ lint, test, storybook ]
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 22
+        registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
+        scope: '@nuxeo'
+
+    - name: Prepare environment
+      run: |
+        git config user.name "nuxeo-webui-jx-bot" && git config user.email "webui@hyland.com"
+        echo "PACKAGE_VERSION=$(npx --no-install -c 'echo "$npm_package_version"')" >> $GITHUB_ENV
+
+    - name: Get prerelease version
+      run: |
+        git fetch origin --tags
+        # Alpha tags live in their own namespace WITHOUT the leading "v" prefix
+        # (e.g. 2025.18.0-alpha.3) so they never match the rc pipeline's
+        # "v${version}*" tag glob and cannot corrupt rc version numbering.
+        LAST_TAG=$(git tag --sort=taggerdate --list "${PACKAGE_VERSION/-SNAPSHOT}-${PREID}.*" | tail -1 | tr -d '\n')
+        echo "VERSION=$(npx semver -i prerelease --preid ${PREID} ${LAST_TAG:-$PACKAGE_VERSION} | tr -d '\n')" >> $GITHUB_ENV
+
+    - name: Set version to ${{ env.VERSION }}
+      run: |
+        npm version $VERSION --no-git-tag-version
+        npx ${{ env.LERNA }} version $VERSION --no-push --force-publish --no-git-tag-version --yes
+
+    - name: Tag
+      run: |
+        git commit -a -m "Alpha release ${VERSION}"
+        # Tag without the "v" prefix to stay out of the rc pipeline's tag namespace
+        git tag -a ${VERSION} -m "Alpha release ${VERSION}"
+        git push origin ${VERSION}
+
+    - name: Publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
+      # Publish under the `alpha` dist-tag so SNAPSHOT consumers are untouched
+      run: npx ${{ env.LERNA }} exec --ignore @nuxeo/nuxeo-elements-storybook -- npm publish --tag ${PREID}


### PR DESCRIPTION
https://hyland.atlassian.net/browse/ELEMENTS-1980

# Alpha builds (rebranding / work-in-progress deploys)

This document explains how to produce deployable Nuxeo Web UI builds from a
**feature branch** (e.g. the rebranding branch) **without merging into
`lts-2025`** and without triggering the RC pipeline.

It covers the two `alpha.yaml` workflows (one in `nuxeo-elements`, one in
`nuxeo-web-ui`), how they relate to the existing RC build, and the exact steps to
generate and deploy an alpha build.

---

## 1. Why this exists

Merging a PR into a main branch (`maintenance-3.1.x`, `lts-2025`) triggers the
**RC pipeline** (`main.yaml`), which:

1. computes the next `-rc.N` version,
2. links the latest RC of `@nuxeo/nuxeo-elements`,
3. builds the marketplace package, and
4. publishes it to the **Connect PREPROD** marketplace.

To deploy rebranding work we previously merged the feature branch into `lts-2025`
to get an RC, then reverted it — which broke the PR Sonar gates and required
temporary Sonar-config hacks.

The **alpha build** removes that entire dance. It produces the *exact same
artifact* as an RC (same steps, same PREPROD upload) but with an **`-alpha.N`**
version, built **directly from your feature branch**. Nothing is merged into or
reverted from a main branch.

`alpha` sorts below `rc` in semver (`alpha < beta < rc < release`), so an alpha
build can never be resolved ahead of a real release candidate.

---

## 2. How it maps to the RC pipeline

| Concern            | RC (`main.yaml`)                     | Alpha (`alpha.yaml`)                          |
| ------------------ | ------------------------------------ | --------------------------------------------- |
| Trigger            | push to `lts-2025`                   | **manual** (`workflow_dispatch`) on any branch |
| Version            | `2025.x.x-rc.N`                      | `2025.x.x-alpha.N`                            |
| Elements linked    | latest `@nuxeo/...-rc.N` on npm      | latest `@nuxeo/...-alpha.N` (falls back to rc) |
| Quality gates      | lint, test, a11y, ftest, sonar       | none in the build — the rebranding **PR already runs** lint/test/a11y/ftest/sonar on every push (see §2.1) |
| Marketplace upload | Connect **PREPROD**                  | Connect **PREPROD** (identical)               |
| npm dist-tag (ftest / elements) | `SNAPSHOT`              | `alpha`                                       |

The build/publish steps are otherwise byte-for-byte identical to the RC build.

### 2.1 Why there are no quality gates in the alpha build

Each check workflow (`lint`, `test`, `a11y`, `ftest`, `sonar`) has an
`on: pull_request` trigger against `lts-2025`, so **they already run on every
push to your rebranding PR** — using the same reusable workflows and the same
element resolution the alpha build would use. Re-running them inside the alpha
build would just duplicate the same checks on the same commit (and make the
build much slower with ftest + Sauce Labs).

So the alpha build is a pure **build + publish**. The rule of thumb:
**dispatch an alpha build only from a commit whose PR checks are green.** Your
"don't publish untested code" guarantee comes from the PR gates, not a second
redundant run.

---

## 3. The full pipeline

```
   ┌─────────────────────────────┐        ┌──────────────────────────────┐
   │ nuxeo-elements / alpha.yaml │        │  nuxeo-web-ui / alpha.yaml   │
   │ (run FIRST)                 │        │  (run SECOND)                │
   ├─────────────────────────────┤        ├──────────────────────────────┤
   │ (no gates — see §2.1)       │        │ (no gates — see §2.1)        │
   │             ↓               │        │             ↓                │
   │ version 2025.x.x-alpha.N    │        │ version 2025.x.x-alpha.N     │
   │ lerna publish --tag alpha ──┼──npm──▶ │ link latest elements -alpha  │
   │ tag 2025.x.x-alpha.N        │        │ mvn build marketplace zip    │
   └─────────────────────────────┘        │ upload zip → Connect PREPROD │
                                          │ tag 2025.x.x-alpha.N         │
                                          └──────────────────────────────┘
                                                        ↓
                                     Deploy the alpha package to the
                                     rebranding environment (Connect PREPROD)
```

**Order matters:** run the **elements** alpha build first so the alpha elements
packages exist on npm, then run the **web-ui** alpha build so it can link them.

---

## 4. One-time setup (required before first use)

GitHub only shows the **Run workflow** button (and only allows `workflow_dispatch`)
if the workflow file exists on the repository's **default branch**.

So, **once**, land these on each repo's default/main branch (`lts-2025` and/or
`maintenance-3.1.x`) via a small CI-only PR:

- `nuxeo-elements/.github/workflows/alpha.yaml` (new)
- `nuxeo-web-ui/.github/workflows/alpha.yaml` (new)

**No changes are made to `main.yaml` or the RC pipeline.** Alpha builds stay
isolated by tagging in their own namespace (see §6.1), so the RC pipeline is left
exactly as-is.

This is a one-time infrastructure change — **not** the repeated feature
merge/revert. After it merges, your feature branch (which is based on the main
branch) will also carry `alpha.yaml`, and the workflow can be dispatched against
any branch.

> The workflow that actually *runs* is the copy on the branch you dispatch
> against, so keep your feature branch rebased/up-to-date with the main branch to
> pick up any later changes to `alpha.yaml`.

---

## 5. How to generate an alpha build

### Step 1 — Build the elements alpha (only if elements changed on your branch)

**Via the GitHub UI:**
1. Go to the **`nuxeo-elements`** repo → **Actions** tab.
2. Select **Alpha build** in the left sidebar.
3. Click **Run workflow**, choose your feature branch as the ref, **Run**.
4. Wait for it to finish. It publishes `@nuxeo/nuxeo-elements@2025.x.x-alpha.N`
   (and the sibling packages) to npm under the `alpha` dist-tag.

**Via the `gh` CLI:**
```bash
gh workflow run alpha.yaml \
  --repo nuxeo/nuxeo-elements \
  --ref <your-feature-branch>

# watch it
gh run watch --repo nuxeo/nuxeo-elements
```

> If your branch does **not** change elements, you can skip this step — the
> web-ui alpha build will fall back to the latest elements `-rc`.

### Step 2 — Build the web-ui alpha

**Via the GitHub UI:**
1. Go to the **`plugin-nuxeo-web-ui`** repo → **Actions** tab.
2. Select **Alpha build** → **Run workflow** → choose your feature branch → **Run**.
3. When it succeeds, the marketplace package is uploaded to Connect **PREPROD**.

**Via the `gh` CLI:**
```bash
gh workflow run alpha.yaml \
  --repo nuxeo/plugin-nuxeo-web-ui \
  --ref <your-feature-branch>

gh run watch --repo nuxeo/plugin-nuxeo-web-ui
```

### Step 3 — Find the produced version

The version is `2025.x.x-alpha.N`. To find the exact one:
- Check the **Get prerelease version** / **Tag** step logs in the run, or
- Look at the newest `2025.x.x-alpha.*` git tag in the repo (no `v` prefix), or
- Look at the PREPROD marketplace listing for `nuxeo-web-ui`.

The marketplace zip uses a **zero-padded** build number
(e.g. `2025.18.0-alpha.003`) — that padded form is what you install/deploy.

### Step 4 — Deploy to the rebranding environment

Deploy the `nuxeo-web-ui` package at the produced alpha version to your
rebranding environment (it is served from Connect PREPROD, same as RC builds).
Pin the environment to the **explicit** `2025.x.x-alpha.NNN` version.

---

## 6. How the elements version is chosen (latest, not matched)

Exactly like the RC build, the web-ui alpha build does **not** try to match its
own version number to elements. It queries npm and picks the **latest** alpha:

```bash
npm view @nuxeo/nuxeo-ui-elements versions --json \
  | jq -r '.[]' \
  | grep -E "2025\.[0-9]+\.[0-9]+-alpha\.[0-9]+$" \
  | sort -V | tail -n1
```

- The two repos version independently, so elements might be `-alpha.7` while
  web-ui is `-alpha.4`.
- Because you run the elements alpha build **immediately before** the web-ui one,
  "latest alpha on npm" is the one just built from your branch.
- **Fallback:** if no `-alpha` elements exist on npm yet, it uses the latest
  `-rc` elements instead (so the very first web-ui alpha build still works).

All four dependencies are pinned with a `~` (patch-range) prefix:
`@nuxeo/nuxeo-elements`, `@nuxeo/nuxeo-dataviz-elements`,
`@nuxeo/nuxeo-ui-elements`, `@nuxeo/testing-helpers`.

### 6.1 Tag namespace (why RC is never affected)

The RC pipeline (`main.yaml`) computes its next version from git tags matching
the glob `v2025.x.x*`. To keep alpha builds from ever interfering with that,
**alpha builds tag WITHOUT the leading `v`** — e.g. `2025.18.0-alpha.3` instead
of `v2025.18.0-alpha.3`.

- RC tags: `v2025.18.0-rc.5` → matched by the RC glob `v2025.18.0*`
- Alpha tags: `2025.18.0-alpha.3` → **not** matched by `v2025.18.0*`

The alpha workflow reads only its own (`v`-less) tags to compute the next alpha
number, and the RC workflow reads only its own (`v`-prefixed) tags. The two never
see each other, so **no change to `main.yaml` is required.**

---

## 7. What gets published, and where

| Artifact                                   | Destination                        | Tag/version           |
| ------------------------------------------ | ---------------------------------- | --------------------- |
| `@nuxeo/nuxeo-elements` (+ siblings)       | npm (`packages.nuxeo.com`)         | dist-tag `alpha`      |
| Git tag `2025.x.x-alpha.N` (no `v` prefix) | both repos                         | —                     |
| `nuxeo-web-ui` marketplace zip             | **Connect PREPROD** only           | `2025.x.x-alpha.NNN`  |
| `@nuxeo/nuxeo-web-ui-ftest`                | npm                                | dist-tag `alpha`      |

**PROD is never touched.** Only the RC promotion workflow (`promote.yaml`) pushes
to Connect PROD; alpha builds stop at PREPROD.

---

## 8. FAQ / troubleshooting

**Q: Will alpha builds interfere with the RC pipeline?**
No. Alpha builds tag in a separate namespace (no `v` prefix, e.g.
`2025.18.0-alpha.3`), so they never match the RC pipeline's `v2025.x.x*` tag
glob. `main.yaml` is left completely unchanged. See §6.1.

**Q: The "Run workflow" button isn't showing.**
The workflow file must exist on the repo's **default branch** — complete the
one-time setup in §4.

**Q: Where did the lint/test/a11y/ftest/sonar gates go?**
They are not run inside the alpha build on purpose. Those checks already run on
every push to your rebranding PR (each has an `on: pull_request` trigger), so
the alpha build would only duplicate them on the same commit. Dispatch an alpha
build from a commit whose PR checks are green. See §2.1.

**Q: Can I run web-ui alpha without rebuilding elements?**
Yes — skip Step 1. It will link the latest existing elements `-alpha` (or `-rc`).

**Q: How do I get back to a clean RC once rebranding merges normally?**
Nothing to undo. Alpha builds only add `-alpha` tags and a PREPROD package;
they never modify main-branch source. When the feature merges through the normal
PR flow, the RC pipeline resumes as usual.
