### PR TITLE
ELEMENTS-2024: Security Fix: brace-expansion [LTS-2025]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1335,16 +1335,16 @@
       }
     },
     "node_modules/@npmcli/arborist/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@npmcli/arborist/node_modules/lru-cache": {
@@ -1611,16 +1611,16 @@
       }
     },
     "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@npmcli/map-workspaces/node_modules/glob": {
@@ -1734,16 +1734,16 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@npmcli/package-json/node_modules/glob": {
@@ -2013,16 +2013,16 @@
       }
     },
     "node_modules/@nx/devkit/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@nx/devkit/node_modules/minimatch": {
@@ -4783,16 +4783,16 @@
       }
     },
     "node_modules/@tufjs/models/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@tufjs/models/node_modules/minimatch": {
@@ -6497,17 +6497,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -6682,16 +6671,16 @@
       }
     },
     "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/cacache/node_modules/glob": {
@@ -10746,16 +10735,16 @@
       }
     },
     "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/ignore-walk/node_modules/minimatch": {
@@ -12326,6 +12315,17 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/lerna/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/lerna/node_modules/chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -13316,6 +13316,17 @@
         "node": "*"
       }
     },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -13589,6 +13600,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/mocha/node_modules/camelcase": {
@@ -14930,9 +14952,9 @@
       }
     },
     "node_modules/nuxeo/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -15347,16 +15369,16 @@
       }
     },
     "node_modules/nx/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/nx/node_modules/buffer": {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,9 @@
   },
   "overrides": {
     "axios": "1.18.0",
+    "brace-expansion@1": "1.1.18",
+    "brace-expansion@2": "2.1.4",
+    "brace-expansion@5": "5.0.9",
     "js-yaml@3": "3.15.1",
     "js-yaml@4": "4.3.1"
   }


### PR DESCRIPTION
# Security Fix: brace-expansion

## Summary
This PR addresses Dependabot security alert(s) for `brace-expansion` (Regular Expression / unbounded-expansion Denial of Service) in `nuxeo-elements`, on the **LTS-2025** line.

