### PR TITLE
ELEMENTS-2013: Post SonarQube analysis summary on PRs [lts-2025]

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
       - uses: catchpoint/workflow-telemetry-action@v2
@@ -95,6 +96,114 @@ jobs:
             github.event.pull_request.head.ref,
             github.event.pull_request.base.ref)
             || format('-Dsonar.branch.name={0}', steps.project_meta.outputs.branch) }}
+
+      - name: Report analysis summary on PR
+        # The SonarQube Cloud GitHub App does not decorate this repository, so PRs never get the
+        # analysis summary that nuxeo-web-ui gets automatically. Rebuild it from the API instead.
+        # Self-disabling: skipped as soon as the App starts posting its own comment.
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- sonarqube-pr-report -->';
+            const { owner, repo } = context.repo;
+            const prKey = context.issue.number;
+
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: prKey,
+                per_page: 100,
+              });
+              if (comments.some((c) => c.user && c.user.login === 'sonarqubecloud[bot]')) {
+                core.info('Native SonarQube Cloud decoration detected — skipping fallback report.');
+                return;
+              }
+
+              const projectKey = fs
+                .readFileSync('sonar-project.properties', 'utf8')
+                .split('\n')
+                .find((line) => line.startsWith('sonar.projectKey='))
+                ?.split('=')[1]
+                .trim();
+              if (!projectKey) {
+                core.warning('Could not read sonar.projectKey — skipping fallback report.');
+                return;
+              }
+              core.info(`projectKey=${projectKey} pullRequest=${prKey}`);
+
+              const api = async (path) => {
+                const res = await fetch(`https://sonarcloud.io/api/${path}`, {
+                  headers: { Authorization: `Bearer ${process.env.SONAR_TOKEN}` },
+                });
+                if (!res.ok) {
+                  throw new Error(`GET /api/${path} responded ${res.status}`);
+                }
+                return res.json();
+              };
+              const scope = `pullRequest=${prKey}`;
+
+              const [gate, open, accepted, hotspots] = await Promise.all([
+                api(`qualitygates/project_status?projectKey=${projectKey}&${scope}`),
+                api(`issues/search?componentKeys=${projectKey}&${scope}&resolved=false&ps=1`),
+                api(`issues/search?componentKeys=${projectKey}&${scope}&issueStatuses=ACCEPTED&ps=1`),
+                api(`hotspots/search?projectKey=${projectKey}&${scope}&ps=1`),
+              ]);
+
+              const passed = gate.projectStatus.status === 'OK';
+              const conditions = Object.fromEntries(
+                gate.projectStatus.conditions.map((c) => [c.metricKey, c]),
+              );
+              core.info(
+                `gate=${gate.projectStatus.status} newIssues=${open.total} accepted=${accepted.total} ` +
+                  `hotspots=${hotspots.paging.total}`,
+              );
+
+              const icon = (ok) => (ok ? ':white_check_mark:' : ':x:');
+              const metric = (key, label) => {
+                const c = conditions[key];
+                if (!c) {
+                  return null;
+                }
+                return `${icon(c.status === 'OK')} ${Number(c.actualValue).toFixed(1)}% ${label}`;
+              };
+              const dashboard = `https://sonarcloud.io/dashboard?id=${projectKey}&pullRequest=${prKey}`;
+
+              const body = [
+                marker,
+                `## ${icon(passed)} Quality Gate ${passed ? 'passed' : 'failed'}`,
+                '',
+                '**Issues**',
+                `${icon(open.total === 0)} ${open.total} New issues`,
+                `${icon(true)} ${accepted.total} Accepted issues`,
+                '',
+                '**Measures**',
+                `${icon(hotspots.paging.total === 0)} ${hotspots.paging.total} Security Hotspots`,
+                metric('new_coverage', 'Coverage on New Code'),
+                metric('new_duplicated_lines_density', 'Duplication on New Code'),
+                '',
+                `[See analysis details on SonarQube Cloud](${dashboard})`,
+              ]
+                .filter((line) => line !== null)
+                .join('\n');
+
+              const previous = comments.find((c) => c.body && c.body.includes(marker));
+              if (previous) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: previous.id, body });
+                core.info(`Updated existing report comment ${previous.id}.`);
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: prKey, body });
+                core.info('Created report comment.');
+              }
+            } catch (error) {
+              // Never fail the build on reporting problems; the Quality Gate step below is what gates.
+              core.warning(`Could not publish the analysis summary: ${error.message}`);
+            }
 
       - name: Enforce Quality Gate
         # Fails if sonar scan was skipped (e.g. prior step failed) or gate not passed.


