### PR TITLE
WEBUI-2151: Make the rich text editor's image picker usable from the keyboard [lts-2025]

### DIFF
--- a/ui/i18n/messages.json
+++ b/ui/i18n/messages.json
@@ -139,6 +139,7 @@
   "documentDistributionChart.size": "Size",
   "documentLayout.notFound": "Failed to find {0} layout for {1}.",
   "documentPage.resize.side": "Resize the information pane. Use Left/Right arrow keys to adjust width, Home or End for minimum or maximum, Enter or Space to reset.",
+  "documentPicker.dialog": "Select documents",
   "documentPermissions.block": "Block",
   "documentPermissions.block.ariaLabel": "Block permissions inherited from upper levels",
   "documentPermissions.blockDescription": "If you want to explicitly control the access to this document you can block the permissions inheritance. Any change made on parent document will not affect the access conditions to this document. You and the administrators will be added to local permissions.",

--- a/ui/nuxeo-document-picker/nuxeo-document-picker.js
+++ b/ui/nuxeo-document-picker/nuxeo-document-picker.js
@@ -16,6 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 import '@nuxeo/nuxeo-elements/nuxeo-element.js';
@@ -76,7 +77,13 @@ import '@polymer/paper-icon-button/paper-icon-button.js';
             );
           }
         </style>
-        <nuxeo-dialog id="dialog" modal>
+        <nuxeo-dialog
+          id="dialog"
+          modal
+          restore-focus-on-close
+          aria-label$="[[_dialogLabel(dialogLabel, i18n)]]"
+          on-iron-overlay-opened="_onDialogOpened"
+        >
           <div id="topContainer">
             <paper-icon-button
               aria-label$="[[i18n('command.close')]]"
@@ -103,13 +110,20 @@ import '@polymer/paper-icon-button/paper-icon-button.js';
               opened
               on-navigate="_onNavigate"
               on-results-changed="_onResultsChanged"
+              on-search-form-layout-changed="_onSearchFormLoaded"
             ></nuxeo-results-view>
           </div>
           <div class="buttons">
             <paper-button noink class="secondary" dialog-dismiss id="cancelButton">
               [[i18n('command.cancel')]]
             </paper-button>
-            <paper-button noink class="primary" on-tap="_onSelect" id="selectButton">
+            <paper-button
+              noink
+              class="primary"
+              on-tap="_onSelect"
+              id="selectButton"
+              aria-keyshortcuts="Control+Enter Meta+Enter"
+            >
               [[i18n('command.select')]]
             </paper-button>
           </div>
@@ -123,6 +137,11 @@ import '@polymer/paper-icon-button/paper-icon-button.js';
 
     static get properties() {
       return {
+        /**
+         * Accessible name of the picker dialog. The same picker is opened for different purposes,
+         * so the name follows the caller; it falls back to a generic one.
+         */
+        dialogLabel: String,
         /**
          * List of content enrichers passed on to `provider`.
          */
@@ -173,8 +192,23 @@ import '@polymer/paper-icon-button/paper-icon-button.js';
       };
     }
 
+    ready() {
+      super.ready();
+      this._boundDialogKeydown = this._onDialogKeydown.bind(this);
+      this._listenForShortcut();
+    }
+
+    connectedCallback() {
+      super.connectedCallback();
+      // Runs before ready() on the first connection, when there is nothing to listen on yet.
+      this._listenForShortcut();
+    }
+
     disconnectedCallback() {
       super.disconnectedCallback();
+      if (this._boundDialogKeydown) {
+        this.$.dialog.removeEventListener('keydown', this._boundDialogKeydown, true);
+      }
       if (this._listenedResults && this._boundUpdateFn) {
         this._listenedResults.removeEventListener('selected-items-changed', this._boundUpdateFn);
       }
@@ -186,11 +220,73 @@ import '@polymer/paper-icon-button/paper-icon-button.js';
         this.$.resultsView._clear();
       }
       this._updateSelectButton();
