### PR TITLE
ELEMENTS-2029: bump trigger-workflow action to off-by-one fix [lts-2025]

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "BRANCH_NAME=${GITHUB_HEAD_REF##*/}" >> $GITHUB_ENV
 
       - name: Web UI preview
-        uses: nuxeo/ui-team-gh-actions/trigger-workflow@a5b89f35e0d1f3a912f528d7f1c3acdb73c60549
+        uses: nuxeo/ui-team-gh-actions/trigger-workflow@46f1ea323a97203402dbc57d0537bd5b6a6099eb
         with:
           owner: nuxeo
           repo: nuxeo-web-ui

--- a/.github/workflows/cross-repo.yaml
+++ b/.github/workflows/cross-repo.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Web UI cross repo check
-        uses: nuxeo/ui-team-gh-actions/trigger-workflow@dcf8be425447c7fb9cdd1e048585a6df905ed878
+        uses: nuxeo/ui-team-gh-actions/trigger-workflow@46f1ea323a97203402dbc57d0537bd5b6a6099eb
         with:
           owner: nuxeo
           repo: nuxeo-web-ui


### PR DESCRIPTION
Re-points the `trigger-workflow` action to the fixed SHA merged in [nuxeo/ui-team-gh-actions#6](https://github.com/nuxeo/ui-team-gh-actions/pull/6) (`main` = `46f1ea323a97203402dbc57d0537bd5b6a6099eb`), which fixes the intermittent cross-repo check crash `Cannot read properties of undefined (reading 'id')`.

**Changes (2 files):**
- `.github/workflows/cross-repo.yaml`: `trigger-workflow@dcf8be4` → `@46f1ea3`
- `.github/workflows/cleanup.yaml`: `trigger-workflow@a5b89f35` → `@46f1ea3`

`preview.yaml` is **intentionally left** on its current pin for now (handled separately).

Jira: [ELEMENTS-2029](https://hyland.atlassian.net/browse/ELEMENTS-2029)

🤖 Generated with [Claude Code](https://claude.com/claude-code)