### PR DESCRIPTION
## Problem
PRs in this repo never show the SonarQube Cloud analysis summary, while `nuxeo-web-ui` PRs get a "Quality Gate passed" comment listing New issues, Accepted issues, Security Hotspots, Coverage on New Code and Duplication on New Code. Compare [nuxeo-web-ui#3407](https://github.com/nuxeo/nuxeo-web-ui/pull/3407) (has it) with [#1522](https://github.com/nuxeo/nuxeo-elements/pull/1522) (does not, and targets this base). Jira: [ELEMENTS-2013](https://hyland.atlassian.net/browse/ELEMENTS-2013)

## Root cause
Not a repository-config problem. `sonar-project.properties` is identical between `lts-2025` and `maintenance-3.1.x`, and `sonar.yaml` differs from Web UI's only in trigger branch names, the Web UI-only RC-install step, and `sonar.qualitygate.wait`. Both repos pass the same `sonar.pullrequest.*` args.

The scan is healthy — run [30341518957](https://github.com/nuxeo/nuxeo-elements/actions/runs/30341518957) logs `Pull request 1522 for merge into lts-2025 ...` and `QUALITY GATE STATUS: PASSED`, and the PR exists server-side with `qualityGateStatus: OK`.

What is missing is the decoration written by the GitHub App `sonarqubecloud` (app id 12526). Across 12 sampled PRs (#1567–#1578) plus #1499/#1522/#1530/#1531 there are **zero** check runs from that app — only `github-actions` and `github-advanced-security`. The fingerprint is in the stored PR URL: Web UI's is the `html_url` an App installation returns, ours is the raw `https://api.github.com/repos/.../pulls/1522`. The app is not covering this repo, which needs an org admin to fix (`GET /orgs/nuxeo/installations` needs `admin:org`).

## Changes
* **`.github/workflows/sonar.yaml`**: add a `Report analysis summary on PR` step that rebuilds the summary from `api/qualitygates/project_status`, `api/issues/search` and `api/hotspots/search`, and upserts a sticky comment (marker `<!-- sonarqube-pr-report -->`). Uses the `actions/github-script@v9` pattern already in `preview.yaml`, and adds `pull-requests: write`.
  * **Self-retiring**: skips entirely if a `sonarqubecloud[bot]` comment exists, so it goes quiet once the App is installed — no duplicate reports.
  * **Cannot break the build**: all failures are caught and reported via `core.warning`; `Enforce Quality Gate` still runs after it and remains the only gate.
  * `projectKey` is read from `sonar-project.properties` rather than hardcoded.

## Test plan
- [x] `npm run lint` passes (clean once the gitignored `*/test/load-all-tests.js` barrels from a local `npm test` are out of the way — `polymer lint` trips on those generated files; CI never sees them)
- [x] YAML parses; step order verified as scan → report → enforce gate; `lts-2025` triggers unchanged
- [x] Script extracted from the YAML and executed against live SonarCloud data for PR 1522. Rendered output matches the Web UI report line for line: `0 New issues`, `0 Accepted issues`, `0 Security Hotspots`, `100.0% Coverage on New Code`, `0.0% Duplication on New Code`
- [x] Path coverage: creates when absent; **skips** when `sonarqubecloud[bot]` has commented; **updates** in place when its own comment exists (no duplicates); renders `❌ Quality Gate failed` with the failing condition; on a PR with no analysis (404) warns and exits 0 without commenting
- [ ] This PR's own Sonar run posts the summary comment below

## Notes
Interim mitigation only — the permanent fix is adding `nuxeo-elements` to the SonarQube Cloud GitHub App installation, tracked in ELEMENTS-2013. PRs were never unprotected: `sonar.qualitygate.wait=true` already fails the job on a failing gate; only the visible report was missing.

Backport pair of #1579 (`maintenance-3.1.x`), same commit cherry-picked.

Made with [Cursor](https://cursor.com)