+      // `modal` is what enables nuxeo-dialog's focus trap, but paper-dialog-behavior also derives
+      // noCancelOnEscKey from it, so Escape is swallowed and a keyboard user has no way out of the
+      // picker other than tabbing through every result. Cancelling still goes through close(), so
+      // restore-focus-on-close hands focus back to whatever opened the picker.
+      this.$.dialog.noCancelOnEscKey = false;
+      this._focusPending = true;
       this.$.dialog.open();
     }
 
     close() {
       this.$.dialog.close();
+    }
+
+    _dialogLabel(dialogLabel) {
+      return dialogLabel || this.i18n('documentPicker.dialog');
+    }
+
+    _listenForShortcut() {
+      if (!this._boundDialogKeydown) {
+        return;
+      }
+      // Capture phase, so the search field does not run a search for the same key press.
+      this.$.dialog.addEventListener('keydown', this._boundDialogKeydown, true);
+    }
+
+    /**
+     * Confirms the selection with Ctrl/Cmd+Enter, the same shortcut the comment editor uses to
+     * submit. The Select button is the last thing in the dialog's tab sequence, behind every
+     * result and each of its actions, so without a shortcut confirming a pick can take dozens of
+     * Tab presses on a full page of results.
+     */
+    _onDialogKeydown(e) {
+      if (e.key !== 'Enter' || !(e.ctrlKey || e.metaKey) || this.$.selectButton.disabled || !this.$.dialog.opened) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      this._onSelect();
+    }
+
+    _onDialogOpened(e) {
+      // Overlays nested in the search form bubble the same event.
+      if (e.target === this.$.dialog) {
+        afterNextRender(this, () => this._focusSearchField());
+      }
+    }
+
+    _onSearchFormLoaded() {
+      // The search layout is fetched lazily, so on the first open it is stamped after the dialog.
+      afterNextRender(this, () => this._focusSearchField());
+    }
+
+    /**
+     * Moves focus to the search field once the picker is up. Without this focus stays on the dialog
+     * container, which draws no focus ring, so a keyboard user is given no starting point.
+     */
+    _focusSearchField() {
+      if (!this._focusPending || !this.$.dialog.opened) {
+        return;
+      }
+      const { form } = this.$.resultsView;
+      const shadowRoot = form ? form.shadowRoot : null;
+      const field = shadowRoot ? shadowRoot.querySelector('[autofocus]') : null;
+      if (field && typeof field.focus === 'function') {
+        this._focusPending = false;
+        field.focus();
+      }
     }
 
     get _selectedItems() {

--- a/ui/test/nuxeo-document-picker.test.js
+++ b/ui/test/nuxeo-document-picker.test.js
@@ -34,6 +34,7 @@ window.nuxeo.I18n.en['command.cancel'] = 'Cancel';
 window.nuxeo.I18n.en['command.clear'] = 'Clear';
 window.nuxeo.I18n.en['command.search'] = 'Search';
 window.nuxeo.I18n.en['command.select'] = 'Select';
+window.nuxeo.I18n.en['documentPicker.dialog'] = 'Select documents';
 window.nuxeo.I18n.en['pickerSearch.title'] = 'Quick Search';
 window.nuxeo.I18n.en['resultsView.filters.heading'] = 'Filters';
 
@@ -186,6 +187,128 @@ suite('nuxeo-document-picker', () => {
     // dialog is closed and the select button is no longer visible
     expect(isElementVisible(dialog)).to.be.false;
     expect(isElementVisible(selectButton)).to.be.false;
+  });
+
+  suite('keyboard accessibility', () => {
+    const ctrlEnter = (target, key = 'Enter') =>
+      target.dispatchEvent(
+        new KeyboardEvent('keydown', { key, ctrlKey: true, bubbles: true, composed: true, cancelable: true }),
+      );
+    const openAndSearch = async (picker) => {
+      picker.open();
+      await waitForDialogOpen(picker.$.dialog);
+      // XXX the search is not being automatically triggered after the dialog is opened
+      picker.$.resultsView
+        .$$('div.form')
+        .querySelector('paper-button.search')
+        .click();
+      await flush();
+    };
+    const selectFirstResult = async (picker) => {
+      const table = picker.$.resultsView.results.results.querySelector('nuxeo-data-table');
+      table.querySelectorAll('nuxeo-data-table-checkbox:not([style*="visibility: hidden;"])')[0].click();
+      await flush();
+    };
+
+    test('Should name the dialog after whatever opened it', async () => {
+      const picker = await buildPicker();
+      expect(picker.$.dialog.getAttribute('aria-label')).to.equal('Select documents');
+      picker.dialogLabel = 'Insert images from existing documents';
+      await flush();
+      expect(picker.$.dialog.getAttribute('aria-label')).to.equal('Insert images from existing documents');
+    });
+
+    test('Should move focus to the search field when the dialog is opened', async () => {
+      const picker = await buildPicker();
+      picker.open();
+      await waitForDialogOpen(picker.$.dialog);
+      await flush();
+      const { form } = picker.$.resultsView;
+      expect(form.shadowRoot.activeElement).to.equal(form.$.searchInput);
+    });
+
+    test('Should let Escape cancel the picker and give focus back', async () => {
+      const picker = await buildPicker();
+      picker.open();
+      await waitForDialogOpen(picker.$.dialog);
+      // `modal` alone leaves paper-dialog-behavior swallowing Escape
+      expect(picker.$.dialog.noCancelOnEscKey).to.be.false;
+      expect(picker.$.dialog.restoreFocusOnClose).to.be.true;
+      picker.$.dialog.cancel();
+      await waitForDialogClose(picker.$.dialog);
+      expect(picker.$.dialog.opened).to.be.false;
+    });
+
+    test('Should confirm the selection with Ctrl+Enter', async () => {
+      const picker = await buildPicker();
+      await openAndSearch(picker);
+      await selectFirstResult(picker);
+      expect(picker.$.selectButton.disabled).to.be.false;
+      const picked = new Promise((resolve) => picker.addEventListener('picked', resolve));
+      ctrlEnter(picker.$.resultsView);
+      const event = await picked;
+      expect(event.detail.selectedItems).to.have.lengthOf(1);
+      await waitForDialogClose(picker.$.dialog);
+      expect(picker.$.dialog.opened).to.be.false;
+    });
+
+    test('Should advertise both the Ctrl and the Cmd shortcut on the select button', async () => {
+      const picker = await buildPicker();
+      expect(picker.$.selectButton.getAttribute('aria-keyshortcuts')).to.equal('Control+Enter Meta+Enter');
+    });
+
+    test('Should keep listening for the shortcut after the picker is moved in the DOM', async () => {
+      const picker = await buildPicker();
+      const parent = picker.parentNode;
+      parent.removeChild(picker);
+      parent.appendChild(picker);
+      await flush();
+      picker.open();
+      await waitForDialogOpen(picker.$.dialog);
+      const spy = sinon.spy(picker, '_onSelect');
+      picker.$.selectButton.disabled = false;
+      ctrlEnter(picker.$.dialog);
+      expect(spy).to.have.been.calledOnce;
+      spy.restore();
+    });
+
+    test('Should ignore Ctrl+Enter while nothing is selected', async () => {
+      const picker = await buildPicker();
+      await openAndSearch(picker);
+      const spy = sinon.spy(picker, '_onSelect');
+      expect(picker.$.selectButton.disabled).to.be.true;
+      ctrlEnter(picker.$.resultsView);
+      expect(spy).to.not.have.been.called;
+      spy.restore();
+      expect(picker.$.dialog.opened).to.be.true;
+    });
+
+    test('Should ignore Ctrl+Enter once the dialog is closing', async () => {
+      const picker = await buildPicker();
+      await openAndSearch(picker);
+      await selectFirstResult(picker);
+      const spy = sinon.spy(picker, '_onSelect');
+      ctrlEnter(picker.$.resultsView);
+      expect(spy).to.have.been.calledOnce;
+      await waitForDialogClose(picker.$.dialog);
+      expect(picker.$.dialog.opened).to.be.false;
+      ctrlEnter(picker.$.dialog);
+      expect(spy).to.have.been.calledOnce;
+      spy.restore();
+    });
+
+    test('Should leave a plain Enter to the control that has focus', async () => {
+      const picker = await buildPicker();
+      await openAndSearch(picker);
+      await selectFirstResult(picker);
+      const spy = sinon.spy(picker, '_onSelect');
+      picker.$.resultsView.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true, cancelable: true }),
+      );
+      expect(spy).to.not.have.been.called;
+      spy.restore();
+      expect(picker.$.dialog.opened).to.be.true;
+    });
   });
 
   test('Should refine the results through a search and clear it', async () => {

--- a/ui/test/nuxeo-html-editor.test.js
+++ b/ui/test/nuxeo-html-editor.test.js
@@ -177,6 +177,28 @@ suite('nuxeo-html-editor extras', () => {
     });
   });
 
