### PR TITLE
ELEMENTS-2012: Remove obsolete @nuxeo RC install step from Sonar workflow [lts-2025]

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -65,23 +65,6 @@ jobs:
         run: npm ci --ignore-scripts
         working-directory: ${{ github.workspace }}
 
-      - name: Ensure latest @nuxeo RC packages
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
-        run: |
-          ELEMENTS_VERSION=$(npm view @nuxeo/nuxeo-ui-elements versions --json \
-            | jq -r '.[]' \
-            | grep -E "3\.1\.[0-9]+-rc\.[0-9]+$" \
-            | sort -V | tail -n1)
-          echo "Resolved latest nuxeo-elements RC: $ELEMENTS_VERSION"
-
-          npm install --no-package-lock --no-save --ignore-scripts \
-            @nuxeo/nuxeo-elements@"$ELEMENTS_VERSION" \
-            @nuxeo/nuxeo-ui-elements@"$ELEMENTS_VERSION" \
-            @nuxeo/nuxeo-dataviz-elements@"$ELEMENTS_VERSION" \
-            @nuxeo/testing-helpers@"$ELEMENTS_VERSION"
-        working-directory: ${{ github.workspace }}
-
       - name: Run unit tests with coverage
         run: npm test
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## Problem

The `sonar / Build and analyze` job fails on every run. The step **`Ensure latest @nuxeo RC packages`** in `.github/workflows/sonar.yaml` aborts with:

```
Resolved latest nuxeo-elements RC: 3.1.33-rc.14
npm error code ERR_INVALID_ARG_TYPE
npm error The "from" argument must be of type string. Received undefined
```

Because that step fails, the `Build and analyze` (SonarQube scan) step is skipped, and `Enforce Quality Gate` (which runs with `if: always()`) then prints `❌ SonarCloud scan was skipped — a prior step (e.g. coverage baseline) failed.` and exits `1`. The whole job is red and no Sonar analysis is produced.

Both bases are affected:
- `lts-2025` — https://github.com/nuxeo/nuxeo-elements/actions/runs/30808647387 (job `91669828944`)
- `maintenance-3.1.x` — https://github.com/nuxeo/nuxeo-elements/actions/runs/30808600839/job/91670440928

Jira: [ELEMENTS-2012](https://hyland.atlassian.net/browse/ELEMENTS-2012)

## Root cause

`sonar.yaml` first runs `npm ci --ignore-scripts`, producing a complete `node_modules` from the committed `package-lock.json`. The `Ensure latest @nuxeo RC packages` step then runs `npm install --no-package-lock --no-save --ignore-scripts @nuxeo/…`. The `--no-package-lock` flag makes npm **discard the lockfile and re-resolve the entire dependency graph** from the semver ranges in `package.json`.

`nx@22.7.8` was published on 2026-07-30T23:14Z. It floats into the tree via `lerna@^9.0.7` (range `nx >=21.5.3 <23.0.0`); the last green sonar run was 2026-07-30T05:55Z, just before that publish. A `--dry-run` now shows entries such as `change @nx/nx-win32-x64-msvc undefined => 22.7.8`, `change @nx/nx-darwin-x64 undefined => 22.7.8` and `change @napi-rs/lzma-linux-x64-gnu undefined => 1.5.1` — cross-platform optional binaries that are not installed on the runner.

Reifying that diff over the existing tree drives npm into its retire/rollback path, and arborist's own rollback handler throws:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "from" argument must be of type string. Received undefined
    at relative (node:path:1372:5)
    at .../@npmcli/arborist/lib/arborist/reify.js:1198:21
    at [rollbackMoveBackRetiredUnchanged] (.../@npmcli/arborist/lib/arborist/reify.js:1196:8)
    at [reifyPackages] (.../@npmcli/arborist/lib/arborist/reify.js:331:31)
```

At `reify.js:1198` it calls `relative(realFolder, node.path)` where `realFolder = realFolders.get(retireFolder)` is `undefined`. The rollback throws before rethrowing the original error, so the real underlying error is swallowed and only `ERR_INVALID_ARG_TYPE` surfaces.

Reproduced locally on `da2ca7a6e` with Node 22.20.0 / npm 10.9.3. The `@nuxeo` arguments are **not** what breaks it:
- `npm ci` then that exact install → fails
- `npm ci` then `npm install --no-package-lock --no-save --ignore-scripts` with **no** package arguments → fails identically
- the same install on a **clean** tree with no prior `npm ci` → succeeds

**The step is also a no-op for its stated purpose.** `@nuxeo/nuxeo-elements`, `@nuxeo/nuxeo-ui-elements`, `@nuxeo/nuxeo-dataviz-elements` and `@nuxeo/testing-helpers` are *this repo's own npm workspaces* (`core`, `ui`, `dataviz`, `testing-helpers`). On a tree where the install did succeed, npm keeps the workspace symlinks regardless (`node_modules/@nuxeo/nuxeo-elements -> ../../core`, etc.), so the requested RC versions are never used. The step only churns unrelated parts of the tree — which is exactly what now crashes. On `lts-2025` it is additionally wrong: the version regex is hardcoded to `3\.1\.[0-9]+-rc\.[0-9]+$`, so a branch on `2025.19.0-SNAPSHOT` resolves the unrelated `3.1.33-rc.14`.

It was copy-pasted from `nuxeo-web-ui` (where it is legitimate, because Web UI *consumes* Elements) by `9adb2711c` / #1419 (ELEMENTS-1940).

## Changes

* **`.github/workflows/sonar.yaml`**: delete the entire `Ensure latest @nuxeo RC packages` step, leaving `npm ci --ignore-scripts` as the only dependency install. Nothing else in the workflow changes.

No other workflow (`test.yaml`, `lint.yaml`, `storybook.yaml`, `main.yaml`) and neither `package.json` nor `package-lock.json` are touched.

## Test plan

- [x] The change is a 17-line pure deletion; the resulting `sonar.yaml` still parses as valid YAML and the job's step list is unchanged apart from the removed step.
- [x] `npm run lint:prettier` only covers `**/*.{js,html}`, so this YAML-only change is outside the lint gate — nothing to reformat.
- [ ] **Real verification is CI on this PR**: the `sonar` job must get past dependency installation and produce a SonarQube analysis instead of failing at `Ensure latest @nuxeo RC packages`.
- Supporting evidence that `npm ci --ignore-scripts` alone is sufficient: on the same commits where `sonar` failed, the `lint`, `test` and `storybook` jobs — none of which have this step — all passed, and `test` runs the very coverage suite Sonar consumes.

No unit tests were run locally for this change, as it only touches workflow YAML.

## Notes

Backport pair — the identical change is applied to `maintenance-3.1.x` in a companion PR, since the step and the failure are identical on both bases.

Made with [Cursor](https://cursor.com)