### PR TITLE
ELEMENTS-2030: seed complex entries as objects in single-column data tables [lts-2025]

### DIFF
--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1389,23 +1389,25 @@ import '../nuxeo-button-styles.js';
     _isComplexEntry(dtform) {
       const template = this._getFormTemplate(dtform);
 
-      const sources = this._getTemplateBindingSources(template);
-      if (sources.some((source) => source.startsWith('item.'))) {
-        return true;
-      }
-      if (sources.includes('item')) {
-        return false;
-      }
+      if (template) {
+        const sources = this._getTemplateBindingSources(template);
+        if (sources.some((source) => source.startsWith('item.'))) {
+          return true;
+        }
+        if (sources.includes('item')) {
+          return false;
+        }
 
-      // Templates Polymer has not parsed yet still carry their annotations in the markup.
-      const markup = (template || {}).innerHTML || '';
-      if (/\bitem\s*\./.test(markup)) {
-        return true;
-      }
-      // `[\s!]*` rather than `\s*!?\s*`: adjacent optional whitespace groups make the match ambiguous
-      // and backtrack super-linearly on long inputs.
-      if (/(?:\[\[|\{\{)[\s!]*item\s*(?:::[^\]}]*)?(?:\]\]|\}\})/.test(markup)) {
-        return false;
+        // Templates Polymer has not parsed yet still carry their annotations in the markup.
+        const markup = template.innerHTML || '';
+        if (/\bitem\s*\./.test(markup)) {
+          return true;
+        }
+        // `[\s!]*` rather than `\s*!?\s*`: adjacent optional whitespace groups make the match
+        // ambiguous and backtrack super-linearly on long inputs.
+        if (/(?:\[\[|\{\{)[\s!]*item\s*(?:::[^\]}]*)?(?:\]\]|\}\})/.test(markup)) {
+          return false;
+        }
       }
       // Without a usable template, mirror the entries already in the list, then fall back to columns.
       const existing = (this.items || []).find((item) => item !== null && item !== undefined);

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1283,7 +1283,7 @@ import '../nuxeo-button-styles.js';
 
       // Only the entry itself can be the value of a single-column table; subfields of a complex entry
       // must not inherit that assumption, or a one-subfield complex would coerce "007" to 7.
