### PR TITLE
ELEMENTS-1995: Fix display of user information throughout the UI [lts-2025]

### DIFF
--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -441,7 +441,7 @@ import '../nuxeo-button-styles.js';
       } catch (error) {
         if (requestId !== this._authorRequestId) return;
         if (error.status && error.status !== 404) {
-          console.warn(`Unexpected error resolving comment author "${author}":`, error.message);
+          console.warn(`Unexpected error resolving comment author "${author}":`, error);
         }
         this._authorEntity = null;
       }
@@ -449,13 +449,14 @@ import '../nuxeo-button-styles.js';
     }
 
     _authorDisplayName(author, entity, loading) {
+      if (!author) return '';
       if (!entity || loading) {
-        return author || '';
+        return author;
       }
       if (entity.properties) {
         return formatUserDisplayName(entity);
       }
-      return author || '';
+      return author;
     }
 
     _checkForEnter(e) {

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -30,7 +30,6 @@ import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
 import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '../widgets/nuxeo-dialog.js';
 import '../widgets/nuxeo-tooltip.js';
-import '../widgets/nuxeo-user-tag.js';
 
 import './nuxeo-document-comment-thread.js';
 import './nuxeo-document-comments-styles.js';
@@ -59,6 +58,15 @@ import '../nuxeo-button-styles.js';
         <style include="nuxeo-document-comments-styles nuxeo-button-styles">
           :host {
             margin-top: 5px;
+          }
+
+          .author {
+            font-weight: bold;
+            margin-right: 5px;
+          }
+
+          :host([dir='rtl']) .author {
+            margin-left: 5px;
           }
 
           .info {
@@ -155,10 +163,18 @@ import '../nuxeo-button-styles.js';
         <dom-if if="[[comment]]">
           <template>
             <div id="content" class="horizontal">
+              <nuxeo-user-avatar
+                user="[[comment.author]]"
+                height="[[_computeAvatarDimensions(level)]]"
+                width="[[_computeAvatarDimensions(level)]]"
+                border-radius="50"
+                font-size="[[_computeAvatarFontSize(level)]]"
+              >
+              </nuxeo-user-avatar>
               <div class="info">
                 <div id="body">
                   <div id="header" class="horizontal">
-                    <nuxeo-user-tag class="author" user="[[comment.author]]" disabled></nuxeo-user-tag>
+                    <span class="author">[[comment.author]]</span>
                     <span class="smaller opaque"
                       >[[_computeDateLabel(comment, comment.creationDate, comment.modificationDate, i18n)]]</span
                     >

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -30,6 +30,7 @@ import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
 import { NotifyBehavior } from '@nuxeo/nuxeo-elements/nuxeo-notify-behavior.js';
 import '../widgets/nuxeo-dialog.js';
 import '../widgets/nuxeo-tooltip.js';
+import '../widgets/nuxeo-user-tag.js';
 
 import './nuxeo-document-comment-thread.js';
 import './nuxeo-document-comments-styles.js';
@@ -58,15 +59,6 @@ import '../nuxeo-button-styles.js';
         <style include="nuxeo-document-comments-styles nuxeo-button-styles">
           :host {
             margin-top: 5px;
-          }
-
-          .author {
-            font-weight: bold;
-            margin-right: 5px;
-          }
-
-          :host([dir='rtl']) .author {
-            margin-left: 5px;
           }
 
           .info {
@@ -163,18 +155,10 @@ import '../nuxeo-button-styles.js';
         <dom-if if="[[comment]]">
           <template>
             <div id="content" class="horizontal">
-              <nuxeo-user-avatar
-                user="[[comment.author]]"
-                height="[[_computeAvatarDimensions(level)]]"
-                width="[[_computeAvatarDimensions(level)]]"
-                border-radius="50"
-                font-size="[[_computeAvatarFontSize(level)]]"
-              >
-              </nuxeo-user-avatar>
               <div class="info">
                 <div id="body">
                   <div id="header" class="horizontal">
-                    <span class="author">[[comment.author]]</span>
+                    <nuxeo-user-tag user="[[comment.author]]" disabled></nuxeo-user-tag>
                     <span class="smaller opaque"
                       >[[_computeDateLabel(comment, comment.creationDate, comment.modificationDate, i18n)]]</span
                     >

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -37,6 +37,7 @@ import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { FormatBehavior } from '../nuxeo-format-behavior.js';
+import { formatUserDisplayName } from '../nuxeo-user-group-management/nuxeo-user-display.js';
 import '../nuxeo-button-styles.js';
 
 /**
@@ -146,6 +147,7 @@ import '../nuxeo-button-styles.js';
 
         <nuxeo-connection id="nxcon" user="{{currentUser}}"></nuxeo-connection>
         <nuxeo-resource id="commentRequest" path="/id/[[comment.parentId]]/@comment/[[comment.id]]"></nuxeo-resource>
+        <nuxeo-resource id="authorResource"></nuxeo-resource>
 
         <nuxeo-dialog id="dialog" with-backdrop>
           <h2>[[i18n('comments.deletion.dialog.heading')]]</h2>
@@ -174,7 +176,7 @@ import '../nuxeo-button-styles.js';
               <div class="info">
                 <div id="body">
                   <div id="header" class="horizontal">
-                    <span class="author">[[comment.author]]</span>
+                    <span class="author">[[_authorDisplayName(comment.author, _authorEntity, _authorLoading)]]</span>
                     <span class="smaller opaque"
                       >[[_computeDateLabel(comment, comment.creationDate, comment.modificationDate, i18n)]]</span
                     >
@@ -364,7 +366,23 @@ import '../nuxeo-button-styles.js';
           reflectToAttribute: true,
           value: false,
         },
+
+        /** Resolved author user entity. */
+        _authorEntity: {
+          type: Object,
+          value: null,
+        },
+
+        /** Whether the author entity is being fetched. */
+        _authorLoading: {
+          type: Boolean,
+          value: false,
+        },
       };
+    }
+
+    static get observers() {
+      return ['_fetchAuthorEntity(comment.author)'];
     }
 
     /**
@@ -403,6 +421,28 @@ import '../nuxeo-button-styles.js';
     disconnectedCallback() {
       this.removeEventListener('number-of-replies', this._handleRepliesChange);
       super.disconnectedCallback();
+    }
+
+    async _fetchAuthorEntity(author) {
+      if (!author || typeof author !== 'string') return;
+      this._authorLoading = true;
+      try {
+        this.$.authorResource.path = `/user/${author}`;
+        this._authorEntity = await this.$.authorResource.get();
+      } catch (error) {
+        if (error.status && error.status !== 404) {
+          console.warn(`Unexpected error resolving comment author "${author}":`, error.message);
+        }
+        this._authorEntity = null;
+      }
+      this._authorLoading = false;
+    }
+
+    _authorDisplayName(author, entity, loading) {
+      if (entity && entity.properties && !loading) {
+        return formatUserDisplayName(entity);
+      }
+      return author || '';
     }
 
     _checkForEnter(e) {

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -444,7 +444,7 @@ import '../nuxeo-button-styles.js';
         this._authorEntity = entity;
       } catch (error) {
         if (requestId !== this._authorRequestId) return;
-        if (error.status && error.status !== 404) {
+        if (error.status !== 404) {
           console.warn(`Unexpected error resolving comment author "${author}":`, error);
         }
         this._authorEntity = null;

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -378,6 +378,12 @@ import '../nuxeo-button-styles.js';
           type: Boolean,
           value: false,
         },
+
+        /** Monotonic counter to discard stale author fetch responses. */
+        _authorRequestId: {
+          type: Number,
+          value: 0,
+        },
       };
     }
 
