### PR TITLE
WEBUI-2148: show image viewer toolbar labels on keyboard focus

### DIFF
--- a/ui/test/nuxeo-image-viewer.test.js
+++ b/ui/test/nuxeo-image-viewer.test.js
@@ -227,6 +227,92 @@ suite('nuxeo-image-viewer', () => {
           expect(rotateRightOption.icon).to.equal('image:rotate-right');
         });
       });
+
+      /**
+       * WEBUI-2148: the toolbar is icon-only, so each button must expose an accessible name for
+       * screen readers *and* reveal a visible label to a sighted keyboard-only user. A native
+       * `title` only ever appears on pointer hover, so the label is carried by <nuxeo-tooltip>,
+       * which also opens on `focus`.
+       */
+      suite('Accessible labelling', () => {
+        let viewer;
+        let toolbar;
+        const buttons = () => Array.from(toolbar.querySelectorAll('paper-icon-button'));
+        const tooltips = () => Array.from(toolbar.querySelectorAll('nuxeo-tooltip'));
+
+        setup(async () => {
+          viewer = await fixture(
+            html`
+              <nuxeo-image-viewer src="${base}/resources/sample.png" controls></nuxeo-image-viewer>
+            `,
+          );
+          await viewerLoad(viewer);
+          toolbar = viewer.$$('#toolbar');
+        });
+
+        test('Should give every toolbar button a non-empty aria-label', () => {
+          buttons().forEach((button) => {
+            expect(
+              button.getAttribute('aria-label'),
+              `missing aria-label on ${button.getAttribute('data-action')}`,
+            ).to.be.a('string').and.not.to.be.empty;
+          });
+        });
+
+        test('Should not rely on a hover-only title attribute', () => {
+          buttons().forEach((button) => {
+            expect(button.hasAttribute('title'), `unexpected title on ${button.getAttribute('data-action')}`).to.be
+              .false;
+          });
+        });
+
+        test('Should anchor a nuxeo-tooltip to each toolbar button', () => {
+          const allButtons = buttons();
+          expect(tooltips()).to.have.lengthOf(allButtons.length);
+          allButtons.forEach((button) => {
+            expect(button.id, 'toolbar buttons need an id so a tooltip can target them').to.not.be.empty;
+            const tooltip = tooltips().find((t) => t.getAttribute('for') === button.id);
+            expect(tooltip, `no nuxeo-tooltip for #${button.id}`).to.exist;
+            // Targeting the button itself (not a wrapper) is what makes the tooltip open on focus,
+            // since `focus` does not bubble.
+            expect(tooltip.target).to.equal(button);
+          });
+        });
+
+        test('Should show the tooltip when a toolbar button receives keyboard focus', async () => {
+          const zoomIn = toolbar.querySelector('paper-icon-button[data-action="zoom-in"]');
+          const tooltip = toolbar.querySelector('nuxeo-tooltip[for="zoomIn"]');
+          expect(tooltip.isShowing()).to.be.false;
+          zoomIn.focus();
+          flush();
+          await timePasses(1);
+          expect(tooltip.isShowing()).to.be.true;
+          tooltip.hide();
+        });
+
+        test('Should keep the tooltip on the fit button after the fit-to-viewer dom-if swap', async () => {
+          // Applying zoom swaps the second button from fit-to-real-size to fit-to-viewer. The
+          // replacement is stamped by a different <dom-if>, so its tooltip has to re-resolve its
+          // target — that is the path most likely to silently lose the label.
+          viewer.setProperties({ _fitToRealSize: true });
+          viewer.shadowRoot.querySelectorAll('dom-if').forEach((domIf) => domIf.render && domIf.render());
+          flush();
+
+          const fitToViewer = toolbar.querySelector('paper-icon-button[data-action="fit-to-viewer"]');
+          const tooltip = toolbar.querySelector('nuxeo-tooltip[for="fitToViewer"]');
+          expect(fitToViewer).to.exist;
+          expect(tooltip, 'no nuxeo-tooltip for the swapped-in fit-to-viewer button').to.exist;
+          expect(tooltip.target).to.equal(fitToViewer);
+          expect(fitToViewer.hasAttribute('title')).to.be.false;
+
+          expect(tooltip.isShowing()).to.be.false;
+          fitToViewer.focus();
+          flush();
+          await timePasses(1);
+          expect(tooltip.isShowing()).to.be.true;
+          tooltip.hide();
+        });
+      });
     });
   });
 