## Resolves Dependabot Security Alerts
- [Security Alert #184](https://github.com/nuxeo/nuxeo-elements/security/dependabot/184) — `package-lock.json` — CVE-2026-13149 / [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp), dev, range `< 1.1.16`
- [Security Alert #189](https://github.com/nuxeo/nuxeo-elements/security/dependabot/189) — `package-lock.json` — CVE-2026-13149 / [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp), dev, range `>= 3.0.0, < 5.0.7`
- [Security Alert #206](https://github.com/nuxeo/nuxeo-elements/security/dependabot/206) — `package-lock.json` — CVE-2026-14257 / [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), runtime, range `>= 2.0.0, < 2.1.3`
- [Security Alert #217](https://github.com/nuxeo/nuxeo-elements/security/dependabot/217) — `package-lock.json` — CVE-2026-69152 / [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895), runtime, range `>= 2.0.0, < 2.1.4`

> These alerts stay **open** after this PR merges. Dependabot only re-scans branches it tracks, so they dismiss once `security-fixes-Q3-lts-2025` is merged up into `lts-2025` — not when this PR lands. The proof the fix works is the CVE-resolution check below (lockfile scan + `npm audit` → 0 flagged instances).

**CVE:** CVE-2026-13149, CVE-2026-14257, CVE-2026-69152
**GHSA:** GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895
**Severity:** High

## Vulnerability Details
`brace-expansion` is vulnerable to Denial of Service through pathological brace-pattern expansion: exponential-time expansion of consecutive non-expanding `{}` groups (CVE-2026-13149) and unbounded expansion length / unbounded intermediate arrays causing an out-of-memory crash (CVE-2026-14257, and CVE-2026-69152 which bypasses the 14257 mitigation). An attacker who controls a brace-expansion input can hang or OOM the process. In this repo `brace-expansion` is transitive: a **runtime** copy via `nuxeo` (the JS client) → `minimatch@^2.0.1` → `brace-expansion@2.x`, and several **dev/build-time** copies via the `nx` / `lerna` / `@npmcli` / `minimatch` tooling chain (`1.x` and `5.x` lines).

## Fix Strategy
- **Type:** override (three scoped overrides, per major)
- **Updated to:** `brace-expansion@1 → 1.1.18`, `brace-expansion@2 → 2.1.4`, `brace-expansion@5 → 5.0.9`
- **Files changed:**
  - `package.json` (added `overrides`)
  - `package-lock.json`
- **Why scoped overrides per major:** `brace-expansion` resolves as several independent instances at different majors — a runtime `2.x` under the `nuxeo` client and dev `1.x`/`5.x` under the build tooling (`minimatch`/`nx`/`@npmcli`) — each with its own patched version. A single global `brace-expansion` override would force one line across a major boundary its parent never declared support for (e.g. dragging the runtime `2.x` under `minimatch@^2.0.1` up to a `5.x`), an untested pairing that risks a runtime break. Scoping per major (`@1`/`@2`/`@5`) clears every advisory while keeping each instance inside its supported major. Parent-bumping was not an option here: `lerna` is already latest, and `nx` pins `brace-expansion@5.0.6` exactly and is capped below its next major by `lerna`'s peer range, so an override is required to move it.
- **Other packages changed and why:** None — only `brace-expansion` instances changed (verified in the lockfile diff: the top-level `1.1.16` node was replaced by nested `1.1.18` copies under `lerna`/`minimatch`/`mocha`, and the `2.x`/`5.x` nodes moved to their patched versions; no other package's resolved tarball changed).
- **Same-manifest instances:** 12 resolved instances after the fix — all clear. Runtime `2.x` (`nuxeo → minimatch`) → `2.1.4`; dev `5.x` (8 build-tooling copies incl. the `nx`-pinned one) → `5.0.9`; dev `1.x` (3 copies under `lerna`/`minimatch`/`mocha`) → `1.1.18`.

## Version Compatibility
**Upgrade path:** `1.1.16 → 1.1.18`, `2.1.2 → 2.1.4`, `5.0.6/5.0.7 → 5.0.9` (patch-level bumps within each major)

**Research findings:**
- Reviewed the `brace-expansion` advisories (GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895) and their patched versions.
- **Breaking changes:** none — all are patch releases within the same major.
- **Backward compatible:** yes.

**Safety assessment:** ✅ **Safe to merge**
Patch-level, no-API-change ReDoS/DoS fixes. Each instance stays within the major its parent declared support for. Full lint + unit suites pass.

## Local Validation Results
**CVE Resolution (two independent sources):**
- Lockfile scan: `package-lock.json` — `brace-expansion`: 12 resolved instances, all clear of `<1.1.18`, `>=2.0.0 <2.1.4`, and `>=4.0.0 <5.0.9`.
- `npm audit` flagged-instance diff: `brace-expansion`: 10 nodes flagged before → **0 after** (fully cleared across ALL advisories, including the wider GHSA-mh99 `<1.1.17 || >=4.0.0 <5.0.8` and GHSA-rgw5 `<1.1.18 || >=4.0.0 <5.0.9` ranges). Removed nodes: the runtime `nuxeo` `2.x` copy plus all dev `1.x`/`5.x` copies.
- Manifest coverage: the single root `package-lock.json` covers every alert's `manifest_path` (all four report `package-lock.json`).

**Testing:**
- Lint: ✅ Pass (`npm run lint` — polymer lint + eslint + prettier; only pre-existing warnings in untouched files, 0 errors)
- Build: n/a (nuxeo-elements is a published component library, no build step)
- Unit tests: ✅ Pass (full suite — core 164, ui 3715 (+2 skipped), dataviz 29; all passed)

## Manual Testing Steps
**Affected Features:** none directly — `brace-expansion` is a transitive dependency of glob/minimatch used internally.

**Testing Checklist:**
- [ ] Data-layer smoke sanity: exercise the `nuxeo` JS client path (connection + a document fetch/query) to confirm the runtime `minimatch@^2.0.1 → brace-expansion@2.1.4` bump behaves normally. This is a no-API-change patch, so no broader UI regression is expected; the only runtime-reachable instance is in the data-layer/`nuxeo`-client tree.

## Cross-repo follow-up
Once this is published (SNAPSHOT then promoted), a **separate follow-up in `nuxeo-web-ui` is still required**: `nuxeo-web-ui` independently resolves the `nuxeo` client's `brace-expansion@2.x` below `2.1.4` and needs its own bump — a security PR here does not close the `WEBUI`-side alert. This is only a reminder; that ticket is not created here.

---
Jira: https://hyland.atlassian.net/browse/ELEMENTS-2024
