### PR TITLE
WEBUI-2039: Upgrade CI to Node 24 and minimum supported to Node 22 [LTS-2025]

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 Nuxeo Elements is the shared web components library for the Nuxeo content services platform, built with **Polymer 3** (legacy `Polymer({…})` factory pattern and class-based `Nuxeo.Element`). It provides data access, UI, dataviz, and testing components consumed by **Nuxeo Web UI** and third-party applications. Licensed Apache 2.0, owned by Hyland Software.
 
 - **Runtime**: Browser (no server-side JS in production)
-- **Node**: ≥ 18
+- **Node**: ≥ 22
 - **Build**: No bundler (library consumed via npm)
 - **Package manager**: npm (no yarn/pnpm)
 - **Monorepo**: Lerna workspaces (`core`, `ui`, `dataviz`, `testing-helpers`, `storybook`)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
         scope: '@nuxeo'
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
         scope: '@nuxeo'
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
-          node-version: 22
+          node-version: 24
           scope: '@nuxeo'
 
       - name: Cache npm packages

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://packages.nuxeo.com/repository/npm-public/'
           scope: '@nuxeo'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This is a Polymer 3 web components library for the Nuxeo content services platfo
 Always follow this sequence when making changes:
 
 ```bash
-npm install                # Install all workspace dependencies (Node ≥ 18)
+npm install                # Install all workspace dependencies (Node ≥ 22)
 npm run format             # Auto-fix formatting (Polymer lint fix → Prettier → ESLint)
 npm run lint               # ESLint + Prettier + Polymer lint — must pass
 npm test                   # @web/test-runner unit tests (all packages) — must pass

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,7 @@ Nuxeo Elements is a library of reusable web components that forms the foundation
 | UI Framework | Polymer 3 (legacy factory + class-based) | ^3.5.1 |
 | Web Components Polyfills | @webcomponents/webcomponentsjs | ^2.0 |
 | Package Manager | npm | ≥ 8 |
-| Node.js | Node.js | ≥ 18 |
+| Node.js | Node.js | ≥ 22 |
 | Monorepo | Lerna | ^9.0.7 |
 | Unit Testing | @web/test-runner + Mocha + Chai + Sinon | Various |
 | Linting | ESLint 9 (flat config) + Prettier | ^9.0 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Node.js** ≥ 18
+- **Node.js** ≥ 22
 - **npm** (bundled with Node — no yarn or pnpm)
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To install the project's dependencies:
 npm install
 npm run bootstrap
 ```
-Note: This version of Nuxeo Elements requires node version >=14.0.0.
+Note: This version of Nuxeo Elements requires node version >=22.0.0.
 
 ## Quickstart
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Nuxeo",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "postinstall": "check-engine --ignore",


### PR DESCRIPTION
## Summary
- Raise `engines.node` to `>=22.0.0`
- Set GitHub Actions CI runtime to Node 24 in all workflows
- Update developer documentation to reflect Node >= 22 minimum

## Related
- Paired with nuxeo/nuxeo-web-ui PR (same branch name)
- Triggers cross-repo integration check on PR
- Backport of LTS-2023 node upgrade
- Jira: https://hyland.atlassian.net/browse/WEBUI-2039

## Test plan
- [ ] cross-repo check green (lint + unit + ftest + a11y)
- [ ] main pipeline green after merge

Made with [Cursor](https://cursor.com)