--- a/ui/viewers/nuxeo-image-viewer.js
+++ b/ui/viewers/nuxeo-image-viewer.js
@@ -26,6 +26,7 @@ import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import Cropper from 'cropperjs/dist/cropper.esm.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import '../nuxeo-icons.js';
+import '../widgets/nuxeo-tooltip.js';
 
 {
   /**
@@ -163,65 +164,75 @@ import '../nuxeo-icons.js';
             <template>
               <div id="toolbar">
                 <paper-icon-button
+                  id="zoomOut"
                   on-click="_click"
                   icon="zoom-out"
                   alt=""
                   data-action="zoom-out"
                   aria-label$="[[i18n('imagePreviewer.zoom.out')]]"
-                  title$="[[i18n('imagePreviewer.zoom.out')]]"
                 ></paper-icon-button>
+                <nuxeo-tooltip for="zoomOut" position="top">[[i18n('imagePreviewer.zoom.out')]]</nuxeo-tooltip>
                 <dom-if if="[[!_fitToRealSize]]">
                   <template>
                     <paper-icon-button
+                      id="fitToRealSize"
                       on-click="_click"
                       icon="nuxeo:fit-to-real-size"
                       alt=""
                       data-action="fit-to-real-size"
                       aria-label$="[[i18n('imagePreviewer.fitToRealSize')]]"
-                      title$="[[i18n('imagePreviewer.fitToRealSize')]]"
                     >
                     </paper-icon-button>
+                    <nuxeo-tooltip for="fitToRealSize" position="top">
+                      [[i18n('imagePreviewer.fitToRealSize')]]
+                    </nuxeo-tooltip>
                   </template>
                 </dom-if>
                 <dom-if if="[[_fitToRealSize]]">
                   <template>
                     <paper-icon-button
+                      id="fitToViewer"
                       on-click="_click"
                       icon="nuxeo:fit-to-viewer"
                       alt=""
                       data-action="fit-to-viewer"
                       aria-label$="[[i18n('imagePreviewer.fitToViewer')]]"
-                      title$="[[i18n('imagePreviewer.fitToViewer')]]"
                     >
                     </paper-icon-button>
+                    <nuxeo-tooltip for="fitToViewer" position="top">
+                      [[i18n('imagePreviewer.fitToViewer')]]
+                    </nuxeo-tooltip>
                   </template>
                 </dom-if>
                 <paper-icon-button
+                  id="zoomIn"
                   on-click="_click"
                   icon="zoom-in"
                   alt=""
                   data-action="zoom-in"
                   aria-label$="[[i18n('imagePreviewer.zoom.in')]]"
-                  title$="[[i18n('imagePreviewer.zoom.in')]]"
                 ></paper-icon-button>
+                <nuxeo-tooltip for="zoomIn" position="top">[[i18n('imagePreviewer.zoom.in')]]</nuxeo-tooltip>
                 <paper-icon-button
+                  id="rotateLeft"
                   on-click="_click"
                   icon="image:rotate-left"
                   alt=""
                   data-action="rotate-left"
                   aria-label$="[[i18n('imagePreviewer.rotate.left')]]"
-                  title$="[[i18n('imagePreviewer.rotate.left')]]"
                 >
                 </paper-icon-button>
+                <nuxeo-tooltip for="rotateLeft" position="top">[[i18n('imagePreviewer.rotate.left')]]</nuxeo-tooltip>
                 <paper-icon-button
+                  id="rotateRight"
                   on-click="_click"
                   icon="image:rotate-right"
                   alt=""
                   data-action="rotate-right"
                   aria-label$="[[i18n('imagePreviewer.rotate.right')]]"
-                  title$="[[i18n('imagePreviewer.rotate.right')]]"
                 >
                 </paper-icon-button>
+                <nuxeo-tooltip for="rotateRight" position="top">[[i18n('imagePreviewer.rotate.right')]]</nuxeo-tooltip>
               </div>
             </template>
           </dom-if>


### PR DESCRIPTION
## Problem

[WEBUI-2148](https://hyland.atlassian.net/browse/WEBUI-2148) reports that the icon-only controls across all four integrated viewers lack visible text labels or confirmed accessible names.

An audit of every control the ticket lists (computed accessible names taken from CDP `Accessibility.queryAXTree` in the running app, not from grepping for `aria-label`) found that the screen-reader half of the report is already satisfied everywhere — the ticket itself notes "the screen reader correctly reads the elements". What is genuinely broken, and genuinely ours, is the ticket's second scenario:

> The core issue is visual accessibility for sighted keyboard-only users. When a user moves the focus with the Tab key, they cannot see what the button does because the tooltips only trigger on mouse hover events.

On the image viewer toolbar the visible label came from a native `title` attribute. No browser surfaces `title` on keyboard focus, so tabbing along the toolbar showed nothing at all.

## Root cause

`nuxeo-image-viewer` set both `aria-label$=` and `title$=` on each `paper-icon-button`. `aria-label` gives screen readers a correct name, but `title` is pointer-hover only, so there was no visible label for a sighted keyboard user.

## Changes

`ui/viewers/nuxeo-image-viewer.js` only:

- Drop the `title$=` attributes and render a `<nuxeo-tooltip>` per toolbar button instead. `nuxeo-tooltip` opens on `focus` as well as `mouseenter`, so the label now appears for pointer *and* keyboard users.
- Give each button an `id` and anchor its tooltip with `for=`. Anchoring to the button itself rather than to a wrapper is load-bearing: `focus` does not bubble, so a container-bound tooltip never sees focus landing on a descendant.
- `aria-label` is untouched — screen-reader naming was already correct and stays exactly as it was.

Both `dom-if` branches (`fit-to-real-size` / `fit-to-viewer`) get the same treatment, so the label survives the toolbar swap when the zoom level changes.

Four unit tests cover it: every button has a non-empty `aria-label`; no button carries a `title`; each button has a `nuxeo-tooltip` resolving to it; and focusing a button shows its tooltip.

## What is deliberately *not* changed

- **PDF / Word viewer toolbar** — `nuxeo-pdf-viewer` contributes only an `<iframe>`; the toolbar is vendored third-party pdf.js in a separate document (`sameDocumentAsElement: false`). We cannot label it from here, and all nine listed controls are already named by pdf.js (`Toggle Sidebar`, `Find`, `Previous`, `Next`, `Page`, `Zoom Out`, `Zoom In`, `Zoom`, `Tools`). Word documents preview through the same pdf.js path.
- **Video player** — `nuxeo-video-viewer` renders a native `<video controls>`. The transport controls are browser UI we neither render nor can label, and Chrome already names them (`play`, `mute`, `enter full screen`, `show more media controls`).
- **Shared action row** (preview / download / replace / remove) — all named correctly for screen readers, but they *do* fail the keyboard-visible-label scenario. Their tooltips bind to a non-focusable `<div class="action" role="presentation">` wrapper, and `focus` does not bubble. The one-line fix is `focus`/`blur` → `focusin`/`focusout` in `nuxeo-tooltip.js`, verified at runtime. That file is being rewritten right now by WEBUI-504 (#1552 / #1553), so it is left to that ticket rather than conflicting with two open PRs. Full detail is in the audit on the Jira ticket.

## Test plan

- `npm run lint` — clean.
- `npm run test:ui` — 3712 passed, 0 failed, 2 skipped.
- Verified in a running Web UI against a real Nuxeo instance, with CDP accessible-name probes before and after:
  - All five rendered toolbar buttons are reachable by real sequential Tab from the top of the page, in visual order, each with a correct computed name.
  - Before: visible tooltip on focus for 0 of 5 buttons. After: 5 of 5, plus `fit-to-viewer` after the `dom-if` swap.
  - Regression sweep, byte-identical cropper state before and after the change: zoom in, zoom out, rotate left, rotate right, fit-to-real-size and fit-to-viewer all still transform the image as before.
  - PDF viewer still renders (14 pages), next/previous page, find bar and zoom all still work. Video viewer still renders with native controls.

## Notes

- Backport to `maintenance-3.1.x`: #1569
- This is elements-only — `nuxeo-web-ui` contributes no viewer labels, only slot wiring, so it needs no companion PR.

Made with [Cursor](https://cursor.com)