-      if (isEntry && this.columns?.length === 1 && typeof item === 'string' && item.trim() !== '') {
+      if (isEntry && this.columns && this.columns.length === 1 && typeof item === 'string' && item.trim() !== '') {
         const num = Number(item.trim());
         if (Number.isFinite(num)) {
           return num;
@@ -1359,7 +1359,8 @@ import '../nuxeo-button-styles.js';
      */
     _getTemplateBindingSources(template) {
       const templateInfo = template && (template._templateInfo || template.__templateInfo);
-      if (!templateInfo?.nodeInfoList) {
+      // Not optional chaining: polymer lint's parser predates it and fails to load the file.
+      if (!templateInfo || !templateInfo.nodeInfoList) {
         return [];
       }
       const sources = [];
@@ -1395,7 +1396,7 @@ import '../nuxeo-button-styles.js';
       }
 
       // Templates Polymer has not parsed yet still carry their annotations in the markup.
-      const markup = template?.innerHTML || '';
+      const markup = (template && template.innerHTML) || '';
       if (/\bitem\s*\./.test(markup)) {
         return true;
       }

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1283,7 +1283,7 @@ import '../nuxeo-button-styles.js';
 
       // Only the entry itself can be the value of a single-column table; subfields of a complex entry
       // must not inherit that assumption, or a one-subfield complex would coerce "007" to 7.
-      if (isEntry && this.columns && this.columns.length === 1 && typeof item === 'string' && item.trim() !== '') {
+      if (isEntry && this.columns.length === 1 && typeof item === 'string' && item.trim() !== '') {
         const num = Number(item.trim());
         if (Number.isFinite(num)) {
           return num;
@@ -1358,13 +1358,15 @@ import '../nuxeo-button-styles.js';
      * info it leaves behind is the only remaining record of what the form writes to.
      */
     _getTemplateBindingSources(template) {
-      const templateInfo = template && (template._templateInfo || template.__templateInfo);
-      // Not optional chaining: polymer lint's parser predates it and fails to load the file.
-      if (!templateInfo || !templateInfo.nodeInfoList) {
+      // Defaulted rather than optional-chained: polymer lint's parser predates `?.` and fails to
+      // load the file when it appears.
+      const templateInfo = (template && (template._templateInfo || template.__templateInfo)) || {};
+      const { nodeInfoList } = templateInfo;
+      if (!nodeInfoList) {
         return [];
       }
       const sources = [];
-      templateInfo.nodeInfoList.forEach((nodeInfo) => {
+      nodeInfoList.forEach((nodeInfo) => {
         (nodeInfo.bindings || []).forEach((binding) => {
           (binding.parts || []).forEach((part) => {
             if (part && typeof part.source === 'string') {
@@ -1396,7 +1398,7 @@ import '../nuxeo-button-styles.js';
       }
 
       // Templates Polymer has not parsed yet still carry their annotations in the markup.
-      const markup = (template && template.innerHTML) || '';
+      const markup = (template || {}).innerHTML || '';
       if (/\bitem\s*\./.test(markup)) {
         return true;
       }

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1259,7 +1259,9 @@ import '../nuxeo-button-styles.js';
 
     _normalizeItem(item, typeHints, isEntry = true) {
       if (Array.isArray(item)) {
-        return item.map((v) => this._normalizeItem(v, typeHints, false));
+        // The elements of a list of entries are themselves entries; a nested array reaches here with
+        // isEntry already false, so propagating keeps the entry-only coercion correct either way.
+        return item.map((v) => this._normalizeItem(v, typeHints, isEntry));
       }
 
       if (item !== null && typeof item === 'object') {
@@ -1281,7 +1283,7 @@ import '../nuxeo-button-styles.js';
 
       // Only the entry itself can be the value of a single-column table; subfields of a complex entry
       // must not inherit that assumption, or a one-subfield complex would coerce "007" to 7.
-      if (isEntry && this.columns && this.columns.length === 1 && typeof item === 'string' && item.trim() !== '') {
+      if (isEntry && this.columns?.length === 1 && typeof item === 'string' && item.trim() !== '') {
         const num = Number(item.trim());
         if (Number.isFinite(num)) {
           return num;
@@ -1357,7 +1359,7 @@ import '../nuxeo-button-styles.js';
      */
     _getTemplateBindingSources(template) {
       const templateInfo = template && (template._templateInfo || template.__templateInfo);
-      if (!templateInfo || !templateInfo.nodeInfoList) {
+      if (!templateInfo?.nodeInfoList) {
         return [];
       }
       const sources = [];
@@ -1388,16 +1390,18 @@ import '../nuxeo-button-styles.js';
       if (sources.some((source) => source.startsWith('item.'))) {
         return true;
       }
-      if (sources.some((source) => source === 'item')) {
+      if (sources.includes('item')) {
         return false;
       }
 
       // Templates Polymer has not parsed yet still carry their annotations in the markup.
-      const markup = (template && template.innerHTML) || '';
+      const markup = template?.innerHTML || '';
       if (/\bitem\s*\./.test(markup)) {
         return true;
       }
-      if (/(\[\[|\{\{)\s*!?\s*item\s*(::[^\]}]*)?\s*(\]\]|\}\})/.test(markup)) {
+      // `[\s!]*` rather than `\s*!?\s*`: adjacent optional whitespace groups make the match ambiguous
+      // and backtrack super-linearly on long inputs.
+      if (/(?:\[\[|\{\{)[\s!]*item\s*(?:::[^\]}]*)?(?:\]\]|\}\})/.test(markup)) {
         return false;
       }
       // Without a usable template, mirror the entries already in the list, then fall back to columns.

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1283,7 +1283,7 @@ import '../nuxeo-button-styles.js';
 
       // Only the entry itself can be the value of a single-column table; subfields of a complex entry
       // must not inherit that assumption, or a one-subfield complex would coerce "007" to 7.
-      if (isEntry && this.columns.length === 1 && typeof item === 'string' && item.trim() !== '') {
+      if (isEntry && (this.columns || []).length === 1 && typeof item === 'string' && item.trim() !== '') {
         const num = Number(item.trim());
         if (Number.isFinite(num)) {
           return num;
@@ -1361,7 +1361,14 @@ import '../nuxeo-button-styles.js';
       // Defaulted rather than optional-chained: polymer lint's parser predates `?.` and fails to
       // load the file when it appears.
       const templateInfo = (template && (template._templateInfo || template.__templateInfo)) || {};
-      const { nodeInfoList } = templateInfo;
+      return this._collectBindingSources(templateInfo);
+    }
+
+    /**
+     * Walks parsed template info, including nested templates, collecting every property path bound.
+     */
+    _collectBindingSources(templateInfo) {
+      const { nodeInfoList } = templateInfo || {};
       if (!nodeInfoList) {
         return [];
       }
@@ -1369,11 +1376,28 @@ import '../nuxeo-button-styles.js';
       nodeInfoList.forEach((nodeInfo) => {
         (nodeInfo.bindings || []).forEach((binding) => {
           (binding.parts || []).forEach((part) => {
-            if (part && typeof part.source === 'string') {
+            if (!part || part.hostProp) {
+              // A host-prop part only records that a nested template forwards `item` down from its
+              // host; the paths the form really binds live in that nested template. Treating it as a
+              // binding would make every `dom-if`-wrapped form look like a whole-value binding.
+              return;
+            }
+            if (typeof part.source === 'string') {
               sources.push(part.source);
             }
+            // For a computed binding `source` is the whole expression, e.g. `i18n('x', item.address)`,
+            // so the argument paths are only reachable through the dependencies.
+            (part.dependencies || []).forEach((dependency) => {
+              if (dependency && typeof dependency.name === 'string') {
+                sources.push(dependency.name);
+              }
+            });
           });
         });
+        // A nested `<template>` (`dom-if`, `dom-repeat`) carries its own parsed bindings.
+        if (nodeInfo.templateInfo) {
+          this._collectBindingSources(nodeInfo.templateInfo).forEach((source) => sources.push(source));
+        }
       });
       return sources;
     }
@@ -1414,7 +1438,7 @@ import '../nuxeo-button-styles.js';
       if (existing !== undefined) {
         return typeof existing === 'object';
       }
-      return this.columns.length > 1;
+      return (this.columns || []).length > 1;
     }
 
     _toggleEditDialog(itemIndex) {

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1257,9 +1257,9 @@ import '../nuxeo-button-styles.js';
       this._fieldTypeHints = this._computeFieldTypeHintsFromStats(this._fieldTypeStats);
     }
 
-    _normalizeItem(item, typeHints) {
+    _normalizeItem(item, typeHints, isEntry = true) {
       if (Array.isArray(item)) {
-        return item.map((v) => this._normalizeItem(v, typeHints));
+        return item.map((v) => this._normalizeItem(v, typeHints, false));
       }
 
       if (item !== null && typeof item === 'object') {
@@ -1273,13 +1273,15 @@ import '../nuxeo-button-styles.js';
             // Keep string columns as strings (for ID-like values such as "00123").
             item[key] = typeof item[key] === 'number' ? String(item[key]) : item[key];
           } else {
-            item[key] = this._normalizeItem(item[key]);
+            item[key] = this._normalizeItem(item[key], undefined, false);
           }
         });
         return item;
       }
 
-      if (this.columns && this.columns.length === 1 && typeof item === 'string' && item.trim() !== '') {
+      // Only the entry itself can be the value of a single-column table; subfields of a complex entry
+      // must not inherit that assumption, or a one-subfield complex would coerce "007" to 7.
+      if (isEntry && this.columns && this.columns.length === 1 && typeof item === 'string' && item.trim() !== '') {
         const num = Number(item.trim());
         if (Number.isFinite(num)) {
           return num;
@@ -1339,6 +1341,73 @@ import '../nuxeo-button-styles.js';
       return result;
     }
 
+    _getFormTemplate(dtform) {
+      if (!dtform || typeof dtform.queryEffectiveChildren !== 'function') {
+        return null;
+      }
+      return dtform.queryEffectiveChildren('template');
+    }
+
+    /**
+     * Lists the property paths a template binds to, e.g. `item.address` or `item`.
+     *
+     * Polymer moves a template's content out when it is stamped and strips binding annotations
+     * while parsing, so by the time the edit dialog opens the markup is empty. The parsed template
+     * info it leaves behind is the only remaining record of what the form writes to.
+     */
+    _getTemplateBindingSources(template) {
+      const templateInfo = template && (template._templateInfo || template.__templateInfo);
+      if (!templateInfo || !templateInfo.nodeInfoList) {
+        return [];
+      }
+      const sources = [];
+      templateInfo.nodeInfoList.forEach((nodeInfo) => {
+        (nodeInfo.bindings || []).forEach((binding) => {
+          (binding.parts || []).forEach((part) => {
+            if (part && typeof part.source === 'string') {
+              sources.push(part.source);
+            }
+          });
+        });
+      });
+      return sources;
+    }
+
+    /**
+     * Decides whether a new entry is a complex object or a primitive value.
+     *
+     * Column count cannot be used on its own: a complex type declaring a single subfield produces a
+     * one-column table just like a list of primitives does. The form template disambiguates the two,
+     * since sub-property bindings (`{{item.address}}`) can only target an object while whole-value
+     * bindings (`{{item}}`) can only target a primitive.
+     */
+    _isComplexEntry(dtform) {
+      const template = this._getFormTemplate(dtform);
+
+      const sources = this._getTemplateBindingSources(template);
+      if (sources.some((source) => source.startsWith('item.'))) {
+        return true;
+      }
+      if (sources.some((source) => source === 'item')) {
+        return false;
+      }
+
+      // Templates Polymer has not parsed yet still carry their annotations in the markup.
+      const markup = (template && template.innerHTML) || '';
+      if (/\bitem\s*\./.test(markup)) {
+        return true;
+      }
+      if (/(\[\[|\{\{)\s*!?\s*item\s*(::[^\]}]*)?\s*(\]\]|\}\})/.test(markup)) {
+        return false;
+      }
+      // Without a usable template, mirror the entries already in the list, then fall back to columns.
+      const existing = (this.items || []).find((item) => item !== null && item !== undefined);
+      if (existing !== undefined) {
+        return typeof existing === 'object';
+      }
+      return this.columns.length > 1;
+    }
+
     _toggleEditDialog(itemIndex) {
       const dtform = this.getContentChildren('#form')[0];
       if (typeof itemIndex !== 'undefined') {
@@ -1346,12 +1415,7 @@ import '../nuxeo-button-styles.js';
         dtform.item = this._deepCopy(this.items[itemIndex]);
       } else {
         dtform.index = -1;
-        if ((this.items.length > 1 && typeof this.items[0] !== 'object') || this.columns.length === 1) {
-          // dirty but will work with primitive such as string, number, etc.
-          dtform.item = '';
-        } else {
-          dtform.item = {};
-        }
+        dtform.item = this._isComplexEntry(dtform) ? {} : '';
       }
       this.$.dialog.toggle();
     }

--- a/ui/test/iron-data-table.test.js
+++ b/ui/test/iron-data-table.test.js
@@ -698,6 +698,14 @@ suite('iron-data-table extras', () => {
 
       expect(result).to.deep.equal({ codes: ['007', 42] });
     });
+
+    test('does not throw when columns is explicitly null', async () => {
+      const el = await newTable();
+      el.columns = null;
+
+      expect(() => el._normalizeItem('007')).to.not.throw();
+      expect(el._normalizeItem('007')).to.equal('007');
+    });
   });
 
   // ------------------------------------------------------------------
@@ -1128,7 +1136,9 @@ suite('iron-data-table extras', () => {
       expect(el._isComplexEntry(formWith('<input value="{{item::input}}">'))).to.be.false;
     });
 
-    test('detects sub-properties inside computed bindings', async () => {
+    // Covers the raw-markup path only. The parsed-template equivalent is asserted further down
+    // against a real stamped form, where `source` is the whole expression rather than a path.
+    test('detects sub-properties inside computed bindings in unparsed markup', async () => {
       const el = await newTable();
       el.columns = [{ name: 'Date' }];
 
@@ -1207,6 +1217,124 @@ suite('iron-data-table extras', () => {
       el.items = [{ address: 'a' }];
 
       expect(el._isComplexEntry(stampedFormWith(undefined))).to.be.true;
+    });
+
+    test('ignores host-prop parts that only forward the entry to a nested template', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Address' }];
+      el.items = [];
+
+      // The shape Polymer produces for `<template is="dom-if">`: a host-prop part on the outer node
+      // naming `item`, with the real binding held in that node's nested template info.
+      const template = document.createElement('template');
+      template._templateInfo = {
+        nodeInfoList: [
+          {
+            bindings: [{ target: '_host_item', parts: [{ source: 'item', hostProp: true }] }],
+            templateInfo: {
+              nodeInfoList: [{ bindings: [{ target: 'value', parts: [{ source: 'item.address' }] }] }],
+            },
+          },
+        ],
+      };
+
+      expect(el._isComplexEntry({ queryEffectiveChildren: () => template })).to.be.true;
+    });
+
+    test('falls back safely when columns is explicitly null', async () => {
+      const el = await newTable();
+      el.columns = null;
+      el.items = [];
+
+      expect(() => el._isComplexEntry(null)).to.not.throw();
+      expect(el._isComplexEntry(null)).to.be.false;
+    });
+
+    // The suites above pin behaviour against hand-built template info. These mount a real
+    // <nuxeo-data-table-form> so Polymer itself parses and stamps the template, which is what
+    // guarantees the assumed shape actually matches the one in production.
+    suite('against templates parsed by Polymer', () => {
+      const mounted = [];
+
+      async function parsedForm(markup) {
+        const form = document.createElement('nuxeo-data-table-form');
+        const template = document.createElement('template');
+        template.innerHTML = markup;
+        form.appendChild(template);
+        document.body.appendChild(form);
+        mounted.push(form);
+        await flush();
+        return form;
+      }
+
+      teardown(() => {
+        while (mounted.length) {
+          mounted.pop().remove();
+        }
+      });
+
+      test('reads the entry shape once Polymer has consumed the markup', async () => {
+        const el = await newTable();
+        el.columns = [{ name: 'Address' }];
+        el.items = [];
+
+        const form = await parsedForm('<input value="{{item.address}}">');
+        const template = form.queryEffectiveChildren('template');
+
+        // Parsing strips the annotation, so the markup regex cannot be what answers this.
+        expect(template.innerHTML).to.not.contain('item.address');
+        expect(el._isComplexEntry(form)).to.be.true;
+      });
+
+      test('reads primitive entries once Polymer has consumed the markup', async () => {
+        const el = await newTable();
+        el.columns = [{ name: 'Value' }];
+        el.items = [];
+
+        expect(el._isComplexEntry(await parsedForm('<input value="{{item}}">'))).to.be.false;
+      });
+
+      test('detects sub-properties bound inside a dom-if', async () => {
+        const el = await newTable();
+        el.columns = [{ name: 'Address' }];
+        el.items = [];
+
+        const form = await parsedForm(
+          '<template is="dom-if" if="[[show]]"><input value="{{item.address}}"></template>',
+        );
+
+        expect(el._isComplexEntry(form)).to.be.true;
+      });
+
+      test('detects a multi-column complex form wrapped in a dom-if', async () => {
+        const el = await newTable();
+        el.columns = [{ name: 'Address' }, { name: 'City' }];
+        el.items = [];
+
+        const form = await parsedForm(
+          '<template is="dom-if" if="[[show]]"><input value="{{item.address}}"><input value="{{item.city}}"></template>',
+        );
+
+        expect(el._isComplexEntry(form)).to.be.true;
+      });
+
+      test('treats a dom-if around a whole-value binding as a primitive entry', async () => {
+        const el = await newTable();
+        el.columns = [{ name: 'Value' }];
+        el.items = [];
+
+        const form = await parsedForm('<template is="dom-if" if="[[show]]"><input value="{{item}}"></template>');
+
+        expect(el._isComplexEntry(form)).to.be.false;
+      });
+
+      test('detects sub-properties reached only through a computed binding', async () => {
+        const el = await newTable();
+        el.columns = [{ name: 'Date' }];
+        el.items = [];
+
+        expect(el._isComplexEntry(await parsedForm('<span>[[formatDate(item.date)]]</span>'))).to.be.true;
+      });
     });
   });
 

--- a/ui/test/iron-data-table.test.js
+++ b/ui/test/iron-data-table.test.js
@@ -665,6 +665,23 @@ suite('iron-data-table extras', () => {
       expect(result).to.equal('001234');
       expect(result).to.be.a('string');
     });
+
+    test('single-column: does not apply entry coercion to subfields of a complex entry', async () => {
+      const el = await newTable();
+      el.columns = [{}]; // single column, one-subfield complex
+      const result = el._normalizeItem({ address: '007' });
+
+      expect(result).to.deep.equal({ address: '007' });
+      expect(result.address).to.be.a('string');
+    });
+
+    test('single-column: still coerces subfields that round-trip as numbers', async () => {
+      const el = await newTable();
+      el.columns = [{}];
+      const result = el._normalizeItem({ address: '42' });
+
+      expect(result).to.deep.equal({ address: 42 });
+    });
   });
 
   // ------------------------------------------------------------------
@@ -1054,11 +1071,140 @@ suite('iron-data-table extras', () => {
   });
 
   // ------------------------------------------------------------------
+  // _isComplexEntry
+  // ------------------------------------------------------------------
+  suite('_isComplexEntry', () => {
+    function formWith(markup) {
+      const template = document.createElement('template');
+      template.innerHTML = markup;
+      return { queryEffectiveChildren: () => template };
+    }
+
+    // Mirrors what a form looks like once Polymer has parsed and stamped its template: the markup
+    // has been moved out and the binding annotations survive only in the parsed template info.
+    function stampedFormWith(...sources) {
+      const template = document.createElement('template');
+      const parts = sources.map((source) => {
+        return { source };
+      });
+      template._templateInfo = { nodeInfoList: [{ bindings: [{ target: 'value', parts }] }] };
+      return { queryEffectiveChildren: () => template };
+    }
+
+    test('treats sub-property bindings as complex entries', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Address' }];
+
+      expect(el._isComplexEntry(formWith('<nuxeo-input value="{{item.address}}"></nuxeo-input>'))).to.be.true;
+    });
+
+    test('treats whole-value bindings as primitive entries', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Value' }];
+
+      expect(el._isComplexEntry(formWith('<nuxeo-input value="{{item}}"></nuxeo-input>'))).to.be.false;
+    });
+
+    test('treats event-annotated whole-value bindings as primitive entries', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Value' }];
+
+      expect(el._isComplexEntry(formWith('<input value="{{item::input}}">'))).to.be.false;
+    });
+
+    test('detects sub-properties inside computed bindings', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Date' }];
+
+      expect(el._isComplexEntry(formWith('<span>[[formatDate(item.date)]]</span>'))).to.be.true;
+    });
+
+    test('does not mistake an "items" reference for a sub-property', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Value' }];
+
+      expect(el._isComplexEntry(formWith('<span>[[items.length]]</span><input value="{{item}}">'))).to.be.false;
+    });
+
+    test('falls back to the shape of existing entries when no template is available', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Only' }];
+
+      el.items = [{ address: 'a' }];
+      expect(el._isComplexEntry(null)).to.be.true;
+
+      el.items = ['a'];
+      expect(el._isComplexEntry(null)).to.be.false;
+    });
+
+    test('skips null and undefined entries when sampling existing entries', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Only' }];
+      el.items = [null, undefined, { address: 'a' }];
+
+      expect(el._isComplexEntry(null)).to.be.true;
+    });
+
+    test('falls back to column count for an empty list with no template', async () => {
+      const el = await newTable();
+      el.items = [];
+
+      el.columns = [{ name: 'Only' }];
+      expect(el._isComplexEntry(null)).to.be.false;
+
+      el.columns = [{ name: 'A' }, { name: 'B' }];
+      expect(el._isComplexEntry(null)).to.be.true;
+    });
+
+    test('reads the entry shape from a stamped template whose markup is gone', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Address' }];
+      el.items = [];
+
+      expect(el._isComplexEntry(stampedFormWith('item.address'))).to.be.true;
+    });
+
+    test('reads primitive entries from a stamped template whose markup is gone', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Value' }];
+      el.items = [];
+
+      expect(el._isComplexEntry(stampedFormWith('item'))).to.be.false;
+    });
+
+    test('reads the entry shape from a template parsed by the templatizer', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Address' }];
+      el.items = [];
+
+      const template = document.createElement('template');
+      template.__templateInfo = {
+        nodeInfoList: [{ bindings: [{ target: 'value', parts: [{ source: 'item.address' }] }] }],
+      };
+
+      expect(el._isComplexEntry({ queryEffectiveChildren: () => template })).to.be.true;
+    });
+
+    test('ignores binding parts that carry no property path', async () => {
+      const el = await newTable();
+      el.columns = [{ name: 'Only' }];
+      el.items = [{ address: 'a' }];
+
+      expect(el._isComplexEntry(stampedFormWith(undefined))).to.be.true;
+    });
+  });
+
+  // ------------------------------------------------------------------
   // _toggleEditDialog
   // ------------------------------------------------------------------
   suite('_toggleEditDialog', () => {
-    function makeMockForm(el) {
+    function makeMockForm(el, markup) {
       const form = { index: -1, item: null };
+      if (typeof markup === 'string') {
+        const template = document.createElement('template');
+        template.innerHTML = markup;
+        form.queryEffectiveChildren = () => template;
+      }
       sinon.stub(el, 'getContentChildren').returns([form]);
       sinon.stub(el.$.dialog, 'toggle');
       return form;
@@ -1101,7 +1247,7 @@ suite('iron-data-table extras', () => {
       expect(form.item).to.equal('');
     });
 
-    test('sets form to empty string when single column', async () => {
+    test('sets form to empty object when a single column holds complex items', async () => {
       const el = await newTable();
       el.items = [{ a: 1 }, { b: 2 }];
       el.columns = [{ name: 'Only' }];
@@ -1110,7 +1256,53 @@ suite('iron-data-table extras', () => {
       el._toggleEditDialog();
 
       expect(form.index).to.equal(-1);
+      expect(form.item).to.deep.equal({});
+    });
+
+    test('sets form to empty object for an empty single-column complex field', async () => {
+      const el = await newTable();
+      el.items = [];
+      el.columns = [{ name: 'Address' }];
+      const form = makeMockForm(el, '<nuxeo-input value="{{item.address}}" name="address"></nuxeo-input>');
+
+      el._toggleEditDialog();
+
+      expect(form.index).to.equal(-1);
+      expect(form.item).to.deep.equal({});
+    });
+
+    test('sets form to empty string for an empty single-column primitive field', async () => {
+      const el = await newTable();
+      el.items = [];
+      el.columns = [{ name: 'Multi String' }];
+      const form = makeMockForm(el, '<nuxeo-input value="{{item}}" name="string"></nuxeo-input>');
+
+      el._toggleEditDialog();
+
+      expect(form.index).to.equal(-1);
       expect(form.item).to.equal('');
+    });
+
+    // WEBUI-1443: a complex type with a single subfield renders one column, exactly like a list of
+    // primitives. Once the form has been stamped its markup is empty, so the shape has to come from
+    // the parsed binding info, otherwise the entry is seeded as '' and the typed value is dropped.
+    test('seeds an object for a stamped single-column complex form', async () => {
+      const el = await newTable();
+      el.items = [];
+      el.columns = [{ name: 'Address' }];
+
+      const template = document.createElement('template');
+      template._templateInfo = {
+        nodeInfoList: [{ bindings: [{ target: 'value', parts: [{ source: 'item.address' }] }] }],
+      };
+      const form = { index: -1, item: null, queryEffectiveChildren: () => template };
+      sinon.stub(el, 'getContentChildren').returns([form]);
+      sinon.stub(el.$.dialog, 'toggle');
+
+      el._toggleEditDialog();
+
+      expect(template.innerHTML).to.equal('');
+      expect(form.item).to.deep.equal({});
     });
 
     test('handles index 0 as a valid itemIndex', async () => {

--- a/ui/test/iron-data-table.test.js
+++ b/ui/test/iron-data-table.test.js
@@ -682,6 +682,22 @@ suite('iron-data-table extras', () => {
 
       expect(result).to.deep.equal({ address: 42 });
     });
+
+    test('single-column: applies entry coercion to each element of a list of entries', async () => {
+      const el = await newTable();
+      el.columns = [{}];
+      const result = el._normalizeItem(['007', '42']);
+
+      expect(result).to.deep.equal([7, 42]);
+    });
+
+    test('single-column: does not apply entry coercion inside an array subfield', async () => {
+      const el = await newTable();
+      el.columns = [{}];
+      const result = el._normalizeItem({ codes: ['007', '42'] });
+
+      expect(result).to.deep.equal({ codes: ['007', 42] });
+    });
   });
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A multi-valued complex field that declares a **single subfield** renders a one-column `nuxeo-data-table`. Adding an entry produced an empty row — the value typed in the edit dialog was silently dropped — and creating the document then failed with `Unable to deserialize property: monocomplex:signataires/-1` (HTTP 400).

Jira: [ELEMENTS-2030](https://hyland.atlassian.net/browse/ELEMENTS-2030) (the fix lives entirely in `nuxeo-elements`; originally reported against Web UI as [WEBUI-1443](https://hyland.atlassian.net/browse/WEBUI-1443)).

## Root cause

`iron-data-table._toggleEditDialog()` decided the shape of a new entry from the column count:

```js
if ((this.items.length > 1 && typeof this.items[0] !== 'object') || this.columns.length === 1) {
  dtform.item = ''; // primitive
} else {
  dtform.item = {}; // complex
}
```

A complex type with one subfield produces exactly one column, indistinguishable from a list of primitives, so the entry was seeded as `''`. The form binds `{{item.address}}`, and Polymer cannot set a sub-path on a string, so the typed value never reached `items`. The array kept `''`, which the server then refused to deserialize into a complex list — the two symptoms in the ticket are the same root cause.

## Changes

* **`ui/nuxeo-data-table/iron-data-table.js`**
  * `_isComplexEntry()` replaces the column-count heuristic. It derives the entry shape from what the form template actually binds to: a sub-property binding (`item.address`) can only target an object, a whole-value binding (`item`) only a primitive.
  * `_getTemplateBindingSources()` / `_collectBindingSources()` read Polymer's parsed template info. This is the load-bearing detail — by the time the dialog opens the form has already been stamped, so `template.innerHTML` is empty and the binding annotations have been stripped from the markup. The parsed info is the only surviving record of what the form writes to. The walk skips host-prop parts (a `<template is="dom-if">` forwards `item` to its nested template, which would otherwise read as a whole-value binding), recurses into nested template info, and reads computed-binding arguments from `part.dependencies[].name`, since for `[[formatDate(item.date)]]` the part's `source` is the whole expression.
  * Detection degrades safely: parsed bindings → raw markup (for templates Polymer has not parsed yet) → shape of existing entries → column count.
  * `_normalizeItem()` takes an `isEntry` flag so the single-column numeric coercion applies only to top-level entries. Previously a subfield of a one-subfield complex could be coerced, turning `"007"` into `7`.
* **`ui/test/iron-data-table.test.js`** — covers both detection paths and every fallback, plus an `against templates parsed by Polymer` suite that mounts a real `<nuxeo-data-table-form>` and lets Polymer parse and stamp the template, rather than asserting against hand-built template info.

## Test plan

- [x] `npm run lint` passes (Polymer lint + ESLint + Prettier)
- [x] `npm test` passes — 3931 tests (core 164, ui 3738, dataviz 29), 0 failures
- [x] New tests verified to fail against the pre-fix source (6 failures), so they pin the defects rather than describing them
- [x] Verified end-to-end against a Nuxeo instance with the reporter's `monocomplex` Studio bundle: entry seeded as `{}`, the row renders the address, the document creates, and the server persists `monocomplex:signataires = [{"address":"12 Rue de la Paix"}]` with no deserialization error
- [x] Control run forcing the pre-fix decision in the same environment reproduces the original blank row and dropped value
- [ ] QA: confirm existing single-column **primitive** lists (list of strings/numbers) still add entries correctly

## Notes

`_templateInfo` is Polymer-internal. Access is guarded (a missing `templateInfo`/`nodeInfoList` yields `[]`) and every previous code path is retained as a fallback, so an internal change degrades to the old behaviour rather than throwing. The assumed shape is now pinned by tests that let Polymer do the parsing, so a future Polymer change surfaces as a test failure instead of silent misdetection.

ELEMENTS-2030 lists `fixVersions: 3.1.x`, but the faulty heuristic is present on `lts-2025` as well, so the fix is proposed on both lines. Please confirm whether `fixVersions` should also include the 2025 line.

Backport pair: the matching PR for `maintenance-3.1.x` is https://github.com/nuxeo/nuxeo-elements/pull/1581.
