### PR TITLE
WEBUI-2039: Upgrade CI to Node 24 and minimum supported to Node 22 [LTS-2023]

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 Nuxeo Elements is the shared web components library for the Nuxeo content services platform, built with **Polymer 3** (legacy `Polymer({…})` factory pattern and class-based `Nuxeo.Element`). It provides data access, UI, dataviz, and testing components consumed by **Nuxeo Web UI** and third-party applications. Licensed Apache 2.0, owned by Hyland Software.
 
 - **Runtime**: Browser (no server-side JS in production)
-- **Node**: ≥ 18
+- **Node**: ≥ 22
 - **Build**: No bundler (library consumed via npm)
 - **Package manager**: npm (no yarn/pnpm)
 - **Monorepo**: Lerna workspaces (`core`, `ui`, `dataviz`, `testing-helpers`, `storybook`)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
         scope: '@nuxeo'
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
         scope: '@nuxeo'
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
-          node-version: 22
+          node-version: 24
           scope: '@nuxeo'
 
       - name: Cache npm packages

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a Polymer 3 web components library for the Nuxeo content services platfo
 Always follow this sequence when making changes:
 
 ```bash
-npm install                # Install all workspace dependencies (Node ≥ 18)
+npm install                # Install all workspace dependencies (Node ≥ 22)
 npm run format             # Auto-fix formatting (Polymer lint fix → Prettier → ESLint)
 npm run lint               # ESLint + Prettier + Polymer lint — must pass
 npm test                   # @web/test-runner unit tests (all packages) — must pass

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,7 @@ Nuxeo Elements is a library of reusable web components that forms the foundation
 | UI Framework | Polymer 3 (legacy factory + class-based) | ^3.5.1 |
 | Web Components Polyfills | @webcomponents/webcomponentsjs | ^2.0 |
 | Package Manager | npm | ≥ 8 |
-| Node.js | Node.js | ≥ 18 |
+| Node.js | Node.js | ≥ 22 |
 | Monorepo | Lerna | ^9.0.7 |
 | Unit Testing | @web/test-runner + Mocha + Chai + Sinon | Various |
 | Linting | ESLint 9 (flat config) + Prettier | ^9.0 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Node.js** ≥ 18
+- **Node.js** ≥ 22
 - **npm** (bundled with Node — no yarn or pnpm)
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To install the project's dependencies:
 npm install
 npm run bootstrap
 ```
-Note: This version of Nuxeo Elements requires node version >=14.0.0.
+Note: This version of Nuxeo Elements requires node version >=22.0.0.
 
 ## Quickstart
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "sinon-chai": "^4.0.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "core": {
@@ -168,6 +168,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2227,6 +2228,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -2714,27 +2716,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3054,27 +3035,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -5096,6 +5056,7 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -5624,6 +5585,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6439,6 +6401,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -6802,6 +6765,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8194,7 +8158,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
       "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "5.2.2",
@@ -8417,29 +8382,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -8779,6 +8721,7 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12447,6 +12390,7 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
       "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -14938,6 +14882,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -29613,6 +29558,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -31107,6 +31053,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -32632,6 +32579,7 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -32691,28 +32639,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "storybook/node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "storybook/node_modules/storybook": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.0.tgz",
       "integrity": "sha512-dRhM/kSSvHQR8DmZO41v5sJuz9U6zDjjR2gRBTgZN2RBSXbmF0Brvgszrvvxyx2VfxuYKzhB+xumKwWkwlBtig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
@@ -32777,6 +32709,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -32865,23 +32798,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "storybook/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "testing-helpers": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Nuxeo",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "postinstall": "check-engine --ignore",


### PR DESCRIPTION
## Summary
- Raise `engines.node` to `>=22.0.0`
- Set GitHub Actions CI runtime to Node 24 in all workflows
- Update developer documentation to reflect Node >= 22 minimum

## Related
- Paired with nuxeo/nuxeo-web-ui PR (same branch name)
- Triggers cross-repo integration check on PR
- Jira: https://hyland.atlassian.net/browse/WEBUI-2039

## Test plan
- [ ] lint, test, storybook CI green on PR
- [ ] cross-repo check green (lint + unit + ftest + a11y)

Made with [Cursor](https://cursor.com)