+  suite('image controls keyboard accessibility', () => {
+    const buttonFor = (icon) =>
+      Array.from(el.$.toolbar.querySelectorAll('button')).find((button) =>
+        button.querySelector(`iron-icon[icon="${icon}"]`),
+      );
+
+    test('announces that the repository button opens a dialog', () => {
+      expect(buttonFor('nuxeo:search-picture').getAttribute('aria-haspopup')).to.equal('dialog');
+    });
+
+    test('names the picker dialog after the button that opens it', () => {
+      expect(el.$.picker.dialogLabel).to.equal(el.i18n('htmlEditor.insert.imagesFromDocuments'));
+    });
+
+    test('carries on in the document once an image has been inserted', () => {
+      el._onPickerSelected({
+        detail: { selectedItems: [{ properties: { 'file:content': { data: 'http://img.png' } } }] },
+      });
+      expect(el._editor.hasFocus()).to.be.true;
+    });
+  });
+
   suite('ready (RTL handling)', () => {
     test('sets dir attribute from document if not already set', async () => {
       const origDir = document.documentElement.getAttribute('dir');

--- a/ui/widgets/nuxeo-html-editor.js
+++ b/ui/widgets/nuxeo-html-editor.js
@@ -59,6 +59,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 
         <nuxeo-document-picker
           id="picker"
+          dialog-label="[[i18n('htmlEditor.insert.imagesFromDocuments')]]"
           provider="document_picker"
           page-size="40"
           schemas="dublincore,file"
@@ -120,7 +121,11 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
             <button on-tap="_onImageUpload" title$="[[i18n('htmlEditor.insert.image')]]">
               <iron-icon icon="nuxeo:picture"></iron-icon>
             </button>
-            <button on-tap="_onSearchImage" title$="[[i18n('htmlEditor.insert.imagesFromDocuments')]]">
+            <button
+              on-tap="_onSearchImage"
+              title$="[[i18n('htmlEditor.insert.imagesFromDocuments')]]"
+              aria-haspopup="dialog"
+            >
               <iron-icon icon="nuxeo:search-picture"></iron-icon>
             </button>
             <button class="ql-video" title$="[[i18n('htmlEditor.insert.video')]]"></button>
@@ -236,6 +241,9 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
           .map((doc) => `<img src="${doc.properties['file:content'].data}">`)
           .join('\n');
         this._editor.clipboard.dangerouslyPasteHTML(this._editor.getSelection(true).index, templateToInsert);
+        // Carry on in the document instead of being sent back to the toolbar: the picker only
+        // restores focus to the button that opened it while focus is still inside its dialog.
+        this._editor.focus();
       }
     }
   }


### PR DESCRIPTION
## Problem

In a Note, tabbing to **Insert images from existing documents** and activating it opens the document picker, but a keyboard user cannot get an image into the document. Jira: [WEBUI-2151](https://hyland.atlassian.net/browse/WEBUI-2151)

Reproduced keyboard-only against a live instance (activeElement trace attached to the ticket):

| Step | Before |
|---|---|
| Focus after the picker opens | stays on `nuxeo-dialog` itself (`tabindex="-1"`, no focus ring, no starting point) |
| Reaching the search field | 3 extra Tab presses |
| Accessible name of the dialog | none (`aria-label` absent) |
| Confirming the pick | `#selectButton` is the last stop in the dialog: 51 Tab presses with 9 results, ~230 with the default page size of 40 — the image never gets inserted in practice |
| Escape | ignored, the dialog stays open |
| Closing the picker | focus is left wherever it was inside the dialog, never back on the toolbar button |

## Root cause

* `nuxeo-dialog` only moves initial focus when it can resolve a target — it looks for `[autofocus]` in its own light DOM and treats "the dialog element has focus" as already-inside, so for the picker (whose search field lives several shadow roots down, in the lazily loaded search form layout) focus is simply left on the container.
* The picker opens the dialog with `modal`, and `paper-dialog-behavior` derives `noCancelOnEscKey` from it, so Escape is swallowed. Nothing sets `restore-focus-on-close`, so no focus is handed back on close.
* The dialog has no `aria-label`, and the same picker element is reused for different purposes, so a hard-coded name would be wrong — the name has to follow the caller (the lesson from #1560).
* The Select button sits after the whole result grid in the tab sequence, and each result contributes six tab stops (host, thumbnail, title link, favourite, download, select), so confirming is unreachable in practice on a full page.

## Changes

* **`ui/nuxeo-document-picker/nuxeo-document-picker.js`**: move focus to the search form's `[autofocus]` field once the dialog is up (on `iron-overlay-opened`, and again when the lazily loaded search layout is stamped, guarded so it happens once per open); clear `noCancelOnEscKey` on `open()` so Escape cancels; add `restore-focus-on-close` so cancelling or confirming returns focus to whatever opened the picker; expose an `aria-label` from a new `dialogLabel` property that falls back to a generic `documentPicker.dialog`; confirm the selection with Ctrl/Cmd+Enter — the shortcut `nuxeo-document-comment` already uses to submit — advertised on the button through `aria-keyshortcuts="Control+Enter Meta+Enter"`. The shortcut listener is registered in the capture phase so the search field does not also run a search for that key press, it is a no-op while the Select button is disabled, and it is bound once then detached/re-attached with the element so moving the picker in the DOM neither leaks it nor loses the shortcut.
* **`ui/widgets/nuxeo-html-editor.js`**: pass `dialog-label` so the picker announces the invoking action instead of a generic name, declare `aria-haspopup="dialog"` on the repository image button, and focus the editor after inserting so the caret carries on in the document rather than being restored to the button behind the dialog.
* **`ui/i18n/messages.json`**: one new key, `documentPicker.dialog`, for callers that do not pass a name.
* **`ui/test/*`**: 12 new tests covering the dialog name (custom + fallback), initial focus, Escape/focus restoration, the shortcut (confirms, ignored when nothing is selected, plain Enter left to the focused control), `aria-keyshortcuts`, `aria-haspopup`, the label handed to the picker, and focus returning to the document after an insert.

After the change the whole journey is keyboard-only: open → focus in the search field → 8 Tabs to a result's Select control → Enter selects → Ctrl+Enter inserts and closes → focus back in the document; Escape cancels and restores focus to the toolbar button.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` (ui) passes — 3719 tests, 0 failures, on this base and on `maintenance-3.1.x`
- [x] Keyboard-only journey verified against a live instance; before/after screenshots, video and activeElement traces attached to WEBUI-2151
- [x] Regression sweep on `nuxeo-html-editor`: upload path still clicks the hidden `ql-image` button (which stays `display: none` and out of the tab order), bold/headers/colour pickers/link/video controls unaffected, value still syncs back to the document, read-only still hides the toolbar

## Notes

* Companion `nuxeo-web-ui` PR: a result's Select control used to toggle on **any** key except Tab/Shift, so pressing Ctrl (or an arrow key) while it had focus silently deselected the image. Both changes are needed for the shortcut path to work end to end.
* Backport of the same commit to `maintenance-3.1.x`: #1573.
* Textual overlap in `nuxeo-html-editor.js` with the in-flight #1560 (WEBUI-2149, link/video popup) and #1564 (WEBUI-2150, colour pickers). This PR only touches the two image buttons, the picker element and `_onPickerSelected`, and does not add helpers those PRs introduce. **Merge #1560 and #1564 first**; this one then rebases with at most trivial conflicts in the toolbar template.
* Follow-up worth its own ticket: every result tile in a grid contributes six tab stops and carries a positive `tabindex`, which is why the dialog's actions are so far away. Making a tile a single tab stop (roving `tabindex`, arrow-key navigation) would help the picker and every other result grid, but it is a shared-component redesign well beyond this fix.

Made with [Cursor](https://cursor.com)

