### PR TITLE
ELEMENTS-2016: allow deferring the initial search in nuxeo-results-view [LTS-2025]

### DIFF
--- a/ui/search/nuxeo-results-view.js
+++ b/ui/search/nuxeo-results-view.js
@@ -380,7 +380,7 @@ import './nuxeo-search-results-layout.js';
     }
 
     _search() {
-      if (this.deferInitialSearch && !this._searched) {
+      if (this.deferInitialSearch && !this._searched && !this.auto) {
         return;
       }
       if (this.results) {

--- a/ui/search/nuxeo-results-view.js
+++ b/ui/search/nuxeo-results-view.js
@@ -262,7 +262,11 @@ import './nuxeo-search-results-layout.js';
         },
         /**
          * If `true`, no search is performed until the user explicitly triggers one, so loading the
-         * page does not execute the initial query. Has no effect when `auto` is `true`.
+         * page does not execute the initial query. Clearing the filters returns to that state
+         * instead of searching again. Has no effect when `auto` is `true`.
+         *
+         * Requires `showFilters`, since the Search button that lifts the suppression lives in the
+         * filtering panel; without it the view would have no way to ever run a search.
          */
         deferInitialSearch: {
           type: Boolean,
@@ -296,10 +300,6 @@ import './nuxeo-search-results-layout.js';
         hrefBase: String,
         _params: Object,
         _paramsCount: Number,
-        _searched: {
-          type: Boolean,
-          value: false,
-        },
         _nxProvider: HTMLElement,
         _hideCounter: {
           type: String,
@@ -310,6 +310,13 @@ import './nuxeo-search-results-layout.js';
 
     static get observers() {
       return ['_visibilityOrAutoChanged(visible, auto)'];
+    }
+
+    constructor() {
+      super();
+      // whether an explicit search has already lifted the `deferInitialSearch` suppression
+      this._searched = false;
+      this._searchOnTrigger = () => this.search();
     }
 
     ready() {
@@ -409,6 +416,15 @@ import './nuxeo-search-results-layout.js';
       if (!this.auto) {
         this.aggregations = {};
       }
+      // clearing the filters is not a request to search, so a deferred view goes back to its
+      // pristine state rather than re-running the query the deferral is there to avoid
+      if (this.deferInitialSearch && !this.auto) {
+        this._searched = false;
+        if (this.results) {
+          this.results.reset();
+        }
+        return;
+      }
       if (!this.auto && this.visible) {
         this._search();
       }
@@ -432,7 +448,10 @@ import './nuxeo-search-results-layout.js';
       form.addEventListener('skip-aggregates-changed', (evt) => {
         this.notifyPath('skipAggregates', evt.detail.value);
       });
-      form.addEventListener('trigger-search', this.search.bind(this));
+      // re-attaching a single bound handler keeps listeners from accumulating if the same form
+      // layout fires more than once
+      form.removeEventListener('trigger-search', this._searchOnTrigger);
+      form.addEventListener('trigger-search', this._searchOnTrigger);
       this._search();
     }
 

--- a/ui/search/nuxeo-results-view.js
+++ b/ui/search/nuxeo-results-view.js
@@ -137,7 +137,7 @@ import './nuxeo-search-results-layout.js';
                 [[i18n('command.clear')]]
               </paper-button>
               <div class="horizontal layout flex end-justified">
-                <paper-button noink class="primary search" on-tap="_search" hidden$="[[auto]]" disabled$="[[loading]]">
+                <paper-button noink class="primary search" on-tap="search" hidden$="[[auto]]" disabled$="[[loading]]">
                   [[i18n('command.search')]]
                   <template is="dom-if" if="[[loading]]">
                     <paper-spinner-lite active></paper-spinner-lite>
@@ -261,6 +261,14 @@ import './nuxeo-search-results-layout.js';
           value: false,
         },
         /**
+         * If `true`, no search is performed until the user explicitly triggers one, so loading the
+         * page does not execute the initial query. Has no effect when `auto` is `true`.
+         */
+        deferInitialSearch: {
+          type: Boolean,
+          value: false,
+        },
+        /**
          * If `true`, opens the collapsible top filtering panel.
          */
         opened: {
@@ -288,6 +296,10 @@ import './nuxeo-search-results-layout.js';
         hrefBase: String,
         _params: Object,
         _paramsCount: Number,
+        _searched: {
+          type: Boolean,
+          value: false,
+        },
         _nxProvider: HTMLElement,
         _hideCounter: {
           type: String,
@@ -359,7 +371,18 @@ import './nuxeo-search-results-layout.js';
       }
     }
 
+    /**
+     * Runs the search on an explicit user action, lifting any `deferInitialSearch` suppression.
+     */
+    search() {
+      this._searched = true;
+      this._search();
+    }
+
     _search() {
+      if (this.deferInitialSearch && !this._searched) {
+        return;
+      }
       if (this.results) {
         this.results.reset();
         this.results.fetch();
@@ -409,7 +432,7 @@ import './nuxeo-search-results-layout.js';
       form.addEventListener('skip-aggregates-changed', (evt) => {
         this.notifyPath('skipAggregates', evt.detail.value);
       });
-      form.addEventListener('trigger-search', this._search.bind(this));
+      form.addEventListener('trigger-search', this.search.bind(this));
       this._search();
     }
 

--- a/ui/test/nuxeo-results-view.test.js
+++ b/ui/test/nuxeo-results-view.test.js
@@ -268,6 +268,14 @@ suite('nuxeo-results-view', () => {
       expect(results.fetch).to.have.been.calledTwice;
     });
 
+    test('_search fetches on an automatic view even while the initial search is deferred', () => {
+      element.deferInitialSearch = true;
+      element.auto = true;
+      results.fetch.resetHistory();
+      element._search();
+      expect(results.fetch).to.have.been.calledOnce;
+    });
+
     test('_clear does not search while the initial search is deferred', () => {
       element.deferInitialSearch = true;
       element.auto = false;

--- a/ui/test/nuxeo-results-view.test.js
+++ b/ui/test/nuxeo-results-view.test.js
@@ -230,6 +230,64 @@ suite('nuxeo-results-view', () => {
     });
   });
 
+  suite('deferInitialSearch', () => {
+    let results;
+
+    setup(() => {
+      results = { reset: sinon.stub(), fetch: sinon.stub() };
+      sinon.stub(element, '$$').callsFake((sel) => (sel === '#results' ? results : null));
+    });
+
+    teardown(() => {
+      element.$$.restore();
+    });
+
+    test('_search fetches when not deferred', () => {
+      element._search();
+      expect(results.reset).to.have.been.calledOnce;
+      expect(results.fetch).to.have.been.calledOnce;
+    });
+
+    test('_search does not fetch while the initial search is deferred', () => {
+      element.deferInitialSearch = true;
+      element._search();
+      expect(results.reset).to.not.have.been.called;
+      expect(results.fetch).to.not.have.been.called;
+    });
+
+    test('search lifts the deferral and fetches', () => {
+      element.deferInitialSearch = true;
+      element.search();
+      expect(results.fetch).to.have.been.calledOnce;
+    });
+
+    test('_search fetches once an explicit search has run', () => {
+      element.deferInitialSearch = true;
+      element.search();
+      element._search();
+      expect(results.fetch).to.have.been.calledTwice;
+    });
+
+    test('_clear does not search while the initial search is deferred', () => {
+      element.deferInitialSearch = true;
+      element.auto = false;
+      element.visible = true;
+      element._clear();
+      expect(results.fetch).to.not.have.been.called;
+    });
+
+    test('_formChanged does not search when the initial search is deferred', () => {
+      element.deferInitialSearch = true;
+      element._formChanged({ detail: { value: document.createElement('div') } });
+      expect(results.fetch).to.not.have.been.called;
+    });
+
+    test('_formChanged searches when not deferred', () => {
+      element._formChanged({ detail: { value: document.createElement('div') } });
+      expect(results.fetch).to.have.been.called;
+    });
+  });
+
   suite('_aggregationsChanged', () => {
     test('sets aggregations on form when form exists', () => {
       const fakeForm = { aggregations: null };

--- a/ui/test/nuxeo-results-view.test.js
+++ b/ui/test/nuxeo-results-view.test.js
@@ -284,10 +284,65 @@ suite('nuxeo-results-view', () => {
       expect(results.fetch).to.not.have.been.called;
     });
 
+    test('_clear returns to the deferred state after an explicit search', () => {
+      element.deferInitialSearch = true;
+      element.auto = false;
+      element.visible = true;
+      element.search();
+      results.fetch.resetHistory();
+      results.reset.resetHistory();
+
+      element._clear();
+
+      expect(results.fetch).to.not.have.been.called;
+      expect(results.reset).to.have.been.calledOnce;
+    });
+
+    test('_search does not fetch after clearing an explicit search', () => {
+      element.deferInitialSearch = true;
+      element.auto = false;
+      element.visible = true;
+      element.search();
+      element._clear();
+      results.fetch.resetHistory();
+
+      element._search();
+
+      expect(results.fetch).to.not.have.been.called;
+    });
+
+    test('_clear leaves an automatic view alone while the initial search is deferred', () => {
+      element.deferInitialSearch = true;
+      element.auto = true;
+      element.visible = true;
+      element.search();
+      results.fetch.resetHistory();
+      results.reset.resetHistory();
+
+      element._clear();
+
+      // an automatic view searches from its params observer, so _clear neither searches nor drops
+      // back into the deferred state
+      expect(results.fetch).to.not.have.been.called;
+      expect(results.reset).to.not.have.been.called;
+      expect(element._searched).to.be.true;
+    });
+
     test('_formChanged does not search when the initial search is deferred', () => {
       element.deferInitialSearch = true;
       element._formChanged({ detail: { value: document.createElement('div') } });
       expect(results.fetch).to.not.have.been.called;
+    });
+
+    test('_formChanged attaches a single trigger-search listener per form', () => {
+      const form = document.createElement('div');
+      element._formChanged({ detail: { value: form } });
+      element._formChanged({ detail: { value: form } });
+      results.fetch.resetHistory();
+
+      form.dispatchEvent(new CustomEvent('trigger-search'));
+
+      expect(results.fetch).to.have.been.calledOnce;
     });
 
     test('_formChanged searches when not deferred', () => {


### PR DESCRIPTION
## Problem

The Administration > NXQL Search page in Web UI runs a broad query as soon as it is opened:

```
SELECT * FROM Document WHERE ecm:mixinType != 'HiddenInNavigation' AND ecm:isProxy = 0 AND ecm:isVersion = 0 AND ecm:isTrashed = 0
```

On customers with large repositories this unbounded query is executed on every visit to the page and destabilises the instance and its database.

Ticket: https://hyland.atlassian.net/browse/ELEMENTS-2016 (elements-side clone of https://hyland.atlassian.net/browse/WEBUI-1946)

## Root cause

`nuxeo-results-view` searches unconditionally as soon as the search form layout has loaded, independently of `auto`:

- `_formChanged()` calls `_clear()`, which itself calls `_search()` when `!auto && visible`
- `_formChanged()` then calls `_search()` again

There was no way for a consumer to say "render the form and results, but do not query until the user asks for it".

## Changes

- New opt-in `deferInitialSearch` property. While it is set and no explicit search has happened yet, `_search()` returns early, so loading the page issues no query.
- New public `search()` method that lifts the suppression and searches. The Search button (`on-tap`) and the search form's `trigger-search` event (Ctrl+Enter) now call it, so both user-initiated paths behave exactly as before.
- `_clear()` returns a deferred view to its pristine state — restoring the suppression and emptying the result list — instead of searching. Clearing the filters is not a request to search, so it no longer re-runs the very query the deferral exists to avoid.
- `deferInitialSearch` defaults to `false`, so every existing consumer — document search, saved searches, the document picker, DAM/assets, trash and expired search — keeps searching on load with no change.
- The property documents that it requires `showFilters`, since the Search button that lifts the suppression lives in the filtering panel.

## Test plan

- `npm run test:ui` — **3720 passed, 0 failed, 2 skipped**.
- The `deferInitialSearch` suite in `ui/test/nuxeo-results-view.test.js` covers: `_search` fetching when not deferred; `_search` not fetching while deferred; `search()` lifting the deferral; `_search` working again after an explicit search; automatic views searching regardless of the flag; `_clear` returning to the deferred state after an explicit search and no fetch happening afterwards; `_clear` leaving automatic views alone; `_formChanged` not searching while deferred; and a single `trigger-search` listener being attached per form.
- `npm run lint:eslint` and `npm run lint:prettier` clean on the touched files.

## Notes

- Paired with the nuxeo-web-ui PR for WEBUI-1946 (this ticket is its elements-side clone), which sets this flag for the NXQL admin page only. **This PR needs to be released before that one merges**: the Web UI side suppresses its own fetch path immediately, but the `nuxeo-results-view` path above only stops querying once this change is published.
- Raised on both `lts-2025` and `maintenance-3.1.x`.