@@ -425,11 +431,15 @@ import '../nuxeo-button-styles.js';
 
     async _fetchAuthorEntity(author) {
       if (!author || typeof author !== 'string') return;
+      const requestId = ++this._authorRequestId;
       this._authorLoading = true;
       try {
-        this.$.authorResource.path = `/user/${author}`;
-        this._authorEntity = await this.$.authorResource.get();
+        this.$.authorResource.path = `/user/${encodeURIComponent(author)}`;
+        const entity = await this.$.authorResource.get();
+        if (requestId !== this._authorRequestId) return;
+        this._authorEntity = entity;
       } catch (error) {
+        if (requestId !== this._authorRequestId) return;
         if (error.status && error.status !== 404) {
           console.warn(`Unexpected error resolving comment author "${author}":`, error.message);
         }

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -439,7 +439,10 @@ import '../nuxeo-button-styles.js';
     }
 
     _authorDisplayName(author, entity, loading) {
-      if (entity && entity.properties && !loading) {
+      if (!entity || loading) {
+        return author || '';
+      }
+      if (entity.properties) {
         return formatUserDisplayName(entity);
       }
       return author || '';

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -430,7 +430,11 @@ import '../nuxeo-button-styles.js';
     }
 
     async _fetchAuthorEntity(author) {
-      if (!author || typeof author !== 'string') return;
+      if (!author || typeof author !== 'string') {
+        this._authorEntity = null;
+        this._authorLoading = false;
+        return;
+      }
       const requestId = ++this._authorRequestId;
       this._authorLoading = true;
       try {
@@ -450,6 +454,12 @@ import '../nuxeo-button-styles.js';
 
     _authorDisplayName(author, entity, loading) {
       if (!author) return '';
+      if (this._isAuthorEntity(author)) {
+        return formatUserDisplayName(author);
+      }
+      if (typeof author !== 'string') {
+        return this._authorStringFallback(author);
+      }
       if (!entity || loading) {
         return author;
       }

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -158,7 +158,7 @@ import '../nuxeo-button-styles.js';
               <div class="info">
                 <div id="body">
                   <div id="header" class="horizontal">
-                    <nuxeo-user-tag user="[[comment.author]]" disabled></nuxeo-user-tag>
+                    <nuxeo-user-tag class="author" user="[[comment.author]]" disabled></nuxeo-user-tag>
                     <span class="smaller opaque"
                       >[[_computeDateLabel(comment, comment.creationDate, comment.modificationDate, i18n)]]</span
                     >

--- a/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
+++ b/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
@@ -21,10 +21,12 @@ import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import '@polymer/iron-flex-layout/iron-flex-layout.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
+import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
 import '@polymer/polymer/lib/elements/dom-repeat.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import { FormatBehavior } from '../nuxeo-format-behavior.js';
+import '../widgets/nuxeo-user-tag.js';
 import './nuxeo-popup-confirm.js';
 import './nuxeo-popup-permission.js';
 
@@ -134,9 +136,10 @@ import './nuxeo-popup-permission.js';
                     </div>
                     <div class="flex-2" role="columnheader"><span>{{formatTimeFrame(ace)}}</span></div>
                     <div class="flex-2" role="columnheader">
-                      <span class$="[[entityClass(ace.creator)]]" title="[[entityTooltip(ace.creator)]]">
-                        [[entityDisplay(ace.creator)]]
-                      </span>
+                      <nuxeo-user-tag
+                        user="[[_resolvedCreator(ace.creator, _creatorEntities, _creatorsLoading)]]"
+                        disabled
+                      ></nuxeo-user-tag>
                     </div>
                     <dom-if if="[[showActions]]">
                       <template>
@@ -205,9 +208,10 @@ import './nuxeo-popup-permission.js';
                                     <span>{{formatTimeFrame(ace)}}</span>
                                   </div>
                                   <div class="flex-2" role="columnheader">
-                                    <span class$="[[entityClass(ace.creator)]]" title="[[entityTooltip(ace.creator)]]">
-                                      [[entityDisplay(ace.creator)]]
-                                    </span>
+                                    <nuxeo-user-tag
+                                      user="[[_resolvedCreator(ace.creator, _creatorEntities, _creatorsLoading)]]"
+                                      disabled
+                                    ></nuxeo-user-tag>
                                   </div>
                                 </div>
                               </div>
@@ -230,6 +234,7 @@ import './nuxeo-popup-permission.js';
           input="{{doc.uid}}"
         >
         </nuxeo-operation>
+        <nuxeo-resource id="userResource" path="/user"></nuxeo-resource>
       `;
     }
 
@@ -267,6 +272,16 @@ import './nuxeo-popup-permission.js';
         },
         captionText: {
           type: String,
+        },
+        _creatorEntities: {
+          type: Object,
+          value: () => {
+            return {};
+          },
+        },
+        _creatorsLoading: {
+          type: Boolean,
+          value: false,
         },
       };
     }
@@ -310,6 +325,36 @@ import './nuxeo-popup-permission.js';
       });
 
       this.aces = aces.sort(this._sortAces);
+      this._fetchCreators(this.aces);
+    }
+
+    async _fetchCreators(aces) {
+      if (!aces || !aces.length) return;
+      const creators = new Set();
+      aces.forEach((ace) => {
+        if (ace.creator && typeof ace.creator === 'string') {
+          creators.add(ace.creator);
+        }
+      });
+      if (!creators.size) return;
+      this._creatorsLoading = true;
+      const entities = {};
+      for (const creator of creators) {
+        try {
+          this.$.userResource.path = `/user/${creator}`;
+          const user = await this.$.userResource.get();
+          entities[creator] = user;
+        } catch (_) {
+          // keep the raw username if the fetch fails (e.g. system users)
+        }
+      }
+      this._creatorEntities = entities;
+      this._creatorsLoading = false;
+    }
+
+    _resolvedCreator(creator, entities, loading) {
+      if (loading) return null;
+      return (entities && entities[creator]) || creator;
     }
 
     _aclFilter(acl) {

--- a/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
+++ b/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
@@ -345,7 +345,7 @@ import './nuxeo-popup-permission.js';
           const user = await this.$.userResource.get();
           entities[creator] = user;
         } catch (_) {
-          void _; // system/deleted users — keep raw username as fallback
+          entities[creator] = creator; // fallback: keep raw username for system/deleted users
         }
       }
       this._creatorEntities = entities;

--- a/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
+++ b/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
@@ -335,14 +335,16 @@ import './nuxeo-popup-permission.js';
     }
 
     async _fetchCreators(aces = []) {
-      if (!aces.length) return;
       const creators = new Set();
       aces.forEach((ace) => {
         if (ace.creator && typeof ace.creator === 'string') {
           creators.add(ace.creator);
         }
       });
-      if (!creators.size) return;
+      if (!creators.size) {
+        this._creatorsLoading = false;
+        return;
+      }
       const requestId = ++this._creatorsRequestId;
       this._creatorsLoading = true;
       const entities = await fetchUserEntities(creators, this.$.userResource);

--- a/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
+++ b/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
@@ -329,7 +329,7 @@ import './nuxeo-popup-permission.js';
     }
 
     async _fetchCreators(aces) {
-      if (!aces || !aces.length) return;
+      if (!aces?.length) return;
       const creators = new Set();
       aces.forEach((ace) => {
         if (ace.creator && typeof ace.creator === 'string') {
@@ -345,7 +345,7 @@ import './nuxeo-popup-permission.js';
           const user = await this.$.userResource.get();
           entities[creator] = user;
         } catch (_) {
-          // keep the raw username if the fetch fails (e.g. system users)
+          void _; // system/deleted users — keep raw username as fallback
         }
       }
       this._creatorEntities = entities;
@@ -354,7 +354,7 @@ import './nuxeo-popup-permission.js';
 
     _resolvedCreator(creator, entities, loading) {
       if (loading) return null;
-      return (entities && entities[creator]) || creator;
+      return entities?.[creator] || creator;
     }
 
     _aclFilter(acl) {

--- a/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
+++ b/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
@@ -329,7 +329,7 @@ import './nuxeo-popup-permission.js';
     }
 
     async _fetchCreators(aces) {
-      if (!aces?.length) return;
+      if (!aces || !aces.length) return;
       const creators = new Set();
       aces.forEach((ace) => {
         if (ace.creator && typeof ace.creator === 'string') {
@@ -354,7 +354,7 @@ import './nuxeo-popup-permission.js';
 
     _resolvedCreator(creator, entities, loading) {
       if (loading) return null;
-      return entities?.[creator] || creator;
+      return (entities && entities[creator]) || creator;
     }
 
     _aclFilter(acl) {

--- a/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
+++ b/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
@@ -27,6 +27,7 @@ import '@polymer/polymer/lib/elements/dom-repeat.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import { FormatBehavior } from '../nuxeo-format-behavior.js';
 import '../widgets/nuxeo-user-tag.js';
+import { fetchUserEntities, resolveUser } from '../nuxeo-user-group-management/nuxeo-user-display.js';
 import './nuxeo-popup-confirm.js';
 import './nuxeo-popup-permission.js';
 
@@ -328,8 +329,8 @@ import './nuxeo-popup-permission.js';
       this._fetchCreators(this.aces);
     }
 
-    async _fetchCreators(aces) {
-      if (!aces || !aces.length) return;
+    async _fetchCreators(aces = []) {
+      if (!aces.length) return;
       const creators = new Set();
       aces.forEach((ace) => {
         if (ace.creator && typeof ace.creator === 'string') {
@@ -338,23 +339,13 @@ import './nuxeo-popup-permission.js';
       });
       if (!creators.size) return;
       this._creatorsLoading = true;
-      const entities = {};
-      for (const creator of creators) {
-        try {
-          this.$.userResource.path = `/user/${creator}`;
-          const user = await this.$.userResource.get();
-          entities[creator] = user;
-        } catch (_) {
-          entities[creator] = creator; // fallback: keep raw username for system/deleted users
-        }
-      }
-      this._creatorEntities = entities;
+      this._creatorEntities = await fetchUserEntities(creators, this.$.userResource);
       this._creatorsLoading = false;
     }
 
     _resolvedCreator(creator, entities, loading) {
       if (loading) return null;
-      return (entities && entities[creator]) || creator;
+      return resolveUser(creator, entities);
     }
 
     _aclFilter(acl) {

--- a/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
+++ b/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
@@ -284,6 +284,11 @@ import './nuxeo-popup-permission.js';
           type: Boolean,
           value: false,
         },
+
+        _creatorsRequestId: {
+          type: Number,
+          value: 0,
+        },
       };
     }
 
@@ -338,13 +343,16 @@ import './nuxeo-popup-permission.js';
         }
       });
       if (!creators.size) return;
+      const requestId = ++this._creatorsRequestId;
       this._creatorsLoading = true;
-      this._creatorEntities = await fetchUserEntities(creators, this.$.userResource);
+      const entities = await fetchUserEntities(creators, this.$.userResource);
+      if (requestId !== this._creatorsRequestId) return;
+      this._creatorEntities = entities;
       this._creatorsLoading = false;
     }
 
     _resolvedCreator(creator, entities, loading) {
-      if (loading) return null;
+      if (loading) return creator;
       return resolveUser(creator, entities);
     }
 

--- a/ui/nuxeo-user-group-management/nuxeo-group-management.js
+++ b/ui/nuxeo-user-group-management/nuxeo-group-management.js
@@ -17,6 +17,7 @@ limitations under the License.
 */
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { formatUserDisplayName, formatUserPrincipal } from './nuxeo-user-display.js';
 import '@polymer/iron-form/iron-form.js';
 import '@polymer/iron-icon/iron-icon.js';
 import '@nuxeo/nuxeo-elements/nuxeo-connection.js';
@@ -437,7 +438,7 @@ import '../nuxeo-sort-styles.js';
                             </template>
                           </dom-if>
                         </div>
-                        <div class="flex-4 preserve-white-space" role="columnheader">[[_userDisplayName(item)]]</div>
+                        <div class="flex-4 preserve-white-space" role="columnheader">[[_userPrincipal(item)]]</div>
                         <div class="flex-4" role="columnheader">
                           <div class="email-wrapper">
                             <span class="email-text">
@@ -648,7 +649,7 @@ import '../nuxeo-sort-styles.js';
 
         _removedMemberDisplayName: {
           type: String,
-          computed: '_userDisplayName(_removedMember)',
+          computed: '_userPrincipal(_removedMember)',
         },
 
         // Array of { path, direction } for multi-column sort on member users (nuxeo-data-table-column-sort contract)
@@ -703,11 +704,11 @@ import '../nuxeo-sort-styles.js';
     }
 
     _userDisplayName(user) {
-      if (!user) {
-        return '';
-      }
-      const props = user.properties || {};
-      return props.username || user.name || user.id || '';
+      return formatUserDisplayName(user);
+    }
+
+    _userPrincipal(user) {
+      return formatUserPrincipal(user);
     }
 
     _getEmail(properties) {
@@ -837,7 +838,7 @@ import '../nuxeo-sort-styles.js';
           this._fetchGroups();
         }
         this._removeRecent(this._removedMember.id);
-        this._toast(this.i18n('groupManagement.removedUserFromGroup', this._userDisplayName(this._removedMember)));
+        this._toast(this.i18n('groupManagement.removedUserFromGroup', this._userPrincipal(this._removedMember)));
       });
     }
 

--- a/ui/nuxeo-user-group-management/nuxeo-user-display.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-display.js
@@ -38,3 +38,32 @@ export function formatUserPrincipal(user) {
   const props = user.properties || {};
   return props.username || props['user:username'] || user.id || user.name || '';
 }
+
+/**
+ * Fetches user entities for a set of usernames using a nuxeo-resource element.
+ * Returns a map of username → user entity (or raw username string on failure).
+ */
+export async function fetchUserEntities(usernames, resourceElement) {
+  const entities = {};
+  for (const username of usernames) {
+    try {
+      resourceElement.path = `/user/${username}`;
+      const user = await resourceElement.get();
+      entities[username] = user;
+    } catch (error) {
+      if (error.status && error.status !== 404) {
+        console.warn(`Unexpected error resolving user "${username}":`, error.message);
+      }
+      entities[username] = username;
+    }
+  }
+  return entities;
+}
+
+/**
+ * Resolves a username to its entity from the entities map, falling back to raw username.
+ */
+export function resolveUser(username, entities) {
+  if (!entities) return username;
+  return entities[username] || username;
+}

--- a/ui/nuxeo-user-group-management/nuxeo-user-display.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-display.js
@@ -1,0 +1,40 @@
+/**
+@license
+©2023 Hyland Software, Inc. and its affiliates. All rights reserved. 
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Returns a human-readable display name for a user entity,
+ * preferring firstName + lastName, falling back to username.
+ */
+export function formatUserDisplayName(user) {
+  if (!user) return '';
+  const props = user.properties || {};
+  const first = props.firstName || props['user:firstName'] || '';
+  const last = props.lastName || props['user:lastName'] || '';
+  const full = [first, last].join(' ').trim();
+  return full || props.username || props['user:username'] || user.id || user.name || '';
+}
+
+/**
+ * Returns the principal identifier for a user entity (the login username),
+ * suitable for ACL queries and entity bindings.
+ */
+export function formatUserPrincipal(user) {
+  if (!user) return '';
+  const props = user.properties || {};
+  return props.username || props['user:username'] || user.id || user.name || '';
+}

--- a/ui/nuxeo-user-group-management/nuxeo-user-display.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-display.js
@@ -47,7 +47,7 @@ export async function fetchUserEntities(usernames, resourceElement) {
   const entities = {};
   for (const username of usernames) {
     try {
-      resourceElement.path = `/user/${username}`;
+      resourceElement.path = `/user/${encodeURIComponent(username)}`;
       const user = await resourceElement.get();
       entities[username] = user;
     } catch (error) {

--- a/ui/nuxeo-user-group-management/nuxeo-user-display.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-display.js
@@ -40,10 +40,17 @@ export function formatUserPrincipal(user) {
 }
 
 /**
- * Fetches user entities for a set of usernames using a nuxeo-resource element.
+ * Tracks the in-flight fetch chain for each shared resource element so that
+ * concurrent callers are serialized rather than racing on the same element.
+ */
+const resourceQueues = new WeakMap();
+
+/**
+ * Resolves a set of usernames to user entities by mutating and querying the
+ * shared nuxeo-resource element sequentially.
  * Returns a map of username → user entity (or raw username string on failure).
  */
-export async function fetchUserEntities(usernames, resourceElement) {
+async function resolveUserEntities(usernames, resourceElement) {
   const entities = {};
   for (const username of usernames) {
     try {
@@ -58,6 +65,22 @@ export async function fetchUserEntities(usernames, resourceElement) {
     }
   }
   return entities;
+}
+
+/**
+ * Fetches user entities for a set of usernames using a nuxeo-resource element.
+ * Returns a map of username → user entity (or raw username string on failure).
+ *
+ * Because `nuxeo-resource` mutates a shared `path` and aborts in-flight
+ * requests when a new one starts, concurrent callers using the same resource
+ * element would abort each other's requests. Invocations are therefore
+ * serialized per resource element via a promise chain.
+ */
+export function fetchUserEntities(usernames, resourceElement) {
+  const previous = resourceQueues.get(resourceElement) || Promise.resolve();
+  const run = previous.catch(() => {}).then(() => resolveUserEntities(usernames, resourceElement));
+  resourceQueues.set(resourceElement, run);
+  return run;
 }
 
 /**

--- a/ui/nuxeo-user-group-management/nuxeo-user-display.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-display.js
@@ -58,7 +58,7 @@ async function resolveUserEntities(usernames, resourceElement) {
       const user = await resourceElement.get();
       entities[username] = user;
     } catch (error) {
-      if (error.status && error.status !== 404) {
+      if (error.status !== 404) {
         console.warn(`Unexpected error resolving user "${username}":`, error);
       }
       entities[username] = username;

--- a/ui/nuxeo-user-group-management/nuxeo-user-display.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-display.js
@@ -52,7 +52,7 @@ export async function fetchUserEntities(usernames, resourceElement) {
       entities[username] = user;
     } catch (error) {
       if (error.status && error.status !== 404) {
-        console.warn(`Unexpected error resolving user "${username}":`, error.message);
+        console.warn(`Unexpected error resolving user "${username}":`, error);
       }
       entities[username] = username;
     }

--- a/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
@@ -28,7 +28,6 @@ import '@polymer/polymer/lib/elements/dom-repeat.js';
 import moment from '@nuxeo/moment';
 import '../nuxeo-pagination-controls.js';
 import '../widgets/nuxeo-dialog.js';
-import '../widgets/nuxeo-tag.js';
 import '../widgets/nuxeo-user-tag.js';
 import { fetchUserEntities, resolveUser } from './nuxeo-user-display.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';

--- a/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
@@ -430,7 +430,7 @@ import '../nuxeo-button-styles.js';
           const user = await this.$.userResource.get();
           entities[creator] = user;
         } catch (_) {
-          // keep the raw username if the fetch fails (e.g. system users)
+          void _; // system/deleted users — keep raw username as fallback
         }
       }
       this._creatorEntities = entities;
@@ -439,7 +439,7 @@ import '../nuxeo-button-styles.js';
 
     _resolvedCreator(creator, entities, loading) {
       if (loading) return null;
-      return (entities && entities[creator]) || creator;
+      return entities?.[creator] || creator;
     }
 
     _aceBelongsToEntity(ace) {

--- a/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
@@ -20,6 +20,7 @@ import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 import '@nuxeo/nuxeo-elements/nuxeo-operation.js';
+import '@nuxeo/nuxeo-elements/nuxeo-resource.js';
 import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/polymer/lib/elements/dom-if.js';
@@ -28,6 +29,7 @@ import moment from '@nuxeo/moment';
 import '../nuxeo-pagination-controls.js';
 import '../widgets/nuxeo-dialog.js';
 import '../widgets/nuxeo-tag.js';
+import '../widgets/nuxeo-user-tag.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import '../nuxeo-button-styles.js';
 
@@ -146,6 +148,7 @@ import '../nuxeo-button-styles.js';
 
         <nuxeo-operation id="permissions" op="Repository.Query" enrichers="acls"></nuxeo-operation>
         <nuxeo-operation id="rmPermission" op="Document.RemovePermission"></nuxeo-operation>
+        <nuxeo-resource id="userResource" path="/user"></nuxeo-resource>
 
         <dom-if if="[[label]]">
           <template>
@@ -187,7 +190,10 @@ import '../nuxeo-button-styles.js';
                             <div class="flex-2" role="columnheader">
                               <dom-if if="[[ace.creator]]">
                                 <template>
-                                  <nuxeo-tag icon="nuxeo:group">[[ace.creator]]</nuxeo-tag>
+                                  <nuxeo-user-tag
+                                    user="[[_resolvedCreator(ace.creator, _creatorEntities, _creatorsLoading)]]"
+                                    disabled
+                                  ></nuxeo-user-tag>
                                 </template>
                               </dom-if>
                             </div>
@@ -297,6 +303,16 @@ import '../nuxeo-button-styles.js';
         captionText: {
           type: String,
         },
+        _creatorEntities: {
+          type: Object,
+          value: () => {
+            return {};
+          },
+        },
+        _creatorsLoading: {
+          type: Boolean,
+          value: false,
+        },
       };
     }
 
@@ -393,6 +409,37 @@ import '../nuxeo-button-styles.js';
       });
       this.documents = entries;
       this.empty = this.documents.length === 0;
+      this._fetchCreators(entries);
+    }
+
+    async _fetchCreators(entries) {
+      const creators = new Set();
+      entries.forEach((entry) => {
+        (entry.aces || []).forEach((ace) => {
+          if (ace.creator && typeof ace.creator === 'string') {
+            creators.add(ace.creator);
+          }
+        });
+      });
+      if (!creators.size) return;
+      this._creatorsLoading = true;
+      const entities = {};
+      for (const creator of creators) {
+        try {
+          this.$.userResource.path = `/user/${creator}`;
+          const user = await this.$.userResource.get();
+          entities[creator] = user;
+        } catch (_) {
+          // keep the raw username if the fetch fails (e.g. system users)
+        }
+      }
+      this._creatorEntities = entities;
+      this._creatorsLoading = false;
+    }
+
+    _resolvedCreator(creator, entities, loading) {
+      if (loading) return null;
+      return (entities && entities[creator]) || creator;
     }
 
     _aceBelongsToEntity(ace) {

--- a/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
@@ -417,7 +417,7 @@ import '../nuxeo-button-styles.js';
       this._fetchCreators(entries);
     }
 
-    async _fetchCreators(entries) {
+    async _fetchCreators(entries = []) {
       const creators = new Set();
       entries.forEach((entry) => {
         (entry.aces || []).forEach((ace) => {
@@ -426,7 +426,10 @@ import '../nuxeo-button-styles.js';
           }
         });
       });
-      if (!creators.size) return;
+      if (!creators.size) {
+        this._creatorsLoading = false;
+        return;
+      }
       const requestId = ++this._creatorsRequestId;
       this._creatorsLoading = true;
       const entities = await fetchUserEntities(creators, this.$.userResource);

--- a/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
@@ -430,7 +430,7 @@ import '../nuxeo-button-styles.js';
           const user = await this.$.userResource.get();
           entities[creator] = user;
         } catch (_) {
-          void _; // system/deleted users — keep raw username as fallback
+          entities[creator] = creator; // fallback: keep raw username for system/deleted users
         }
       }
       this._creatorEntities = entities;

--- a/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
@@ -30,6 +30,7 @@ import '../nuxeo-pagination-controls.js';
 import '../widgets/nuxeo-dialog.js';
 import '../widgets/nuxeo-tag.js';
 import '../widgets/nuxeo-user-tag.js';
+import { fetchUserEntities, resolveUser } from './nuxeo-user-display.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import '../nuxeo-button-styles.js';
 
@@ -423,23 +424,13 @@ import '../nuxeo-button-styles.js';
       });
       if (!creators.size) return;
       this._creatorsLoading = true;
-      const entities = {};
-      for (const creator of creators) {
-        try {
-          this.$.userResource.path = `/user/${creator}`;
-          const user = await this.$.userResource.get();
-          entities[creator] = user;
-        } catch (_) {
-          entities[creator] = creator; // fallback: keep raw username for system/deleted users
-        }
-      }
-      this._creatorEntities = entities;
+      this._creatorEntities = await fetchUserEntities(creators, this.$.userResource);
       this._creatorsLoading = false;
     }
 
     _resolvedCreator(creator, entities, loading) {
       if (loading) return null;
-      return (entities && entities[creator]) || creator;
+      return resolveUser(creator, entities);
     }
 
     _aceBelongsToEntity(ace) {

--- a/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
@@ -314,6 +314,11 @@ import '../nuxeo-button-styles.js';
           type: Boolean,
           value: false,
         },
+
+        _creatorsRequestId: {
+          type: Number,
+          value: 0,
+        },
       };
     }
 
@@ -423,13 +428,16 @@ import '../nuxeo-button-styles.js';
         });
       });
       if (!creators.size) return;
+      const requestId = ++this._creatorsRequestId;
       this._creatorsLoading = true;
-      this._creatorEntities = await fetchUserEntities(creators, this.$.userResource);
+      const entities = await fetchUserEntities(creators, this.$.userResource);
+      if (requestId !== this._creatorsRequestId) return;
+      this._creatorEntities = entities;
       this._creatorsLoading = false;
     }
 
     _resolvedCreator(creator, entities, loading) {
-      if (loading) return null;
+      if (loading) return creator;
       return resolveUser(creator, entities);
     }
 

--- a/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js
@@ -439,7 +439,7 @@ import '../nuxeo-button-styles.js';
 
     _resolvedCreator(creator, entities, loading) {
       if (loading) return null;
-      return entities?.[creator] || creator;
+      return (entities && entities[creator]) || creator;
     }
 
     _aceBelongsToEntity(ace) {

--- a/ui/nuxeo-user-group-management/nuxeo-user-management.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-management.js
@@ -17,6 +17,7 @@ limitations under the License.
 */
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { formatUserDisplayName, formatUserPrincipal } from './nuxeo-user-display.js';
 import '@polymer/iron-form/iron-form.js';
 import '@polymer/iron-icon/iron-icon.js';
 import config from '@nuxeo/nuxeo-elements/config.js';
@@ -219,7 +220,7 @@ import '../nuxeo-button-styles.js';
           <div class="horizontal layout center header">
             <iron-icon icon="nuxeo:user" class="user-icon"></iron-icon>
             <div class="layout vertical">
-              <div class="user heading" name="userHeading">[[_userDisplayName(user)]]</div>
+              <div class="user heading" name="userHeading">[[_userPrincipal(user)]]</div>
               <div>[[user.properties.firstName]] [[user.properties.lastName]]</div>
             </div>
 
@@ -365,7 +366,11 @@ import '../nuxeo-button-styles.js';
 
         <!-- local permissions -->
         <nuxeo-card heading="[[i18n('userManagement.localPermissions.heading')]]">
-          <nuxeo-user-group-permissions-table entity="[[_userDisplayName(user)]]" readonly="[[readonly]]">
+          <nuxeo-user-group-permissions-table
+            entity="[[_userPrincipal(user)]]"
+            entity-label="[[_userDisplayName(user)]]"
+            readonly="[[readonly]]"
+          >
           </nuxeo-user-group-permissions-table>
         </nuxeo-card>
 
@@ -507,7 +512,7 @@ import '../nuxeo-button-styles.js';
 
         _displayName: {
           type: String,
-          computed: '_userDisplayName(user)',
+          computed: '_userPrincipal(user)',
         },
       };
     }
@@ -539,11 +544,11 @@ import '../nuxeo-button-styles.js';
     }
 
     _userDisplayName(user) {
-      if (!user) {
-        return '';
-      }
-      const props = user.properties || {};
-      return props.username || user.name || '';
+      return formatUserDisplayName(user);
+    }
+
+    _userPrincipal(user) {
+      return formatUserPrincipal(user);
     }
 
     _fetch() {
@@ -627,7 +632,7 @@ import '../nuxeo-button-styles.js';
         this.$.request.path = `user/${this.user.id}/group/${group.id || group.name}`;
         this.$.request.post().then((response) => {
           this.user = response;
-          this._toast(this.i18n('userManagement.addedUserToGroup', this._userDisplayName(this.user), group.name));
+          this._toast(this.i18n('userManagement.addedUserToGroup', this._userPrincipal(this.user), group.name));
         });
       }
       this.selectedGroup = null;
@@ -639,7 +644,7 @@ import '../nuxeo-button-styles.js';
       return this.$.request.remove().then(() => {
         this._removeRecent(group.name);
         this._removeFromGroup(group.name);
-        this._toast(this.i18n('userManagement.removedUserFromGroup', this._userDisplayName(this.user), group.name));
+        this._toast(this.i18n('userManagement.removedUserFromGroup', this._userPrincipal(this.user), group.name));
       });
     }
 

--- a/ui/nuxeo-user-group-management/nuxeo-user-profile.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-profile.js
@@ -312,11 +312,7 @@ import '../nuxeo-button-styles.js';
     }
 
     _userDisplayName(user) {
-      if (!user) {
-        return '';
-      }
-      const props = user.properties || {};
-      return props.username || user.name || '';
+      return formatUserPrincipal(user);
     }
 
     _userFullName(user) {

--- a/ui/nuxeo-user-group-management/nuxeo-user-profile.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-profile.js
@@ -18,6 +18,7 @@ limitations under the License.
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { formatUserDisplayName, formatUserPrincipal } from './nuxeo-user-display.js';
 import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
 import '@polymer/iron-flex-layout/iron-flex-layout.js';
 import '@polymer/iron-form/iron-form.js';
@@ -228,7 +229,8 @@ import '../nuxeo-button-styles.js';
         <!-- local permissions -->
         <nuxeo-card heading="[[i18n('userManagement.localPermissions.heading')]]">
           <nuxeo-user-group-permissions-table
-            entity="[[_userDisplayName(user)]]"
+            entity="[[_userPrincipal(user)]]"
+            entity-label="[[_userFullName(user)]]"
             caption-text="[[i18n('userManagement.localPermissions.heading')]]"
             readonly
           ></nuxeo-user-group-permissions-table>
@@ -315,6 +317,14 @@ import '../nuxeo-button-styles.js';
       }
       const props = user.properties || {};
       return props.username || user.name || '';
+    }
+
+    _userFullName(user) {
+      return formatUserDisplayName(user);
+    }
+
+    _userPrincipal(user) {
+      return formatUserPrincipal(user);
     }
 
     _openChangePasswordDialog() {

--- a/ui/test/nuxeo-document-acl-table.test.js
+++ b/ui/test/nuxeo-document-acl-table.test.js
@@ -215,5 +215,29 @@ suite('nuxeo-document-acl-table extras', () => {
       expect(el._creatorEntities).to.have.property('unknown', 'unknown');
       el.$.userResource.get.restore();
     });
+
+    test('should warn on unexpected non-404 errors', async () => {
+      const error = new Error('internal error');
+      error.status = 500;
+      sinon.stub(el.$.userResource, 'get').rejects(error);
+      const warnSpy = sinon.spy(console, 'warn');
+      await el._fetchCreators([{ creator: 'baduser', username: 'Admin', permission: 'Read' }]);
+      expect(el._creatorEntities).to.have.property('baduser', 'baduser');
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
+      el.$.userResource.get.restore();
+    });
+
+    test('should not warn on 404 errors', async () => {
+      const error = new Error('not found');
+      error.status = 404;
+      sinon.stub(el.$.userResource, 'get').rejects(error);
+      const warnSpy = sinon.spy(console, 'warn');
+      await el._fetchCreators([{ creator: 'deleted', username: 'Admin', permission: 'Read' }]);
+      expect(el._creatorEntities).to.have.property('deleted', 'deleted');
+      expect(warnSpy).to.not.have.been.called;
+      warnSpy.restore();
+      el.$.userResource.get.restore();
+    });
   });
 });

--- a/ui/test/nuxeo-document-acl-table.test.js
+++ b/ui/test/nuxeo-document-acl-table.test.js
@@ -223,8 +223,12 @@ suite('nuxeo-document-acl-table extras', () => {
 
     test('should handle fetch failure gracefully', async () => {
       sinon.stub(el.$.userResource, 'get').rejects(new Error('not found'));
+      const warnSpy = sinon.stub(console, 'warn');
       await el._fetchCreators([{ creator: 'unknown', username: 'Admin', permission: 'Read' }]);
       expect(el._creatorEntities).to.have.property('unknown', 'unknown');
+      // A statusless (e.g. network/transport) error is unexpected and should be logged.
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
       el.$.userResource.get.restore();
     });
 

--- a/ui/test/nuxeo-document-acl-table.test.js
+++ b/ui/test/nuxeo-document-acl-table.test.js
@@ -190,10 +190,21 @@ suite('nuxeo-document-acl-table extras', () => {
   });
 
   suite('_fetchCreators', () => {
-    test('should skip when aces is empty', async () => {
+    test('should skip and reset loading when aces is empty', async () => {
       const getSpy = sinon.spy(el.$.userResource, 'get');
+      el._creatorsLoading = true;
       await el._fetchCreators([]);
       expect(getSpy).to.not.have.been.called;
+      expect(el._creatorsLoading).to.be.false;
+      getSpy.restore();
+    });
+
+    test('should skip and reset loading when no creators are present', async () => {
+      const getSpy = sinon.spy(el.$.userResource, 'get');
+      el._creatorsLoading = true;
+      await el._fetchCreators([{ username: 'Admin', permission: 'Read' }]);
+      expect(getSpy).to.not.have.been.called;
+      expect(el._creatorsLoading).to.be.false;
       getSpy.restore();
     });
 

--- a/ui/test/nuxeo-document-acl-table.test.js
+++ b/ui/test/nuxeo-document-acl-table.test.js
@@ -173,4 +173,47 @@ suite('nuxeo-document-acl-table extras', () => {
       expect(el.entityTooltip(entity)).to.equal('admins');
     });
   });
+
+  suite('_resolvedCreator', () => {
+    test('returns entity when present in map', () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      expect(el._resolvedCreator('jdoe', { jdoe: entity })).to.equal(entity);
+    });
+
+    test('falls back to raw creator string when not resolved', () => {
+      expect(el._resolvedCreator('system', {})).to.equal('system');
+    });
+
+    test('falls back to raw creator string when entities is null', () => {
+      expect(el._resolvedCreator('system', null)).to.equal('system');
+    });
+  });
+
+  suite('_fetchCreators', () => {
+    test('should skip when aces is empty', async () => {
+      const getSpy = sinon.spy(el.$.userResource, 'get');
+      await el._fetchCreators([]);
+      expect(getSpy).to.not.have.been.called;
+      getSpy.restore();
+    });
+
+    test('should fetch user entity for each unique creator', async () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      sinon.stub(el.$.userResource, 'get').resolves(entity);
+      await el._fetchCreators([
+        { creator: 'jdoe', username: 'Admin', permission: 'Everything' },
+        { creator: 'jdoe', username: 'user1', permission: 'Read' },
+      ]);
+      expect(el.$.userResource.get).to.have.been.calledOnce;
+      expect(el._creatorEntities).to.have.property('jdoe', entity);
+      el.$.userResource.get.restore();
+    });
+
+    test('should handle fetch failure gracefully', async () => {
+      sinon.stub(el.$.userResource, 'get').rejects(new Error('not found'));
+      await el._fetchCreators([{ creator: 'unknown', username: 'Admin', permission: 'Read' }]);
+      expect(el._creatorEntities).to.not.have.property('unknown');
+      el.$.userResource.get.restore();
+    });
+  });
 });

--- a/ui/test/nuxeo-document-acl-table.test.js
+++ b/ui/test/nuxeo-document-acl-table.test.js
@@ -220,7 +220,7 @@ suite('nuxeo-document-acl-table extras', () => {
       const error = new Error('internal error');
       error.status = 500;
       sinon.stub(el.$.userResource, 'get').rejects(error);
-      const warnSpy = sinon.spy(console, 'warn');
+      const warnSpy = sinon.stub(console, 'warn');
       await el._fetchCreators([{ creator: 'baduser', username: 'Admin', permission: 'Read' }]);
       expect(el._creatorEntities).to.have.property('baduser', 'baduser');
       expect(warnSpy).to.have.been.calledOnce;
@@ -232,7 +232,7 @@ suite('nuxeo-document-acl-table extras', () => {
       const error = new Error('not found');
       error.status = 404;
       sinon.stub(el.$.userResource, 'get').rejects(error);
-      const warnSpy = sinon.spy(console, 'warn');
+      const warnSpy = sinon.stub(console, 'warn');
       await el._fetchCreators([{ creator: 'deleted', username: 'Admin', permission: 'Read' }]);
       expect(el._creatorEntities).to.have.property('deleted', 'deleted');
       expect(warnSpy).to.not.have.been.called;

--- a/ui/test/nuxeo-document-acl-table.test.js
+++ b/ui/test/nuxeo-document-acl-table.test.js
@@ -212,7 +212,7 @@ suite('nuxeo-document-acl-table extras', () => {
     test('should handle fetch failure gracefully', async () => {
       sinon.stub(el.$.userResource, 'get').rejects(new Error('not found'));
       await el._fetchCreators([{ creator: 'unknown', username: 'Admin', permission: 'Read' }]);
-      expect(el._creatorEntities).to.not.have.property('unknown');
+      expect(el._creatorEntities).to.have.property('unknown', 'unknown');
       el.$.userResource.get.restore();
     });
   });

--- a/ui/test/nuxeo-document-acl-table.test.js
+++ b/ui/test/nuxeo-document-acl-table.test.js
@@ -17,6 +17,7 @@ limitations under the License.
 */
 import { fixture, html } from '@nuxeo/testing-helpers';
 import '../nuxeo-document-permissions/nuxeo-document-acl-table.js';
+import { fetchUserEntities } from '../nuxeo-user-group-management/nuxeo-user-display.js';
 
 suite('nuxeo-document-acl-table', () => {
   test('should return the element name', () => {
@@ -249,6 +250,32 @@ suite('nuxeo-document-acl-table extras', () => {
       expect(warnSpy).to.not.have.been.called;
       warnSpy.restore();
       el.$.userResource.get.restore();
+    });
+  });
+
+  suite('fetchUserEntities serialization', () => {
+    test('serializes concurrent calls sharing the same resource element', async () => {
+      const order = [];
+      const fakeResource = {
+        path: '',
+        get() {
+          const requestedPath = this.path;
+          order.push(requestedPath);
+          const username = requestedPath.split('/').pop();
+          return Promise.resolve({ 'entity-type': 'user', properties: { username } });
+        },
+      };
+
+      // Fire two overlapping calls on the SAME resource element.
+      const callA = fetchUserEntities(['a1', 'a2'], fakeResource);
+      const callB = fetchUserEntities(['b1'], fakeResource);
+      const [resultA, resultB] = await Promise.all([callA, callB]);
+
+      // With serialization, all of call A's requests complete before call B's,
+      // so the order is deterministic (never interleaved).
+      expect(order).to.deep.equal(['/user/a1', '/user/a2', '/user/b1']);
+      expect(resultA).to.have.all.keys('a1', 'a2');
+      expect(resultB).to.have.all.keys('b1');
     });
   });
 });

--- a/ui/test/nuxeo-document-comment.test.js
+++ b/ui/test/nuxeo-document-comment.test.js
@@ -1201,16 +1201,20 @@ suite('nuxeo-document-comment extras', () => {
         el.$.authorResource.get.restore();
       });
 
-      test('should do nothing when author is empty', async () => {
-        el._authorEntity = 'unchanged';
+      test('should reset state when author is empty', async () => {
+        el._authorEntity = 'stale';
+        el._authorLoading = true;
         await el._fetchAuthorEntity('');
-        expect(el._authorEntity).to.equal('unchanged');
+        expect(el._authorEntity).to.be.null;
+        expect(el._authorLoading).to.be.false;
       });
 
-      test('should do nothing when author is not a string', async () => {
-        el._authorEntity = 'unchanged';
+      test('should reset state when author is not a string', async () => {
+        el._authorEntity = 'stale';
+        el._authorLoading = true;
         await el._fetchAuthorEntity(null);
-        expect(el._authorEntity).to.equal('unchanged');
+        expect(el._authorEntity).to.be.null;
+        expect(el._authorLoading).to.be.false;
       });
     });
 
@@ -1244,6 +1248,20 @@ suite('nuxeo-document-comment extras', () => {
 
       test('should return empty string when author is empty', () => {
         expect(el._authorDisplayName('', null, false)).to.equal('');
+      });
+
+      test('should format entity author directly when comment.author is a user entity', () => {
+        const authorEntity = {
+          'entity-type': 'user',
+          id: 'jdoe',
+          properties: { firstName: 'John', lastName: 'Doe', username: 'jdoe' },
+        };
+        expect(el._authorDisplayName(authorEntity, null, false)).to.equal('John Doe');
+      });
+
+      test('should return id for non-entity object author', () => {
+        const obj = { id: 'some-id' };
+        expect(el._authorDisplayName(obj, null, false)).to.equal('some-id');
       });
     });
   });

--- a/ui/test/nuxeo-document-comment.test.js
+++ b/ui/test/nuxeo-document-comment.test.js
@@ -1115,7 +1115,7 @@ suite('nuxeo-document-comment extras', () => {
         const error = new Error('not found');
         error.status = 404;
         sinon.stub(el.$.authorResource, 'get').rejects(error);
-        const warnSpy = sinon.spy(console, 'warn');
+        const warnSpy = sinon.stub(console, 'warn');
         await el._fetchAuthorEntity('deleted');
         expect(el._authorEntity).to.be.null;
         expect(el._authorLoading).to.be.false;
@@ -1128,7 +1128,7 @@ suite('nuxeo-document-comment extras', () => {
         const error = new Error('server error');
         error.status = 500;
         sinon.stub(el.$.authorResource, 'get').rejects(error);
-        const warnSpy = sinon.spy(console, 'warn');
+        const warnSpy = sinon.stub(console, 'warn');
         await el._fetchAuthorEntity('baduser');
         expect(el._authorEntity).to.be.null;
         expect(el._authorLoading).to.be.false;

--- a/ui/test/nuxeo-document-comment.test.js
+++ b/ui/test/nuxeo-document-comment.test.js
@@ -1095,5 +1095,92 @@ suite('nuxeo-document-comment extras', () => {
         el._handleRepliesChange(evt);
       });
     });
+
+    suite('_fetchAuthorEntity', () => {
+      test('should fetch and set author entity on success', async () => {
+        const userEntity = {
+          'entity-type': 'user',
+          id: 'jdoe',
+          properties: { firstName: 'John', lastName: 'Doe', username: 'jdoe' },
+        };
+        sinon.stub(el.$.authorResource, 'get').resolves(userEntity);
+        await el._fetchAuthorEntity('jdoe');
+        expect(el._authorEntity).to.deep.equal(userEntity);
+        expect(el._authorLoading).to.be.false;
+        expect(el.$.authorResource.path).to.equal('/user/jdoe');
+        el.$.authorResource.get.restore();
+      });
+
+      test('should set entity to null on 404 error', async () => {
+        const error = new Error('not found');
+        error.status = 404;
+        sinon.stub(el.$.authorResource, 'get').rejects(error);
+        const warnSpy = sinon.spy(console, 'warn');
+        await el._fetchAuthorEntity('deleted');
+        expect(el._authorEntity).to.be.null;
+        expect(el._authorLoading).to.be.false;
+        expect(warnSpy).to.not.have.been.called;
+        warnSpy.restore();
+        el.$.authorResource.get.restore();
+      });
+
+      test('should warn on unexpected non-404 errors', async () => {
+        const error = new Error('server error');
+        error.status = 500;
+        sinon.stub(el.$.authorResource, 'get').rejects(error);
+        const warnSpy = sinon.spy(console, 'warn');
+        await el._fetchAuthorEntity('baduser');
+        expect(el._authorEntity).to.be.null;
+        expect(el._authorLoading).to.be.false;
+        expect(warnSpy).to.have.been.calledOnce;
+        warnSpy.restore();
+        el.$.authorResource.get.restore();
+      });
+
+      test('should do nothing when author is empty', async () => {
+        el._authorEntity = 'unchanged';
+        await el._fetchAuthorEntity('');
+        expect(el._authorEntity).to.equal('unchanged');
+      });
+
+      test('should do nothing when author is not a string', async () => {
+        el._authorEntity = 'unchanged';
+        await el._fetchAuthorEntity(null);
+        expect(el._authorEntity).to.equal('unchanged');
+      });
+    });
+
+    suite('_authorDisplayName', () => {
+      test('should return full name from entity', () => {
+        const entity = {
+          'entity-type': 'user',
+          id: 'jdoe',
+          properties: { firstName: 'John', lastName: 'Doe', username: 'jdoe' },
+        };
+        expect(el._authorDisplayName('jdoe', entity, false)).to.equal('John Doe');
+      });
+
+      test('should return author when entity is null', () => {
+        expect(el._authorDisplayName('jdoe', null, false)).to.equal('jdoe');
+      });
+
+      test('should return author when loading', () => {
+        const entity = {
+          'entity-type': 'user',
+          id: 'jdoe',
+          properties: { firstName: 'John', lastName: 'Doe', username: 'jdoe' },
+        };
+        expect(el._authorDisplayName('jdoe', entity, true)).to.equal('jdoe');
+      });
+
+      test('should return author when entity has no properties', () => {
+        const entity = { id: 'jdoe' };
+        expect(el._authorDisplayName('jdoe', entity, false)).to.equal('jdoe');
+      });
+
+      test('should return empty string when author is empty', () => {
+        expect(el._authorDisplayName('', null, false)).to.equal('');
+      });
+    });
   });
 });

--- a/ui/test/nuxeo-group-management.test.js
+++ b/ui/test/nuxeo-group-management.test.js
@@ -479,17 +479,17 @@ suite('nuxeo-group-management', () => {
       expect(el._userDisplayName(undefined)).to.equal('');
     });
 
-    test('prefers properties.username over user.name to avoid showing UUID', () => {
+    test('returns firstName + lastName when both are present', () => {
       expect(
         el._userDisplayName({
           id: 'internal-uid',
           name: 'some-uuid',
           properties: { username: 'login', firstName: 'A', lastName: 'B' },
         }),
-      ).to.equal('login');
+      ).to.equal('A B');
     });
 
-    test('falls back to properties.username when name is absent', () => {
+    test('falls back to properties.username when name fields are absent', () => {
       expect(
         el._userDisplayName({
           id: 'uid-1',
@@ -498,22 +498,79 @@ suite('nuxeo-group-management', () => {
       ).to.equal('jdoe');
     });
 
-    test('falls back to id when name and username are absent', () => {
+    test('falls back to user.id when username is also absent', () => {
       expect(
         el._userDisplayName({
-          id: 'only-id',
+          id: 'jdoe',
+          name: 'fallback-name',
           properties: {},
         }),
-      ).to.equal('only-id');
+      ).to.equal('jdoe');
     });
 
-    test('returns empty string when user.properties is absent', () => {
-      expect(el._userDisplayName({ id: 'some-uuid' })).to.equal('some-uuid');
+    test('falls back to user.name when username and id are both absent', () => {
+      expect(
+        el._userDisplayName({
+          name: 'fallback-name',
+          properties: {},
+        }),
+      ).to.equal('fallback-name');
+    });
+
+    test('returns empty string when user has no displayable fields', () => {
+      expect(el._userDisplayName({ properties: {} })).to.equal('');
+    });
+  });
+
+  suite('_userPrincipal', () => {
+    test('returns empty string when user is null or undefined', () => {
+      expect(el._userPrincipal(null)).to.equal('');
+      expect(el._userPrincipal(undefined)).to.equal('');
+    });
+
+    test('returns username even when firstName and lastName are present', () => {
+      expect(
+        el._userPrincipal({
+          id: 'internal-uid',
+          name: 'some-uuid',
+          properties: { username: 'login', firstName: 'A', lastName: 'B' },
+        }),
+      ).to.equal('login');
+    });
+
+    test('falls back to user.id when properties.username is absent', () => {
+      expect(
+        el._userPrincipal({
+          id: 'jdoe',
+          name: 'some-name',
+          properties: {},
+        }),
+      ).to.equal('jdoe');
+    });
+
+    test('falls back to user.name when properties.username and user.id are absent', () => {
+      expect(
+        el._userPrincipal({
+          name: 'jdoe',
+          properties: {},
+        }),
+      ).to.equal('jdoe');
     });
   });
 
   suite('_removedMemberDisplayName computed property', () => {
-    test('reflects _userDisplayName of _removedMember using properties.username', async () => {
+    test('shows username even when firstName + lastName are available', async () => {
+      el._removedMember = {
+        id: 'some-uuid',
+        name: 'some-uuid',
+        'entity-type': 'user',
+        properties: { username: 'jdoe', firstName: 'Jane', lastName: 'Doe' },
+      };
+      await flush();
+      expect(el._removedMemberDisplayName).to.equal('jdoe');
+    });
+
+    test('falls back to username when name fields are absent', async () => {
       el._removedMember = {
         id: 'some-uuid',
         name: 'some-uuid',
@@ -524,8 +581,14 @@ suite('nuxeo-group-management', () => {
       expect(el._removedMemberDisplayName).to.equal('jdoe');
     });
 
-    test('falls back to user.name when properties.username is absent', async () => {
-      el._removedMember = { id: 'some-uuid', name: 'jdoe', 'entity-type': 'user', properties: {} };
+    test('falls back to user.id when properties.username is absent', async () => {
+      el._removedMember = { id: 'jdoe', name: 'some-name', 'entity-type': 'user', properties: {} };
+      await flush();
+      expect(el._removedMemberDisplayName).to.equal('jdoe');
+    });
+
+    test('falls back to user.name when properties.username and user.id are absent', async () => {
+      el._removedMember = { name: 'jdoe', 'entity-type': 'user', properties: {} };
       await flush();
       expect(el._removedMemberDisplayName).to.equal('jdoe');
     });

--- a/ui/test/nuxeo-user-group-permissions-table.test.js
+++ b/ui/test/nuxeo-user-group-permissions-table.test.js
@@ -353,10 +353,21 @@ suite('nuxeo-user-group-permissions-table', () => {
   });
 
   suite('_fetchCreators', () => {
-    test('should skip when entries have no aces with creators', async () => {
+    test('should skip and reset loading when entries have no aces with creators', async () => {
       const getSpy = sinon.spy(el.$.userResource, 'get');
+      el._creatorsLoading = true;
       await el._fetchCreators([{ aces: [] }]);
       expect(getSpy).to.not.have.been.called;
+      expect(el._creatorsLoading).to.be.false;
+      getSpy.restore();
+    });
+
+    test('should skip and reset loading when called with no entries', async () => {
+      const getSpy = sinon.spy(el.$.userResource, 'get');
+      el._creatorsLoading = true;
+      await el._fetchCreators();
+      expect(getSpy).to.not.have.been.called;
+      expect(el._creatorsLoading).to.be.false;
       getSpy.restore();
     });
 

--- a/ui/test/nuxeo-user-group-permissions-table.test.js
+++ b/ui/test/nuxeo-user-group-permissions-table.test.js
@@ -382,8 +382,12 @@ suite('nuxeo-user-group-permissions-table', () => {
 
     test('should handle fetch failure gracefully', async () => {
       sinon.stub(el.$.userResource, 'get').rejects(new Error('not found'));
+      const warnSpy = sinon.stub(console, 'warn');
       await el._fetchCreators([{ aces: [mkAce({ creator: 'unknown' })] }]);
       expect(el._creatorEntities).to.have.property('unknown', 'unknown');
+      // A statusless (e.g. network/transport) error is unexpected and should be logged.
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
       el.$.userResource.get.restore();
     });
 

--- a/ui/test/nuxeo-user-group-permissions-table.test.js
+++ b/ui/test/nuxeo-user-group-permissions-table.test.js
@@ -375,5 +375,29 @@ suite('nuxeo-user-group-permissions-table', () => {
       expect(el._creatorEntities).to.have.property('unknown', 'unknown');
       el.$.userResource.get.restore();
     });
+
+    test('should warn on unexpected non-404 errors', async () => {
+      const error = new Error('internal error');
+      error.status = 500;
+      sinon.stub(el.$.userResource, 'get').rejects(error);
+      const warnSpy = sinon.spy(console, 'warn');
+      await el._fetchCreators([{ aces: [mkAce({ creator: 'baduser' })] }]);
+      expect(el._creatorEntities).to.have.property('baduser', 'baduser');
+      expect(warnSpy).to.have.been.calledOnce;
+      warnSpy.restore();
+      el.$.userResource.get.restore();
+    });
+
+    test('should not warn on 404 errors', async () => {
+      const error = new Error('not found');
+      error.status = 404;
+      sinon.stub(el.$.userResource, 'get').rejects(error);
+      const warnSpy = sinon.spy(console, 'warn');
+      await el._fetchCreators([{ aces: [mkAce({ creator: 'deleted' })] }]);
+      expect(el._creatorEntities).to.have.property('deleted', 'deleted');
+      expect(warnSpy).to.not.have.been.called;
+      warnSpy.restore();
+      el.$.userResource.get.restore();
+    });
   });
 });

--- a/ui/test/nuxeo-user-group-permissions-table.test.js
+++ b/ui/test/nuxeo-user-group-permissions-table.test.js
@@ -380,7 +380,7 @@ suite('nuxeo-user-group-permissions-table', () => {
       const error = new Error('internal error');
       error.status = 500;
       sinon.stub(el.$.userResource, 'get').rejects(error);
-      const warnSpy = sinon.spy(console, 'warn');
+      const warnSpy = sinon.stub(console, 'warn');
       await el._fetchCreators([{ aces: [mkAce({ creator: 'baduser' })] }]);
       expect(el._creatorEntities).to.have.property('baduser', 'baduser');
       expect(warnSpy).to.have.been.calledOnce;
@@ -392,7 +392,7 @@ suite('nuxeo-user-group-permissions-table', () => {
       const error = new Error('not found');
       error.status = 404;
       sinon.stub(el.$.userResource, 'get').rejects(error);
-      const warnSpy = sinon.spy(console, 'warn');
+      const warnSpy = sinon.stub(console, 'warn');
       await el._fetchCreators([{ aces: [mkAce({ creator: 'deleted' })] }]);
       expect(el._creatorEntities).to.have.property('deleted', 'deleted');
       expect(warnSpy).to.not.have.been.called;

--- a/ui/test/nuxeo-user-group-permissions-table.test.js
+++ b/ui/test/nuxeo-user-group-permissions-table.test.js
@@ -372,7 +372,7 @@ suite('nuxeo-user-group-permissions-table', () => {
     test('should handle fetch failure gracefully', async () => {
       sinon.stub(el.$.userResource, 'get').rejects(new Error('not found'));
       await el._fetchCreators([{ aces: [mkAce({ creator: 'unknown' })] }]);
-      expect(el._creatorEntities).to.not.have.property('unknown');
+      expect(el._creatorEntities).to.have.property('unknown', 'unknown');
       el.$.userResource.get.restore();
     });
   });

--- a/ui/test/nuxeo-user-group-permissions-table.test.js
+++ b/ui/test/nuxeo-user-group-permissions-table.test.js
@@ -336,4 +336,44 @@ suite('nuxeo-user-group-permissions-table', () => {
       expect(elLocal._entityDisplayName).to.equal('administrators');
     });
   });
+
+  suite('_resolvedCreator', () => {
+    test('returns entity when present in map', () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      expect(el._resolvedCreator('jdoe', { jdoe: entity })).to.equal(entity);
+    });
+
+    test('falls back to raw creator string when not resolved', () => {
+      expect(el._resolvedCreator('system', {})).to.equal('system');
+    });
+
+    test('falls back to raw creator string when entities is null', () => {
+      expect(el._resolvedCreator('system', null)).to.equal('system');
+    });
+  });
+
+  suite('_fetchCreators', () => {
+    test('should skip when entries have no aces with creators', async () => {
+      const getSpy = sinon.spy(el.$.userResource, 'get');
+      await el._fetchCreators([{ aces: [] }]);
+      expect(getSpy).to.not.have.been.called;
+      getSpy.restore();
+    });
+
+    test('should fetch user entity for each unique creator', async () => {
+      const entity = { 'entity-type': 'user', id: 'jdoe', properties: { firstName: 'Jane', lastName: 'Doe' } };
+      sinon.stub(el.$.userResource, 'get').resolves(entity);
+      await el._fetchCreators([{ aces: [mkAce({ creator: 'jdoe' }), mkAce({ creator: 'jdoe' })] }]);
+      expect(el.$.userResource.get).to.have.been.calledOnce;
+      expect(el._creatorEntities).to.have.property('jdoe', entity);
+      el.$.userResource.get.restore();
+    });
+
+    test('should handle fetch failure gracefully', async () => {
+      sinon.stub(el.$.userResource, 'get').rejects(new Error('not found'));
+      await el._fetchCreators([{ aces: [mkAce({ creator: 'unknown' })] }]);
+      expect(el._creatorEntities).to.not.have.property('unknown');
+      el.$.userResource.get.restore();
+    });
+  });
 });

--- a/ui/test/nuxeo-user-management.test.js
+++ b/ui/test/nuxeo-user-management.test.js
@@ -517,7 +517,17 @@ suite('nuxeo-user-management', () => {
       expect(el._userDisplayName(undefined)).to.equal('');
     });
 
-    test('prefers properties.username over user.name to avoid showing UUID', () => {
+    test('returns firstName + lastName when both are present', () => {
+      expect(
+        el._userDisplayName({
+          id: 'internal-uid',
+          name: 'some-uuid',
+          properties: { username: 'loginName', firstName: 'John', lastName: 'Smith' },
+        }),
+      ).to.equal('John Smith');
+    });
+
+    test('falls back to username when firstName and lastName are absent', () => {
       expect(
         el._userDisplayName({
           id: 'internal-uid',
@@ -527,17 +537,26 @@ suite('nuxeo-user-management', () => {
       ).to.equal('loginName');
     });
 
-    test('falls back to user.name when properties.username is absent', () => {
+    test('falls back to user.id when properties.username is absent', () => {
       expect(
         el._userDisplayName({
-          id: 'internal-uid',
+          id: 'jdoe',
+          name: 'some-name',
+          properties: {},
+        }),
+      ).to.equal('jdoe');
+    });
+
+    test('falls back to user.name when properties.username and user.id are absent', () => {
+      expect(
+        el._userDisplayName({
           name: 'jdoe',
           properties: {},
         }),
       ).to.equal('jdoe');
     });
 
-    test('does not use user.id as display name', () => {
+    test('prefers properties.username over user.id', () => {
       expect(
         el._userDisplayName({
           id: 'generated-uuid',
@@ -546,8 +565,48 @@ suite('nuxeo-user-management', () => {
       ).to.equal('jdoe');
     });
 
-    test('returns empty string when user.properties is absent', () => {
-      expect(el._userDisplayName({ id: 'generated-uuid' })).to.equal('');
+    test('returns user.id when user.properties is absent', () => {
+      expect(el._userDisplayName({ id: 'jdoe' })).to.equal('jdoe');
+    });
+
+    test('returns empty string when user has no identifiable fields', () => {
+      expect(el._userDisplayName({})).to.equal('');
+    });
+  });
+
+  suite('_userPrincipal', () => {
+    test('returns empty string when user is null or undefined', () => {
+      expect(el._userPrincipal(null)).to.equal('');
+      expect(el._userPrincipal(undefined)).to.equal('');
+    });
+
+    test('returns username even when firstName and lastName are present', () => {
+      expect(
+        el._userPrincipal({
+          id: 'internal-uid',
+          name: 'some-uuid',
+          properties: { username: 'loginName', firstName: 'John', lastName: 'Smith' },
+        }),
+      ).to.equal('loginName');
+    });
+
+    test('falls back to user.id when properties.username is absent', () => {
+      expect(
+        el._userPrincipal({
+          id: 'jdoe',
+          name: 'some-name',
+          properties: {},
+        }),
+      ).to.equal('jdoe');
+    });
+
+    test('falls back to user.name when properties.username and user.id are absent', () => {
+      expect(
+        el._userPrincipal({
+          name: 'jdoe',
+          properties: {},
+        }),
+      ).to.equal('jdoe');
     });
   });
 });

--- a/ui/test/nuxeo-user-profile.test.js
+++ b/ui/test/nuxeo-user-profile.test.js
@@ -204,8 +204,8 @@ suite('nuxeo-user-profile', () => {
       expect(el._userDisplayName({ properties: {} })).to.equal('');
     });
 
-    test('returns empty string when user.properties is absent', () => {
-      expect(el._userDisplayName({ id: 'some-uuid' })).to.equal('');
+    test('falls back to user.id when user.properties is absent', () => {
+      expect(el._userDisplayName({ id: 'some-uuid' })).to.equal('some-uuid');
     });
   });
 

--- a/ui/test/nuxeo-user-profile.test.js
+++ b/ui/test/nuxeo-user-profile.test.js
@@ -183,7 +183,16 @@ suite('nuxeo-user-profile', () => {
       expect(el._userDisplayName(undefined)).to.equal('');
     });
 
-    test('prefers properties.username over user.name to avoid showing UUID', () => {
+    test('returns username even when firstName and lastName are present', () => {
+      expect(
+        el._userDisplayName({
+          name: 'some-uuid',
+          properties: { username: 'jdoe', firstName: 'Jane', lastName: 'Doe' },
+        }),
+      ).to.equal('jdoe');
+    });
+
+    test('returns username when firstName and lastName are absent', () => {
       expect(el._userDisplayName({ name: 'some-uuid', properties: { username: 'jdoe' } })).to.equal('jdoe');
     });
 
@@ -197,6 +206,43 @@ suite('nuxeo-user-profile', () => {
 
     test('returns empty string when user.properties is absent', () => {
       expect(el._userDisplayName({ id: 'some-uuid' })).to.equal('');
+    });
+  });
+
+  suite('_userFullName', () => {
+    test('returns empty string when user is null or undefined', () => {
+      expect(el._userFullName(null)).to.equal('');
+      expect(el._userFullName(undefined)).to.equal('');
+    });
+
+    test('returns firstName + lastName when both are present', () => {
+      expect(
+        el._userFullName({
+          name: 'some-uuid',
+          properties: { username: 'jdoe', firstName: 'Jane', lastName: 'Doe' },
+        }),
+      ).to.equal('Jane Doe');
+    });
+
+    test('falls back to username when firstName and lastName are absent', () => {
+      expect(el._userFullName({ name: 'some-uuid', properties: { username: 'jdoe' } })).to.equal('jdoe');
+    });
+  });
+
+  suite('_userPrincipal', () => {
+    test('returns empty string when user is null or undefined', () => {
+      expect(el._userPrincipal(null)).to.equal('');
+      expect(el._userPrincipal(undefined)).to.equal('');
+    });
+
+    test('returns username even when firstName and lastName are present', () => {
+      expect(
+        el._userPrincipal({ name: 'some-uuid', properties: { username: 'jdoe', firstName: 'Jane', lastName: 'Doe' } }),
+      ).to.equal('jdoe');
+    });
+
+    test('falls back to user.name when properties.username is absent', () => {
+      expect(el._userPrincipal({ name: 'jdoe', properties: {} })).to.equal('jdoe');
     });
   });
 


### PR DESCRIPTION
## Problem
User identity is displayed inconsistently across the UI — some screens show raw usernames while others show full names (firstName + lastName). Jira: [ELEMENTS-1995](https://hyland.atlassian.net/browse/ELEMENTS-1995)

## Root cause
Components like `nuxeo-document-comment`, `nuxeo-document-acl-table`, and `nuxeo-user-group-permissions-table` were rendering `ace.creator` or `comment.author` as plain text strings (usernames) instead of resolving them to user entities and displaying full names.

## Changes
* **`ui/nuxeo-user-group-management/nuxeo-user-display.js`** (NEW): Shared helpers `formatUserDisplayName`, `formatUserPrincipal`, `fetchUserEntities`, and `resolveUser` with robust fallback chain and URL-encoded API paths.
* **`ui/nuxeo-document-comments/nuxeo-document-comment.js`**: Resolves `comment.author` to a user entity and displays the full name via `_authorDisplayName` in the existing `<span class='author'>` element (preserving ftest compatibility). Includes request-id guard for race-condition safety.
* **`ui/nuxeo-document-permissions/nuxeo-document-acl-table.js`**: Added `_fetchCreators` with request-id guard to resolve `ace.creator` usernames to full user entities; shows raw username while loading, full name after resolution.
* **`ui/nuxeo-user-group-management/nuxeo-user-group-permissions-table.js`**: Same pattern — fetch creators with request-id guard, `nuxeo-user-tag`.
* **`ui/nuxeo-user-group-management/nuxeo-user-management.js`**: Use `formatUserPrincipal` for headings/messages (keeps username), `formatUserDisplayName` for entity-label (shows full name).
* **`ui/nuxeo-user-group-management/nuxeo-group-management.js`**: Same pattern as user-management.
* **`ui/nuxeo-user-group-management/nuxeo-user-profile.js`**: Uses helpers for entity + entity-label bindings; `_userDisplayName` delegates to `formatUserPrincipal`.
* **`ui/test/*.test.js`**: Updated and added tests for all new methods and fallback behaviors.

## Test plan
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test:ui` passes (3677 passed, 0 failed)
- [ ] Manual verification: Comments tab shows full name, Permissions 'Granted by' column shows full name, User/Group admin screens show username in headings

## Notes
Backport pair: see corresponding `maintenance-3.1.x` PR (#1518). Related Web UI PR: WEBUI-1096.
