### PR TITLE
ELEMENTS-2020: Security Fix: axios (1.16.0 → 1.18.0) [LTS-2025]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6189,15 +6189,43 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {

--- a/package.json
+++ b/package.json
@@ -138,5 +138,8 @@
     "@polymer/test-fixture": "^4.0.2",
     "marked": "^4.0.17",
     "nuxeo": "^4.0.3"
+  },
+  "overrides": {
+    "axios": "1.18.0"
   }
 }


### PR DESCRIPTION
# Security Fix: axios

## Summary
This PR addresses Dependabot security alerts for `axios` (SSRF / credential-leak / DoS) in nuxeo-elements by pinning it to the patched `1.18.0` via a root `package.json` `overrides` entry.

## Resolves Dependabot Security Alerts
- [Security Alert #188](https://github.com/nuxeo/nuxeo-elements/security/dependabot/188) — package-lock.json (High, GHSA-gcfj-64vw-6mp9)
- [Security Alert #194](https://github.com/nuxeo/nuxeo-elements/security/dependabot/194) — package-lock.json (Medium, GHSA-7q8q-rj6j-mhjq)
- [Security Alert #193](https://github.com/nuxeo/nuxeo-elements/security/dependabot/193) — package-lock.json (Medium, GHSA-mmx7-hfxf-jppx)
- [Security Alert #185](https://github.com/nuxeo/nuxeo-elements/security/dependabot/185) — package-lock.json (Medium, GHSA-f4gw-2p7v-4548)
- [Security Alert #183](https://github.com/nuxeo/nuxeo-elements/security/dependabot/183) — package-lock.json (Medium, GHSA-xj6q-8x83-jv6g)

> These alerts stay **open** after this PR merges. Dependabot only re-scans branches it tracks, so they dismiss once the `security-fixes-Q3-lts-*` integration branch is merged up into `lts-2025` / `maintenance-3.1.x` — not when this PR lands. The proof the fix works is the CVE-resolution check below.

**CVE:** Not assigned
**GHSA:** GHSA-gcfj-64vw-6mp9 (High), GHSA-7q8q-rj6j-mhjq, GHSA-f4gw-2p7v-4548, GHSA-mmx7-hfxf-jppx, GHSA-xj6q-8x83-jv6g (Medium)
**Severity:** high (1) / medium (4)

## Vulnerability Details
`axios` versions in the vulnerable ranges (`< 1.18.0`) are affected by SSRF and credential-leak issues via absolute-URL and redirect handling (a caller-specified sensitive header such as an API key could leak on a cross-origin redirect; prototype-pollution on SSRF-sensitive config paths), plus DoS from unbounded response handling. All five advisories are Node.js HTTP-adapter exploits — only reachable when axios is actually making outbound HTTP calls. `1.18.0` fixes all five.

## Fix Strategy
- **Type:** override (transitive, dev/build-only)
- **Updated to:** `axios@1.18.0`
- **Files changed:**
  - `package.json` (added `overrides` block)
  - `package-lock.json`
- **Other packages changed and why:** None outside `axios`'s own dependency tree. The bump pulls in axios `1.18.0`'s own newly-declared deps nested under `node_modules/axios/` (`https-proxy-agent@5.0.1` → `agent-base@6.0.2`, both dev-only) — a structural consequence of the target upgrade, not unrelated drift. `lerna` (9.0.7) and `nx` (22.7.7) are unchanged.
- **Why override:** `axios` is a transitive dev dependency reached via `lerna@9.0.7` → `nx@22.7.7`, and `nx` pins `axios@1.16.0` exactly. `lerna` is already on its latest release, so there is no parent bump available; an `overrides` entry is the minimal fix. Revisit only if `nx`/`lerna` later relax the pin.
- **Same-manifest instances:** 1 resolved instance — fixed (`1.16.0` → `1.18.0`).
- **Cross-manifest scan:** n/a — nuxeo-elements has a single shared root `package-lock.json`.

## Version Compatibility
**Upgrade path:** 1.16.0 → 1.18.0 (minor × 2, within major 1.x)

**Research findings:**
- Reviewed axios 1.17.0 and 1.18.0 release notes / advisories.
- **Breaking changes:** None. Both are security-hardening minor releases; the only semantics change (`validateStatus: undefined`) is opt-in via a `transitional` flag.
- **Backward compatible:** yes

**Safety assessment:** ✅ **Safe to merge**
axios is invoked only by nx/lerna during CI release workflows (registry HTTP calls in `lerna version` / `lerna exec … npm publish`); it never reaches the browser bundle or any shipped `@nuxeo/*` package.

## Local Validation Results
**CVE Resolution (two independent sources):**
- Lockfile scan: `package-lock.json` — axios: 1 resolved instance, all clear of vulnerable range `< 1.18.0` (resolves to `1.18.0`).
- `npm audit` flagged-instance diff: axios: 1 node flagged before (`node_modules/axios`) → 0 after; removed: `node_modules/axios`; still flagged: none.
- Manifest coverage: the single changed lockfile (`package-lock.json`) covers every alert's `manifest_path`.

**Testing:**
- Lint: ✅ Pass (`npm run lint` — polymer lint + eslint + prettier; 0 errors)
- Build: n/a (nuxeo-elements is a published component library, no build step)
- Unit tests: ✅ Pass (full suite — `npm test`: core + ui + dataviz all green)

## Manual Testing Steps
**Affected Features:** None in end-user product — `axios` is a dev/build-only dependency with no runtime code path in any shipped element or Web UI bundle.

**Testing Checklist (release/publish workflow — the only path that exercises axios):**
- [ ] `npm ls axios` after `npm install` resolves a single `1.18.0` instance (override effective, no leftover `1.16.0`).
- [ ] lerna dry-run publish still works: `npx lerna@9.0.7 exec --ignore @nuxeo/nuxeo-elements-storybook -- npm publish --dry-run`.
- [ ] CI release/build job (`main.yaml` build, or `alpha.yaml`) goes green — it invokes lerna and thus exercises the axios code path end-to-end.

## Cross-repo follow-up
n/a — self-contained in this repo. nuxeo-web-ui installs neither lerna nor nx, and the published `@nuxeo/*` packages carry no axios runtime dependency, so no companion `WEBUI-` bump is required.

---
Jira: https://hyland.atlassian.net/browse/ELEMENTS-2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
