### PR TITLE
ELEMENTS-1990: Add title attribute to PDF viewer iframe for accessibility [LTS-2025]

### DIFF
--- a/ui/i18n/messages.json
+++ b/ui/i18n/messages.json
@@ -283,6 +283,7 @@
   "operationButton.bulk.poll.error": "Error while executing {0}",
   "operationButton.bulk.poll.running": "{0} is running ({1}/{2})",
   "operationButton.bulk.poll.scheduled": "{0} is scheduled. You will be notified when it starts.",
+  "pdfViewer.title": "PDF preview",
   "popupPermission.addPermission": "Add a Permission",
   "popupPermission.cancel": "Cancel",
   "popupPermission.create": "Create",

--- a/ui/test/nuxeo-pdf-viewer.test.js
+++ b/ui/test/nuxeo-pdf-viewer.test.js
@@ -41,6 +41,12 @@ suite('nuxeo-pdf-viewer', () => {
       expect(iframe.src).to.include('pdfjs/web/viewer.html');
     });
 
+    test('should set a non-empty title attribute on the iframe', () => {
+      const iframe = element.shadowRoot.querySelector('iframe');
+      expect(iframe.hasAttribute('title')).to.be.true;
+      expect(iframe.getAttribute('title')).to.have.length.above(0);
+    });
+
     test('should render with no src without throwing', async () => {
       const elem = await fixture(
         html`

--- a/ui/test/nuxeo-pdf-viewer.test.js
+++ b/ui/test/nuxeo-pdf-viewer.test.js
@@ -43,6 +43,7 @@ suite('nuxeo-pdf-viewer', () => {
 
     test('should set the iframe title from the pdfViewer.title i18n key', async () => {
       const originalLanguage = window.nuxeo.I18n.language;
+      const hadEnDict = window.nuxeo.I18n.en !== undefined;
       const dict = (window.nuxeo.I18n.en = window.nuxeo.I18n.en || {});
       const originalValue = dict['pdfViewer.title'];
       window.nuxeo.I18n.language = 'en';
@@ -62,6 +63,9 @@ suite('nuxeo-pdf-viewer', () => {
           delete dict['pdfViewer.title'];
         } else {
           dict['pdfViewer.title'] = originalValue;
+        }
+        if (!hadEnDict) {
+          delete window.nuxeo.I18n.en;
         }
       }
     });

--- a/ui/test/nuxeo-pdf-viewer.test.js
+++ b/ui/test/nuxeo-pdf-viewer.test.js
@@ -41,10 +41,29 @@ suite('nuxeo-pdf-viewer', () => {
       expect(iframe.src).to.include('pdfjs/web/viewer.html');
     });
 
-    test('should set a non-empty title attribute on the iframe', () => {
-      const iframe = element.shadowRoot.querySelector('iframe');
-      expect(iframe.hasAttribute('title')).to.be.true;
-      expect(iframe.getAttribute('title')).to.have.length.above(0);
+    test('should set the iframe title from the pdfViewer.title i18n key', async () => {
+      const originalLanguage = window.nuxeo.I18n.language;
+      const dict = (window.nuxeo.I18n.en = window.nuxeo.I18n.en || {});
+      const originalValue = dict['pdfViewer.title'];
+      window.nuxeo.I18n.language = 'en';
+      dict['pdfViewer.title'] = 'PDF preview';
+      try {
+        const elem = await fixture(
+          html`
+            <nuxeo-pdf-viewer src="sample.pdf"></nuxeo-pdf-viewer>
+          `,
+        );
+        const iframe = elem.shadowRoot.querySelector('iframe');
+        expect(iframe.hasAttribute('title')).to.be.true;
+        expect(iframe.getAttribute('title')).to.equal('PDF preview');
+      } finally {
+        window.nuxeo.I18n.language = originalLanguage;
+        if (originalValue === undefined) {
+          delete dict['pdfViewer.title'];
+        } else {
+          dict['pdfViewer.title'] = originalValue;
+        }
+      }
     });
 
     test('should render with no src without throwing', async () => {

--- a/ui/viewers/nuxeo-pdf-viewer.js
+++ b/ui/viewers/nuxeo-pdf-viewer.js
@@ -16,7 +16,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
+import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 
 {
   /**
@@ -39,7 +41,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
    * @memberof Nuxeo
    * @demo demo/nuxeo-pdf-viewer/index.html
    */
-  class PDFViewer extends Nuxeo.Element {
+  class PDFViewer extends mixinBehaviors([I18nBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style>
@@ -57,7 +59,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
           }
         </style>
 
-        <iframe src$="[[_path(src)]]"></iframe>
+        <iframe src$="[[_path(src)]]" title$="[[i18n('pdfViewer.title')]]"></iframe>
       `;
     }
 


### PR DESCRIPTION
## ELEMENTS-1990: Accessibility — Inline Frame `title` attribute

### Problem
The `<iframe>` rendered by `nuxeo-pdf-viewer` had no `title` attribute. Inline frames must have a unique, non-empty `title` for accessibility (WCAG 2.2 — [H64: Using the title attribute of the iframe element](https://www.w3.org/WAI/WCAG22/Techniques/html/H64)).

### Fix
- `ui/viewers/nuxeo-pdf-viewer.js` — mixed in `I18nBehavior` and added a localized `title$="[[i18n('pdfViewer.title')]]"` to the `<iframe>` (same pattern already used by `nuxeo-image-viewer`).
- `ui/i18n/messages.json` — added the English message key `"pdfViewer.title": "PDF preview"` (only the English source file is edited; other locales are managed by Crowdin).
- `ui/test/nuxeo-pdf-viewer.test.js` — added a test asserting the iframe has a non-empty `title` attribute.

### Validation
- `npm run format` / Prettier: clean
- Unit tests: all 35 `nuxeo-pdf-viewer` tests pass
- Coverage: 100% line coverage on the modified file; changed lines fully covered (the only uncovered branches are pre-existing defensive null-checks in `_iframeLoadHandler`, unrelated to this change)

LTS-2025 port of #1512. Closes ELEMENTS-1990.