### PR TITLE
ELEMENTS-2054: make nuxeo-tooltip comply with WCAG 2.1 AA 1.4.13 (content on hover or focus)

### DIFF
--- a/ui/test/nuxeo-tooltip.test.js
+++ b/ui/test/nuxeo-tooltip.test.js
@@ -15,9 +15,40 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { html, fixture, flush, isElementVisible } from '@nuxeo/testing-helpers';
+import { html, fixture, flush, isElementVisible, timePasses } from '@nuxeo/testing-helpers';
 import '../widgets/nuxeo-tooltip.js';
 import { ensureClonedContentStyles } from '../widgets/nuxeo-tooltip.js';
+import { TOOLTIP_DISMISS_KEYS, TOOLTIP_POINTER_LEAVE_DELAY_MS } from '../widgets/nuxeo-tooltip-a11y-behavior.js';
+
+/** Dispatches a keydown from inside the document, so it travels the real propagation path. */
+function pressKey(key) {
+  document.body.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, composed: true }));
+}
+
+/**
+ * Dispatches a keydown that an ancestor stops before it can reach anything below `window`'s capture
+ * phase — what `IronMenuBehavior._onKeydown` does for every key in the Web UI navigation menu.
+ */
+function pressKeyWithPropagationStopped(key) {
+  const stop = (event) => {
+    if (event.key === key) {
+      event.stopPropagation();
+    }
+  };
+  document.addEventListener('keydown', stop, true);
+  try {
+    pressKey(key);
+  } finally {
+    document.removeEventListener('keydown', stop, true);
+  }
+}
+
+const enter = (node) => node.dispatchEvent(new MouseEvent('mouseenter'));
+const leave = (node) => node.dispatchEvent(new MouseEvent('mouseleave'));
+const focusIn = (node, relatedTarget = null) =>
+  node.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget }));
+const focusOut = (node, relatedTarget = null) =>
+  node.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget }));
 
 suite('nuxeo-tooltip', () => {
   test('Should not add paper-tooltip to the dom when hidden attribute is set', async () => {
@@ -109,7 +140,7 @@ suite('nuxeo-tooltip', () => {
     expect(tooltip.isShowing()).to.be.false;
   });
 
-  test('window keydown hides the tooltip', async () => {
+  test('Escape hides the tooltip', async () => {
     const tooltip = await fixture(
       html`
         <nuxeo-tooltip>Hello</nuxeo-tooltip>
@@ -117,9 +148,10 @@ suite('nuxeo-tooltip', () => {
     );
     tooltip.show();
     await flush();
-    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    pressKey('Escape');
     await flush();
     expect(document.body.querySelector('paper-tooltip')).to.be.null;
+    expect(tooltip.isTooltipDismissed()).to.be.true;
   });
 
   test('Should stamp role only on element clones, not text nodes', async () => {
@@ -239,5 +271,529 @@ suite('nuxeo-tooltip', () => {
     );
     const tooltip = host.shadowRoot.querySelector('nuxeo-tooltip');
     expect(tooltip.target).to.equal(host);
+  });
+
+  /**
+   * WCAG 2.1 AA 1.4.13 "Content on Hover or Focus" — the tooltip must be dismissible, hoverable
+   * and persistent — plus the ARIA wiring assistive technologies need (WEBUI-504).
+   */
+  suite('WCAG 1.4.13 content on hover or focus', () => {
+    /** `<span>` trigger with a tooltip bound to it via `for`. */
+    async function triggerFixture() {
+      const host = await fixture(html`
+        <div>
+          <span id="a11y-target">Target</span>
+          <nuxeo-tooltip for="a11y-target">Tooltip text</nuxeo-tooltip>
+        </div>
+      `);
+      return { host, target: host.querySelector('#a11y-target'), tooltip: host.querySelector('nuxeo-tooltip') };
+    }
+
+    suite('dismissible', () => {
+      test('Escape dismisses the tooltip while the pointer stays on the trigger', async () => {
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+
+        pressKey('Escape');
+        await flush();
+        expect(tooltip.isShowing()).to.be.false;
+        expect(document.body.querySelector('paper-tooltip')).to.be.null;
+      });
+
+      test('Escape dismisses even when an ancestor stops keydown propagation', async () => {
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+
+        pressKeyWithPropagationStopped('Escape');
+        await flush();
+        expect(tooltip.isShowing()).to.be.false;
+      });
+
+      test('the legacy "Esc" key value also dismisses', async () => {
+        expect(TOOLTIP_DISMISS_KEYS).to.include.members(['Escape', 'Esc']);
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+        pressKey('Esc');
+        await flush();
+        expect(tooltip.isShowing()).to.be.false;
+      });
+
+      test('a dismissed tooltip does not come back while the trigger is still hovered', async () => {
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+        pressKey('Escape');
+        await flush();
+
+        // nuxeo-resize-handle re-fires mouseenter on every mousemove over its trigger.
+        enter(target);
+        await flush();
+        expect(tooltip.isShowing()).to.be.false;
+      });
+
+      test('the trigger shows the tooltip again once the pointer really leaves', async () => {
+        const { target, tooltip } = await triggerFixture();
+        tooltip.pointerLeaveDelay = 0;
+        enter(target);
+        await flush();
+        pressKey('Escape');
+        await flush();
+
+        leave(target);
+        await flush();
+        expect(tooltip.isTooltipDismissed()).to.be.false;
+        enter(target);
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+      });
+
+      test('blur clears the dismissal so focusing the trigger again shows the tooltip', async () => {
+        const { target, tooltip } = await triggerFixture();
+        focusIn(target);
+        await flush();
+        pressKey('Escape');
+        await flush();
+        expect(tooltip.isTooltipDismissed()).to.be.true;
+
+        focusOut(target);
+        await flush();
+        expect(tooltip.isTooltipDismissed()).to.be.false;
+        focusIn(target);
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+      });
+
+      test('focus moving within a wrapper keeps an Escape dismissal latched', async () => {
+        const host = await fixture(html`
+          <div>
+            <div id="wrapper">
+              <button id="first">First</button>
+              <button id="second">Second</button>
+              <nuxeo-tooltip>Tooltip text</nuxeo-tooltip>
+            </div>
+          </div>
+        `);
+        const wrapper = host.querySelector('#wrapper');
+        const first = host.querySelector('#first');
+        const second = host.querySelector('#second');
+        const tooltip = host.querySelector('nuxeo-tooltip');
+        expect(tooltip.target).to.equal(wrapper);
+
+        focusIn(first);
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+        pressKey('Escape');
+        await flush();
+        expect(tooltip.isTooltipDismissed()).to.be.true;
+
+        focusOut(first, second);
+        focusIn(second, first);
+        await flush();
+        expect(tooltip.isTooltipDismissed()).to.be.true;
+        expect(tooltip.isShowing()).to.be.false;
+
+        focusOut(second, document.body);
+        await flush();
+        expect(tooltip.isTooltipDismissed()).to.be.false;
+        focusIn(first, document.body);
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+      });
+
+      test('keydown() without an event still dismisses, for backwards compatibility', async () => {
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+        tooltip.keydown();
+        await flush();
+        expect(tooltip.isShowing()).to.be.false;
+      });
+
+      test('keydown() dismisses for a dismissal key and ignores anything else', async () => {
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+
+        tooltip.keydown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+
+        tooltip.keydown(new KeyboardEvent('keydown', { key: 'Escape' }));
+        await flush();
+        expect(tooltip.isShowing()).to.be.false;
+      });
+
+      test('dismissing a tooltip that shows nothing is a no-op', async () => {
+        const { tooltip } = await triggerFixture();
+        tooltip.keydown();
+        await flush();
+        expect(tooltip.isTooltipDismissed()).to.be.false;
+      });
+
+      test('arming and disarming the behavior twice changes nothing', async () => {
+        // Polymer re-runs attached/detached when an element is moved between parents.
+        const { target, tooltip } = await triggerFixture();
+        tooltip._armTooltipA11y();
+        expect(target.getAttribute('aria-describedby')).to.equal(tooltip.id);
+
+        tooltip._disarmTooltipA11y();
+        tooltip._disarmTooltipA11y();
+        expect(target.hasAttribute('aria-describedby')).to.be.false;
+      });
+
+      test('only the tooltips that are actually rendered listen for the dismissal key', async () => {
+        // A screen can hold a hundred tooltips, so they share one listener and it is only on the
+        // window while there is something to dismiss.
+        const added = sinon.spy(window, 'addEventListener');
+        const removed = sinon.spy(window, 'removeEventListener');
+        try {
+          const first = await triggerFixture();
+          const second = await triggerFixture();
+          expect(added.calledWith('keydown'), 'no listener while nothing is rendered').to.be.false;
+
+          enter(first.target);
+          await flush();
+          enter(second.target);
+          await flush();
+          expect(added.withArgs('keydown').callCount, 'a single shared listener').to.equal(1);
+
+          pressKey('Escape');
+          await flush();
+          expect(first.tooltip.isShowing()).to.be.false;
+          expect(second.tooltip.isShowing()).to.be.false;
+          expect(removed.withArgs('keydown').callCount, 'dropped once the last one is gone').to.equal(1);
+        } finally {
+          added.restore();
+          removed.restore();
+        }
+      });
+    });
+
+    suite('hoverable', () => {
+      test('leaving the trigger only schedules the teardown', async () => {
+        const { target, tooltip } = await triggerFixture();
+        tooltip.pointerLeaveDelay = 40;
+        enter(target);
+        await flush();
+        const bubble = tooltip._tooltip;
+
+        leave(target);
+        await flush();
+        expect(tooltip._tooltip, 'tooltip is kept while the pointer travels to it').to.equal(bubble);
+      });
+
+      test('the pointer can rest on the tooltip without it disappearing', async () => {
+        const { target, tooltip } = await triggerFixture();
+        tooltip.pointerLeaveDelay = 40;
+        enter(target);
+        await flush();
+        const bubble = tooltip._tooltip;
+
+        leave(target);
+        enter(bubble);
+        await timePasses(120);
+        expect(tooltip._tooltip).to.equal(bubble);
+        expect(bubble.isConnected).to.be.true;
+      });
+
+      test('the tooltip goes away once the pointer leaves it too', async () => {
+        const { target, tooltip } = await triggerFixture();
+        tooltip.pointerLeaveDelay = 40;
+        enter(target);
+        await flush();
+        const bubble = tooltip._tooltip;
+        leave(target);
+        enter(bubble);
+        await timePasses(60);
+
+        leave(bubble);
+        await timePasses(120);
+        expect(tooltip._tooltip).to.be.null;
+        expect(bubble.isConnected).to.be.false;
+      });
+
+      test('re-entering the trigger during the grace period keeps the same tooltip', async () => {
+        const { target, tooltip } = await triggerFixture();
+        tooltip.pointerLeaveDelay = 60;
+        enter(target);
+        await flush();
+        const bubble = tooltip._tooltip;
+
+        leave(target);
+        enter(target);
+        await timePasses(140);
+        expect(tooltip._tooltip).to.equal(bubble);
+      });
+
+      test('the tooltip is torn down when the pointer leaves without reaching it', async () => {
+        const { target, tooltip } = await triggerFixture();
+        tooltip.pointerLeaveDelay = 20;
+        enter(target);
+        await flush();
+
+        leave(target);
+        await timePasses(80);
+        expect(tooltip._tooltip).to.be.null;
+      });
+
+      test('pressing the pointer on the tooltip hides it so the click reaches the content below', async () => {
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+        const bubble = tooltip._tooltip;
+
+        bubble.dispatchEvent(new MouseEvent('mousedown'));
+        await flush();
+        expect(tooltip._tooltip).to.be.null;
+      });
+
+      test('the pointer grace period defaults to the shared constant', async () => {
+        const { tooltip } = await triggerFixture();
+        expect(tooltip.pointerLeaveDelay).to.equal(TOOLTIP_POINTER_LEAVE_DELAY_MS);
+      });
+    });
+
+    suite('persistent', () => {
+      test('an unrelated keystroke leaves the tooltip visible', async () => {
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+
+        ['a', 'ArrowDown', 'Shift', 'Enter', 'Tab'].forEach((key) => pressKey(key));
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+      });
+
+      test('nothing hides the tooltip on its own while the trigger stays hovered', async () => {
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+
+        await timePasses(TOOLTIP_POINTER_LEAVE_DELAY_MS * 3);
+        expect(tooltip.isShowing()).to.be.true;
+      });
+    });
+
+    suite('keyboard focus', () => {
+      /**
+       * A tooltip anchored to a non-focusable wrapper whose focusable control is a descendant,
+       * as the shared viewer action row does with its `<div role="presentation">`. These drive
+       * real focus rather than synthetic events, so they also cover the browser's own
+       * `focusin`/`focusout` dispatch.
+       */
+      async function wrapperFixture() {
+        const host = await fixture(html`
+          <div>
+            <div id="wrapper" role="presentation">
+              <button id="inner">Download</button>
+            </div>
+            <nuxeo-tooltip for="wrapper">Download</nuxeo-tooltip>
+          </div>
+        `);
+        return { inner: host.querySelector('#inner'), tooltip: host.querySelector('nuxeo-tooltip') };
+      }
+
+      test('shows when a descendant of a non-focusable wrapper really takes focus', async () => {
+        const { inner, tooltip } = await wrapperFixture();
+        inner.focus();
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+      });
+
+      test('hides once focus really leaves the wrapper', async () => {
+        const { inner, tooltip } = await wrapperFixture();
+        inner.focus();
+        await flush();
+        expect(tooltip.isShowing()).to.be.true;
+
+        inner.blur();
+        await flush();
+        expect(tooltip.isShowing()).to.be.false;
+      });
+    });
+
+    suite('accessible description', () => {
+      test('the tooltip gets role="tooltip" and an id, and describes its trigger', async () => {
+        const { target, tooltip } = await triggerFixture();
+        expect(tooltip.getAttribute('role')).to.equal('tooltip');
+        expect(tooltip.id).to.match(/^nuxeo-tooltip-\d+$/);
+        expect(target.getAttribute('aria-describedby')).to.equal(tooltip.id);
+      });
+
+      test('an author-provided id is reused instead of being replaced', async () => {
+        const host = await fixture(html`
+          <div>
+            <span id="described-target">Target</span>
+            <nuxeo-tooltip id="my-tooltip" for="described-target">Tooltip text</nuxeo-tooltip>
+          </div>
+        `);
+        expect(host.querySelector('#described-target').getAttribute('aria-describedby')).to.equal('my-tooltip');
+      });
+
+      test('an existing aria-describedby is appended to and restored on disconnect', async () => {
+        const host = await fixture(html`
+          <div>
+            <span id="described-target" aria-describedby="other-hint">Target</span>
+            <nuxeo-tooltip for="described-target">Tooltip text</nuxeo-tooltip>
+          </div>
+        `);
+        const target = host.querySelector('#described-target');
+        const tooltip = host.querySelector('nuxeo-tooltip');
+        expect(target.getAttribute('aria-describedby')).to.equal(`other-hint ${tooltip.id}`);
+
+        tooltip.remove();
+        await flush();
+        expect(target.getAttribute('aria-describedby')).to.equal('other-hint');
+      });
+
+      test('an empty aria-describedby is preserved on disconnect', async () => {
+        const host = await fixture(html`
+          <div>
+            <span id="described-target" aria-describedby="">Target</span>
+            <nuxeo-tooltip for="described-target">Tooltip text</nuxeo-tooltip>
+          </div>
+        `);
+        const target = host.querySelector('#described-target');
+        const tooltip = host.querySelector('nuxeo-tooltip');
+        expect(target.getAttribute('aria-describedby')).to.equal(tooltip.id);
+
+        tooltip.remove();
+        await flush();
+        expect(target.hasAttribute('aria-describedby')).to.be.true;
+        expect(target.getAttribute('aria-describedby')).to.equal('');
+      });
+
+      test('aria-describedby is removed from the trigger on disconnect', async () => {
+        const { target, tooltip } = await triggerFixture();
+        expect(target.hasAttribute('aria-describedby')).to.be.true;
+
+        tooltip.remove();
+        await flush();
+        expect(target.hasAttribute('aria-describedby')).to.be.false;
+      });
+
+      test('a trigger whose accessible name already says the same thing is not described twice', async () => {
+        const host = await fixture(html`
+          <div>
+            <span id="described-target" aria-label="Tooltip text">Target</span>
+            <nuxeo-tooltip for="described-target">Tooltip text</nuxeo-tooltip>
+          </div>
+        `);
+        expect(host.querySelector('#described-target').hasAttribute('aria-describedby')).to.be.false;
+      });
+
+      test('a trigger labelled by this very tooltip is not described by it as well', async () => {
+        // The nuxeo-menu-icon pattern: aria-labelledby points straight at the tooltip.
+        const host = await fixture(html`
+          <div>
+            <span id="described-target" aria-labelledby="my-tooltip">Target</span>
+            <nuxeo-tooltip id="my-tooltip" for="described-target">Tooltip text</nuxeo-tooltip>
+          </div>
+        `);
+        expect(host.querySelector('#described-target').hasAttribute('aria-describedby')).to.be.false;
+      });
+
+      test('a trigger labelled by another node with the same text is not described twice', async () => {
+        const host = await fixture(html`
+          <div>
+            <span id="described-target" aria-labelledby="visible-label">Target</span>
+            <span id="visible-label">Tooltip text</span>
+            <nuxeo-tooltip for="described-target">Tooltip text</nuxeo-tooltip>
+          </div>
+        `);
+        expect(host.querySelector('#described-target').hasAttribute('aria-describedby')).to.be.false;
+      });
+
+      test('a trigger labelled with different text is still described by the tooltip', async () => {
+        const host = await fixture(html`
+          <div>
+            <span id="described-target" aria-labelledby="visible-label">Target</span>
+            <span id="visible-label">Some other label</span>
+            <nuxeo-tooltip for="described-target">Tooltip text</nuxeo-tooltip>
+          </div>
+        `);
+        const tooltip = host.querySelector('nuxeo-tooltip');
+        expect(host.querySelector('#described-target').getAttribute('aria-describedby')).to.equal(tooltip.id);
+      });
+
+      test('a hidden tooltip does not describe its trigger', async () => {
+        const host = await fixture(html`
+          <div>
+            <span id="described-target">Target</span>
+            <nuxeo-tooltip for="described-target" hidden>Tooltip text</nuxeo-tooltip>
+          </div>
+        `);
+        expect(host.querySelector('#described-target').hasAttribute('aria-describedby')).to.be.false;
+      });
+
+      test('toggling hidden after attach keeps the description in sync without any interaction', async () => {
+        // nuxeo-date binds hidden$ on its tooltip, and a screen reader user may never hover it.
+        const { target, tooltip } = await triggerFixture();
+        expect(target.getAttribute('aria-describedby')).to.equal(tooltip.id);
+
+        tooltip.hidden = true;
+        await flush();
+        expect(target.hasAttribute('aria-describedby')).to.be.false;
+
+        tooltip.hidden = false;
+        await flush();
+        expect(target.getAttribute('aria-describedby')).to.equal(tooltip.id);
+      });
+
+      test('a trigger that is no longer the target stops referencing the tooltip', async () => {
+        const { target, tooltip } = await triggerFixture();
+        expect(target.getAttribute('aria-describedby')).to.equal(tooltip.id);
+
+        target.remove();
+        tooltip._syncTooltipDescription();
+        expect(target.hasAttribute('aria-describedby')).to.be.false;
+      });
+
+      test('an empty tooltip does not describe its trigger', async () => {
+        const host = await fixture(html`
+          <div>
+            <span id="described-target">Target</span>
+            <nuxeo-tooltip for="described-target"></nuxeo-tooltip>
+          </div>
+        `);
+        expect(host.querySelector('#described-target').hasAttribute('aria-describedby')).to.be.false;
+      });
+
+      test('no description is wired across a shadow boundary, where the id cannot resolve', async () => {
+        if (!customElements.get('nuxeo-tooltip-aria-host-fixture')) {
+          customElements.define(
+            'nuxeo-tooltip-aria-host-fixture',
+            class extends HTMLElement {
+              connectedCallback() {
+                this.attachShadow({ mode: 'open' });
+                this.shadowRoot.innerHTML = '<nuxeo-tooltip>Shadow tip</nuxeo-tooltip>';
+              }
+            },
+          );
+        }
+        const host = await fixture(
+          html`
+            <nuxeo-tooltip-aria-host-fixture></nuxeo-tooltip-aria-host-fixture>
+          `,
+        );
+        await flush();
+        const tooltip = host.shadowRoot.querySelector('nuxeo-tooltip');
+        expect(tooltip.target).to.equal(host);
+        expect(host.hasAttribute('aria-describedby')).to.be.false;
+      });
+
+      test('the rendered clone is hidden from assistive technologies', async () => {
+        const { target, tooltip } = await triggerFixture();
+        enter(target);
+        await flush();
+        expect(tooltip._tooltip.getAttribute('aria-hidden')).to.equal('true');
+        expect(tooltip._tooltip.getAttribute('role')).to.equal('tooltip');
+      });
+    });
   });
 });

--- a/ui/widgets/nuxeo-tooltip-a11y-behavior.js
+++ b/ui/widgets/nuxeo-tooltip-a11y-behavior.js
@@ -1,0 +1,340 @@
+/**
+@license
+©2026 Hyland Software, Inc. and its affiliates. All rights reserved.
+All Hyland product names are registered or unregistered trademarks of Hyland Software, Inc. or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import '@nuxeo/nuxeo-elements/nuxeo-element.js';
+
+/** Keys that dismiss hover/focus content, per the WAI-ARIA tooltip pattern. */
+export const TOOLTIP_DISMISS_KEYS = ['Escape', 'Esc'];
+
+/**
+ * Grace period (ms) between the pointer leaving the trigger and the tooltip being torn down.
+ * It has to outlast the pointer crossing the `offset` gap between trigger and bubble.
+ */
+export const TOOLTIP_POINTER_LEAVE_DELAY_MS = 300;
+
+let idSequence = 0;
+
+/** Collapses whitespace so a tooltip label can be compared with an accessible name. */
+function normalizeText(value) {
+  return (value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * The tooltips that currently have something rendered, and the single `keydown` listener that
+ * dismisses them. A screen can hold a hundred `nuxeo-tooltip` instances, so they share one
+ * listener, and it is only on the window while there is actually something to dismiss.
+ */
+const renderedTooltips = new Set();
+let dismissKeyListener = null;
+
+function onDismissKey(event) {
+  if (!TOOLTIP_DISMISS_KEYS.includes(event.key)) {
+    return;
+  }
+  // The event is neither cancelled nor stopped: dialogs and dropdowns keep their own Escape
+  // handling, the tooltips simply get out of the way first.
+  Array.from(renderedTooltips).forEach((tooltip) => tooltip._dismissTooltip());
+}
+
+function registerRenderedTooltip(tooltip) {
+  renderedTooltips.add(tooltip);
+  if (!dismissKeyListener) {
+    dismissKeyListener = onDismissKey;
+    // Capture phase on `window`: the earliest point in the propagation path, so a consumer that
+    // stops keydown propagation cannot silently disable the only way to dismiss the tooltip.
+    window.addEventListener('keydown', dismissKeyListener, true);
+  }
+}
+
+function unregisterRenderedTooltip(tooltip) {
+  renderedTooltips.delete(tooltip);
+  if (dismissKeyListener && renderedTooltips.size === 0) {
+    window.removeEventListener('keydown', dismissKeyListener, true);
+    dismissKeyListener = null;
+  }
+}
+
+/**
+ * WCAG 2.1 AA 1.4.13 "Content on Hover or Focus" support for a tooltip host, plus the ARIA
+ * wiring assistive technologies need. Designed for `nuxeo-tooltip`, which renders its content
+ * in a `paper-tooltip` clone attached to `document.body`. This behavior is private to
+ * `nuxeo-tooltip`; it is exported only for that component's module import.
+ *
+ * The host must provide `show()`, `hide()` and a `target` getter; this behavior owns:
+ *
+ * - **Dismissible** — a shared `window` **capture** phase keydown listener hides the tooltip on
+ *   Escape. Capture is required: ancestors routinely stop keydown propagation before it bubbles back
+ *   up to `window` (`IronMenuBehavior._onKeydown` does it for every key in the `paper-listbox` that
+ *   holds the Web UI navigation menu, and `custom-date-picker` does it while its calendar is open).
+ *   Dismissal is latched so the tooltip cannot re-appear until hover or focus really moves away.
+ * - **Hoverable** — the pointer leaving the trigger schedules the teardown instead of performing it,
+ *   and the rendered bubble keeps itself alive while the pointer is over it.
+ * - **Persistent** — only Escape dismisses; unrelated keystrokes leave the tooltip alone and no
+ *   timer ever hides it on its own.
+ * - **Accessible description** — the host gets `role="tooltip"` and an id, the trigger gets
+ *   `aria-describedby`, and the rendered clone is hidden from assistive technologies so the text is
+ *   announced once, from the trigger.
+ *
+ * @polymerBehavior
+ */
+export const TooltipA11yBehavior = {
+  properties: {
+    /**
+     * How long (ms) the tooltip survives after the pointer leaves the trigger, so the pointer can
+     * travel across the `offset` gap and onto the tooltip itself (WCAG 1.4.13 hoverable).
+     */
+    pointerLeaveDelay: {
+      type: Number,
+      value: TOOLTIP_POINTER_LEAVE_DELAY_MS,
+    },
+  },
+
+  attached() {
+    this._armTooltipA11y();
+  },
+
+  detached() {
+    this._disarmTooltipA11y();
+  },
+
+  /** Gives the tooltip its ARIA identity and starts describing the trigger. */
+  _armTooltipA11y() {
+    if (this._tooltipA11yArmed) {
+      return;
+    }
+    this._tooltipA11yArmed = true;
+    this._tooltipDismissed = false;
+    this._pointerOverTooltip = false;
+    this.setAttribute('role', 'tooltip');
+    if (!this.id) {
+      idSequence += 1;
+      this.id = `nuxeo-tooltip-${idSequence}`;
+    }
+    // A tooltip bound with `hidden$="..."` (`nuxeo-date` does this) can become relevant long after
+    // it was attached, and a screen reader user may never hover or focus the trigger, so the
+    // description has to follow `hidden` on its own rather than waiting for `show()`.
+    this._tooltipHiddenObserver = new MutationObserver(() => this._syncTooltipDescription());
+    this._tooltipHiddenObserver.observe(this, { attributes: true, attributeFilter: ['hidden'] });
+    this._syncTooltipDescription();
+  },
+
+  /** Undoes everything `_armTooltipA11y` set up. */
+  _disarmTooltipA11y() {
+    if (!this._tooltipA11yArmed) {
+      return;
+    }
+    this._tooltipA11yArmed = false;
+    this._onTooltipTornDown();
+    if (this._tooltipHiddenObserver) {
+      this._tooltipHiddenObserver.disconnect();
+      this._tooltipHiddenObserver = null;
+    }
+    this._removeTooltipDescription();
+    this._tooltipDismissed = false;
+  },
+
+  /**
+   * Points the trigger's `aria-describedby` at this tooltip.
+   *
+   * The host stays `display: none`; the accessible name and description computation deliberately
+   * includes hidden nodes that are directly referenced by `aria-describedby`, so the text is
+   * available to assistive technologies without ever being rendered or read out of context.
+   */
+  _syncTooltipDescription() {
+    const target = this.target;
+    // Whatever the outcome, a trigger this tooltip no longer describes must not keep a dangling
+    // reference to its id — the target changes whenever `for` changes or the tooltip is moved.
+    if (!this._canDescribe(target)) {
+      this._removeTooltipDescription();
+      return;
+    }
+    if (this._describedTarget === target) {
+      return;
+    }
+    this._removeTooltipDescription();
+    const tokens = (target.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean);
+    if (!tokens.includes(this.id)) {
+      this._previousDescribedBy = target.getAttribute('aria-describedby');
+      tokens.push(this.id);
+      target.setAttribute('aria-describedby', tokens.join(' '));
+      this._describedTarget = target;
+    }
+  },
+
+  /** Whether `target` should carry an `aria-describedby` pointing at this tooltip. */
+  _canDescribe(target) {
+    if (!target) {
+      return false;
+    }
+    if (!target.setAttribute) {
+      return false;
+    }
+    // A hidden tooltip has nothing to say, so it must not describe its trigger either.
+    if (this.hidden) {
+      return false;
+    }
+    // aria-describedby cannot cross a shadow boundary: the id has to resolve in the trigger's tree.
+    if (target.getRootNode() !== this.getRootNode()) {
+      return false;
+    }
+    return !this._isDescriptionRedundant(target);
+  },
+
+  /** Restores the trigger's original `aria-describedby`. */
+  _removeTooltipDescription() {
+    const target = this._describedTarget;
+    this._describedTarget = null;
+    if (!target) {
+      return;
+    }
+    if (!target.setAttribute) {
+      return;
+    }
+    if (this._previousDescribedBy !== null) {
+      target.setAttribute('aria-describedby', this._previousDescribedBy);
+    } else {
+      target.removeAttribute('aria-describedby');
+    }
+    this._previousDescribedBy = null;
+  },
+
+  /**
+   * True when the trigger already conveys the tooltip text through its own accessible name, in
+   * which case describing it again only makes screen readers repeat themselves. Web UI commonly
+   * labels icon buttons with `aria-labelledby` pointing straight at their `nuxeo-tooltip`.
+   */
+  _isDescriptionRedundant(target) {
+    const text = normalizeText(this.textContent);
+    if (!text) {
+      return true;
+    }
+    const root = target.getRootNode();
+    const labelledBy = (target.getAttribute('aria-labelledby') || '').split(/\s+/).filter(Boolean);
+    if (labelledBy.includes(this.id)) {
+      return true;
+    }
+    const names = [target.getAttribute('aria-label'), target.getAttribute('title')];
+    labelledBy.forEach((id) => {
+      const labelNode = root.getElementById ? root.getElementById(id) : null;
+      if (labelNode) {
+        names.push(labelNode.textContent);
+      }
+    });
+    return names.some((name) => normalizeText(name) === text);
+  },
+
+  /** Whether the tooltip was dismissed and must stay hidden until hover or focus moves away. */
+  isTooltipDismissed() {
+    return !!this._tooltipDismissed;
+  },
+
+  /** Clears the dismissal latch, called when hover or focus actually leaves the trigger. */
+  _resetTooltipDismissal() {
+    this._tooltipDismissed = false;
+  },
+
+  /** Hides the tooltip and latches it dismissed (WCAG 1.4.13 dismissible). */
+  _dismissTooltip() {
+    if (!this._tooltip) {
+      return;
+    }
+    this._tooltipDismissed = true;
+    this.hide();
+  },
+
+  _onTooltipDismissKey(event) {
+    if (!event || !TOOLTIP_DISMISS_KEYS.includes(event.key)) {
+      return;
+    }
+    this._dismissTooltip();
+  },
+
+  _cancelTooltipHide() {
+    if (this._tooltipHideTimer) {
+      clearTimeout(this._tooltipHideTimer);
+      this._tooltipHideTimer = null;
+    }
+  },
+
+  /**
+   * Defers the teardown so the pointer can reach the bubble (WCAG 1.4.13 hoverable). Nothing here
+   * hides a tooltip the pointer is still over — that is the bubble's own `mouseleave`.
+   */
+  _scheduleTooltipHide() {
+    this._cancelTooltipHide();
+    const delay = this.pointerLeaveDelay;
+    if (!delay || delay <= 0) {
+      this.hide();
+      return;
+    }
+    this._tooltipHideTimer = setTimeout(() => {
+      this._tooltipHideTimer = null;
+      if (!this._pointerOverTooltip) {
+        this.hide();
+      }
+    }, delay);
+  },
+
+  /** Pointer left the trigger: keep the tooltip briefly and allow it to be shown again. */
+  _onTriggerPointerLeave() {
+    this._resetTooltipDismissal();
+    this._scheduleTooltipHide();
+  },
+
+  /** Focus left the trigger: tear down unless it only moved between trigger descendants. */
+  _onTriggerBlur(event) {
+    if (event?.relatedTarget && this._target?.contains(event.relatedTarget)) {
+      return;
+    }
+    this._resetTooltipDismissal();
+    this.hide();
+  },
+
+  /**
+   * Makes a freshly rendered `paper-tooltip` clone hoverable and invisible to assistive
+   * technologies (the trigger's `aria-describedby` already carries the text), and opts this
+   * tooltip into the shared dismissal listener for as long as the clone lives.
+   */
+  _prepareRenderedTooltip(renderedTooltip) {
+    renderedTooltip.setAttribute('aria-hidden', 'true');
+    this._pointerOverTooltip = false;
+    registerRenderedTooltip(this);
+    renderedTooltip.addEventListener('mouseenter', () => {
+      this._pointerOverTooltip = true;
+      this._cancelTooltipHide();
+    });
+    renderedTooltip.addEventListener('mouseleave', () => {
+      this._pointerOverTooltip = false;
+      this._scheduleTooltipHide();
+    });
+    // Do not let a hoverable bubble swallow a click meant for the content underneath.
+    renderedTooltip.addEventListener('mousedown', () => {
+      this._pointerOverTooltip = false;
+      this.hide();
+    });
+  },
+
+  /** Counterpart of `_prepareRenderedTooltip`, to be called whenever the clone goes away. */
+  _onTooltipTornDown() {
+    this._cancelTooltipHide();
+    this._pointerOverTooltip = false;
+    unregisterRenderedTooltip(this);
+  },
+};

--- a/ui/widgets/nuxeo-tooltip.js
+++ b/ui/widgets/nuxeo-tooltip.js
@@ -19,7 +19,9 @@ import '@nuxeo/nuxeo-elements/nuxeo-element.js';
 import '@polymer/paper-tooltip/paper-tooltip.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { microTask } from '@polymer/polymer/lib/utils/async.js';
+import { TooltipA11yBehavior } from './nuxeo-tooltip-a11y-behavior.js';
 
 const CLONED_CONTENT_STYLES_ID = 'nuxeo-tooltip-cloned-content-styles';
 
@@ -68,10 +70,17 @@ ensureClonedContentStyles();
    * set `data-nx-tooltip-role` on this element (copied onto the cloned root) and add matching
    * rules in the cloned-content stylesheet above (see `ensureClonedContentStyles`).
    *
+   * ### Accessibility
+   *
+   * The tooltip's private accessibility behavior provides the WCAG 2.1 AA 1.4.13 "Content on
+   * Hover or Focus" behavior — Escape dismisses the tooltip, the pointer can move onto the tooltip
+   * without it disappearing, and nothing else hides it — plus the `role="tooltip"` /
+   * `aria-describedby` wiring that exposes the text to assistive technologies.
+   *
    * @memberof Nuxeo
    * @demo demo/nuxeo-tooltip/index.html
    */
-  class Tooltip extends Nuxeo.Element {
+  class Tooltip extends mixinBehaviors([TooltipA11yBehavior], Nuxeo.Element) {
     static get template() {
       return html`
         <style>
@@ -116,7 +125,10 @@ ensureClonedContentStyles();
       // reference is used in addEventListener and removeEventListener (and prevent potential memory leaks)
       this._showListener = this.show.bind(this);
       this._hideListener = this.hide.bind(this);
-      this._keyListener = this.keydown.bind(this);
+      // WCAG 1.4.13: leaving the trigger with the pointer only *schedules* the teardown, so the
+      // pointer can still reach the tooltip; leaving it with the keyboard tears down at once.
+      this._pointerLeaveListener = this._onTriggerPointerLeave.bind(this);
+      this._focusOutListener = this._onTriggerBlur.bind(this);
     }
 
     connectedCallback() {
@@ -124,11 +136,10 @@ ensureClonedContentStyles();
       this._target = this.target;
       if (this._target) {
         this._target.addEventListener('mouseenter', this._showListener);
-        this._target.addEventListener('focus', this._showListener);
-        this._target.addEventListener('mouseleave', this._hideListener);
-        this._target.addEventListener('blur', this._hideListener);
+        this._target.addEventListener('focusin', this._showListener);
+        this._target.addEventListener('mouseleave', this._pointerLeaveListener);
+        this._target.addEventListener('focusout', this._focusOutListener);
         this._target.addEventListener('tap', this._hideListener);
-        window.addEventListener('keydown', this._keyListener);
       }
     }
 
@@ -137,16 +148,21 @@ ensureClonedContentStyles();
       if (this._target) {
         this.hide();
         this._target.removeEventListener('mouseenter', this._showListener);
-        this._target.removeEventListener('focus', this._showListener);
-        this._target.removeEventListener('mouseleave', this._hideListener);
-        this._target.removeEventListener('blur', this._hideListener);
+        this._target.removeEventListener('focusin', this._showListener);
+        this._target.removeEventListener('mouseleave', this._pointerLeaveListener);
+        this._target.removeEventListener('focusout', this._focusOutListener);
         this._target.removeEventListener('tap', this._hideListener);
-        window.removeEventListener('keydown', this._keyListener);
       }
       this._target = null;
     }
 
     show() {
+      // Re-entering the trigger during the pointer grace period keeps the existing tooltip.
+      this._cancelTooltipHide();
+      if (this.isTooltipDismissed()) {
+        return;
+      }
+      this._syncTooltipDescription();
       if (!this._tooltip && !this.hidden) {
         // create a paper tooltip and append to body
         this._tooltip = document.createElement('paper-tooltip');
@@ -168,6 +184,7 @@ ensureClonedContentStyles();
         this._tooltip.offset = this.offset;
         this._tooltip.position = this.position;
         this._tooltip.fitToVisibleBounds = true;
+        this._prepareRenderedTooltip(this._tooltip);
         microTask.run(() => {
           // hide() may have nulled this._tooltip between scheduling and execution
           // (e.g., focus + immediate disconnect during a pointer interaction).
@@ -179,6 +196,7 @@ ensureClonedContentStyles();
     }
 
     hide() {
+      this._onTooltipTornDown();
       if (this._tooltip) {
         this._tooltip.hide();
         this._tooltip.remove();
@@ -202,8 +220,21 @@ ensureClonedContentStyles();
       }
     }
 
-    keydown() {
-      this.hide();
+    /**
+     * Dismisses the tooltip for a keyboard event.
+     *
+     * Only the dismissal keys act on it: WCAG 1.4.13 requires hover/focus content to stay visible
+     * until its trigger moves away or the user dismisses it, so an unrelated keystroke must not
+     * destroy it. Called without an event it dismisses unconditionally.
+     *
+     * @param {KeyboardEvent} [event]
+     */
+    keydown(event) {
+      if (!event) {
+        this._dismissTooltip();
+        return;
+      }
+      this._onTooltipDismissKey(event);
     }
 
     /**


### PR DESCRIPTION
JIRA: [ELEMENTS-2054](https://hyland.atlassian.net/browse/ELEMENTS-2054)

## Problem

`nuxeo-tooltip` does not comply with [WCAG 2.1 AA 1.4.13 "Content on Hover or Focus"](https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus), and its content is not exposed to assistive technologies. QA re-confirmed it in June 2026 with a code view and a screen-reader view.

All three 1.4.13 requirements failed:

| Requirement | Behaviour before |
|---|---|
| **Dismissible** | Escape only worked when nothing in the ancestor chain stopped `keydown` propagation — inside the navigation menu (`paper-listbox` → `IronMenuBehavior._onKeydown` stops *every* keydown) or while `custom-date-picker`'s calendar is open, the tooltip could not be dismissed at all. |
| **Hoverable** | The pointer could never reach the tooltip: it is rendered `offset` px away from the trigger and `mouseleave` on the trigger destroyed it synchronously. |
| **Persistent** | *Any* keystroke destroyed the tooltip, not just a dismissal key. |
| **Screen readers** | The `<nuxeo-tooltip>` host is `display: none` (so it is out of the accessibility tree) and the rendered `paper-tooltip` is a `role="tooltip"` clone orphaned on `document.body` with no relationship to the trigger — so the text was either never announced, or announced out of context. |

## Root cause

`ui/widgets/nuxeo-tooltip.js` delegates rendering to `paper-tooltip`, which is not 1.4.13-compliant itself, and the wrapper's own listeners reproduced the same gaps:

- `connectedCallback()` registered `window.addEventListener('keydown', this._keyListener)` — **bubble phase**, i.e. the very last point of the propagation path, so any ancestor calling `stopPropagation()` silently disabled the only way to dismiss the tooltip. Nothing latched the dismissal either, so a re-fired `mouseenter` (which the browser sends whenever the pointer moves inside the trigger) brought the tooltip straight back.
- `mouseleave` on the trigger was bound directly to `hide()`, tearing the bubble down before the pointer could cross the `offset` gap onto it.
- `keydown()` called `hide()` unconditionally, for every key.
- Nothing ever set `role`/`id` on the host or `aria-describedby` on the trigger, and the body-level clone kept `paper-tooltip`'s `role="tooltip"` while being unreachable by assistive technologies.

## Changes

New Polymer behavior **`ui/widgets/nuxeo-tooltip-a11y-behavior.js`** (`Nuxeo.TooltipA11yBehavior`), mixed into the element with `mixinBehaviors`. It owns all the cross-cutting state, constants, lifecycle wiring (`attached`/`detached`) and listeners, so the element stays a thin `paper-tooltip` wrapper:

- **Dismissible** — Escape (`Escape`/`Esc`) is handled by a `window` listener in the **capture** phase, the earliest point of the propagation path, so a consumer that stops `keydown` propagation cannot disable it. The event is neither cancelled nor stopped, so dialogs and dropdowns keep their own Escape handling; the tooltip just gets out of the way first. The dismissal is **latched** until hover or focus really leaves the trigger, so it cannot pop back on the next `mouseenter`.
- **Hoverable** — the pointer leaving the trigger *schedules* the teardown (300 ms grace, `pointerLeaveDelay`) instead of performing it, and the rendered bubble cancels that teardown while the pointer is over it. Moving off the bubble schedules it again; `mousedown` on the bubble hides it immediately so it can never swallow a click meant for the content underneath.
- **Persistent** — only the dismissal keys act; no timer ever hides the tooltip on its own.
- **Screen readers** — the host gets `role="tooltip"` and a generated id, the trigger gets `aria-describedby` pointing at it, and the rendered clone gets `aria-hidden="true"` so the text is announced exactly once, from the trigger. The description is skipped when it would be redundant or invalid: when the trigger's own accessible name (`aria-label`, `title`, `aria-labelledby`) already carries the same text — Web UI commonly labels icon buttons with `aria-labelledby` pointing straight at their `nuxeo-tooltip` — when the tooltip is `hidden`, and when the trigger lives in a different shadow root (an id reference cannot cross a shadow boundary). Any pre-existing `aria-describedby` on the trigger is appended to and restored on detach.

`keydown()` stays public and backwards-compatible: it now takes the event and only acts on a dismissal key, and called without an event it still dismisses unconditionally.

## Test plan

- `ui/test/nuxeo-tooltip.test.js` extended with a `WCAG 1.4.13 content on hover or focus` suite covering dismissible (plain Escape, Escape while an ancestor stops propagation, the single shared listener, the dismissal latch, re-showing after hover/focus really leaves, `keydown()` back-compat), hoverable (deferred teardown, pointer over the bubble keeps it, leaving the bubble hides it, re-entering the trigger during the grace period), persistent (unrelated keystroke, no auto-hide) and the ARIA wiring (role/id, `aria-describedby` add + append + restore, redundancy via `aria-label`/`title`/`aria-labelledby`, hidden toggled after attach, target released, cross-shadow-root, `aria-hidden` on the clone).
- `nuxeo-elements`: `npm run lint` clean, `ui` suite **3742 passed / 0 failed**.
- `nuxeo-web-ui` (symlinked against this branch): lint clean, **2305 passed / 0 failed** — no consumer regressions.
- Manual/automated verification in Web UI against a live server with Puppeteer DOM probes (visibility + `role`/`aria-describedby`/`aria-hidden`) before and after each interaction. All 10 probes flipped from FAIL to PASS.
- Consumer sweep over document view, workspace content table (row actions + selection toolbar), search results, personal space, trash, admin → vocabularies and admin → users: every tooltip still shows on hover and hides on leave, positioning unchanged, `role`+id wired on all of them (49–89 per screen), and **0** orphaned `paper-tooltip` nodes left on `document.body`.

## Notes

- Backport of the same commit onto `maintenance-3.1.x`: see the companion PR.
- `paper-tooltip` is unchanged; all compliance now lives in the wrapper, so no upstream Polymer work is needed.
