### PR TITLE
ELEMENTS-2032: Security Fix: ip-address, undici, nanoid, postcss [LTS-2023]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11019,9 +11019,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14229,9 +14229,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -16810,9 +16810,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -16829,7 +16829,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -19553,9 +19553,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
# Security Fix: ip-address, undici, nanoid, postcss

## Summary
This PR addresses 8 Dependabot security alerts (2 high, 6 medium) for four transitive dev-toolchain dependencies in nuxeo-elements. Lockfile-only refresh, no `package.json` change.

## Resolves Dependabot Security Alerts
- [Security Alert #212](https://github.com/nuxeo/nuxeo-elements/security/dependabot/212) — ip-address (high, CVE-2026-69192) — package-lock.json
- [Security Alert #210](https://github.com/nuxeo/nuxeo-elements/security/dependabot/210) — ip-address (medium, CVE-2026-69198) — package-lock.json
- [Security Alert #209](https://github.com/nuxeo/nuxeo-elements/security/dependabot/209) — ip-address (medium, CVE-2026-54272) — package-lock.json
- [Security Alert #215](https://github.com/nuxeo/nuxeo-elements/security/dependabot/215) — undici (medium, CVE-2026-16729) — package-lock.json
- [Security Alert #214](https://github.com/nuxeo/nuxeo-elements/security/dependabot/214) — undici (medium, CVE-2026-15157) — package-lock.json
- [Security Alert #213](https://github.com/nuxeo/nuxeo-elements/security/dependabot/213) — undici (medium, CVE-2026-16728) — package-lock.json
- [Security Alert #220](https://github.com/nuxeo/nuxeo-elements/security/dependabot/220) — nanoid (high, CVE-2026-67213) — package-lock.json
- [Security Alert #218](https://github.com/nuxeo/nuxeo-elements/security/dependabot/218) — postcss (medium, CVE-2026-69153) — package-lock.json

> These alerts stay **open** after this PR merges. Dependabot only re-scans branches it tracks, so they dismiss once `security-fixes-Q3-lts-2023` is merged up into `maintenance-3.1.x` — not when this PR lands. The proof the fix works is the CVE-resolution check below.

**Severity:** 2 high / 6 medium

## Vulnerability Details
- **ip-address** — SSRF / trust-boundary classifier bypass: a CIDR suffix on a bare address ([alert #212](https://github.com/nuxeo/nuxeo-elements/security/dependabot/212)) and IPv4-mapped / NAT64 IPv6 forms ([alert #210](https://github.com/nuxeo/nuxeo-elements/security/dependabot/210)/[alert #209](https://github.com/nuxeo/nuxeo-elements/security/dependabot/209)) are misclassified so internal targets pass an allow/deny check.
- **undici** — cookie attribute injection via unsanitized `domain`/`unparsed` ([alert #215](https://github.com/nuxeo/nuxeo-elements/security/dependabot/215)), CRLF injection via a duck-typed blob `.type` ([alert #214](https://github.com/nuxeo/nuxeo-elements/security/dependabot/214)), and retry-interceptor response desync with a stale `Content-Length` ([alert #213](https://github.com/nuxeo/nuxeo-elements/security/dependabot/213)).
- **nanoid** — infinite-loop DoS in `customAlphabet`/`customRandom` when `size` is 0 ([alert #220](https://github.com/nuxeo/nuxeo-elements/security/dependabot/220)).
- **postcss** — arbitrary `.map` file read via attacker-controlled `sourceMappingURL` when `from` is unset, leaking `sources`/`sourcesContent` ([alert #218](https://github.com/nuxeo/nuxeo-elements/security/dependabot/218)).

**Exposure in this repo:** all four are dev/build/test/docs tooling only (ip-address + undici via lerna's publish stack; nanoid via @web/test-runner-core; postcss via storybook's vite). None is a declared dependency of the published `@nuxeo/*` workspaces (core, ui, dataviz, testing-helpers), so none ships to runtime — the vulnerable code paths are not reachable with attacker-controlled input here.

## Fix Strategy
- **Type:** lockfile-only (`npm update ip-address undici nanoid postcss --package-lock-only`)
- **Updated to (within same major):** ip-address 10.2.0 → 10.5.0, undici 6.27.0 → 6.28.0, nanoid 3.3.16 → 3.3.18, postcss 8.5.18 → 8.5.26
- **Files changed:** package-lock.json (only)
- **Other packages changed and why:** None — the diff is exactly the 4 target packages (8 version lines), no siblings touched.
- **Same-manifest instances:** 1 resolved instance each — all fixed.

## Local Validation Results
**CVE Resolution (two independent sources):**
- Lockfile scan: package-lock.json — all 4 packages resolve a single instance, each clear of its vulnerable range (ip-address ≤10.3.0, undici <6.28.0, nanoid <3.3.17, postcss ≤8.5.22).
- `npm audit` flagged-instance diff: before → ip-address 1 [high], undici 1 [mod], nanoid 1 [high], postcss 1 [mod]; after → all four **not flagged**.
- Manifest coverage: the single changed lockfile (package-lock.json) covers every alert's manifest_path.

**Testing:**
- Lint: ✅ Pass (0 errors; 20 pre-existing warnings unrelated)
- Build: n/a (nuxeo-elements has no bundler/build step)
- Unit tests: ✅ Pass (full suite — core, ui, dataviz)
- `lerna run analysis`: ✅ Pass (exercises lerna task runner + ip-address/undici stack)
- Storybook build: ✅ Pass (exercises postcss via vite)

## Manual Testing Steps
Dev-toolchain-only change, 🟢 low risk. Sanity already covered by the automated gates above (lerna publish/analysis stack for ip-address/undici, test runner for nanoid, storybook/vite build for postcss). No product-UI regression path exists because none of these ship in the `@nuxeo/*` bundles.

## Cross-repo follow-up
n/a — independent repos. nuxeo-web-ui carries its own copies of these packages at `dev:true` in its own lockfile; they do **not** flow there through the published `@nuxeo/*` packages, so this is not a shipped-dependency propagation. Any nuxeo-web-ui alerts are that repo's own Dependabot tickets.

---
Jira: https://hyland.atlassian.net/browse/ELEMENTS-2032

