### PR TITLE
ELEMENTS-2036: give tree nodes a valid ARIA structure [LTS-2025]

### DIFF
--- a/ui/nuxeo-tree/nuxeo-tree-node.js
+++ b/ui/nuxeo-tree/nuxeo-tree-node.js
@@ -135,7 +135,10 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
         const direction = document.documentElement.getAttribute('dir');
         this.setAttribute('dir', direction);
       }
-      if (!this.hasAttribute('role')) {
+      // An empty or whitespace-only role exposes no role at all, so it is treated as unset rather
+      // than as a consumer-supplied one that must be preserved.
+      const role = this.getAttribute('role');
+      if (role === null || role.trim() === '') {
         this.setAttribute('role', 'none');
       }
     }

--- a/ui/nuxeo-tree/nuxeo-tree-node.js
+++ b/ui/nuxeo-tree/nuxeo-tree-node.js
@@ -135,6 +135,9 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
         const direction = document.documentElement.getAttribute('dir');
         this.setAttribute('dir', direction);
       }
+      if (!this.hasAttribute('role')) {
+        this.setAttribute('role', 'none');
+      }
     }
 
     static get observers() {
@@ -198,6 +201,9 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 
         const content = document.createElement('div');
         content.id = 'content';
+        // The node host and this wrapper are layout-only: leaving them untyped puts generic nodes
+        // between role="tree" and the stamped role="treeitem", which is not a valid tree structure.
+        content.setAttribute('role', 'none');
         dom(content).appendChild(this._instance.root);
         dom(this).appendChild(content);
 
@@ -206,6 +212,9 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
         children.opened = this.opened;
         children.loading = this.loading;
         children.noAnimation = 'true';
+        // WEBUI-1877: without a group role this collapse is an untyped node between the tree and its
+        // treeitems, which invalidates the tree structure and can suppress state announcements.
+        children.setAttribute('role', 'group');
         dom(this).appendChild(children);
 
         flush();

--- a/ui/test/nuxeo-tree.test.js
+++ b/ui/test/nuxeo-tree.test.js
@@ -94,5 +94,23 @@ suite('nuxeo-tree', () => {
       expect(removeSpy).to.have.been.called;
       removeSpy.restore();
     });
+
+    // WEBUI-1877: a consumer puts role="tree"/role="treeitem" around these nodes, so the layout-only
+    // wrappers must not sit in the accessibility tree as untyped nodes.
+    test('the node wrappers are presentational and children form a group', () => {
+      const root = tree.querySelector('nuxeo-tree-node');
+      expect(root.getAttribute('role')).to.equal('none');
+      expect(root.querySelector('#content').getAttribute('role')).to.equal('none');
+      expect(root.querySelector('#children').getAttribute('role')).to.equal('group');
+    });
+
+    test('an explicit role on a node is preserved', async () => {
+      const node = document.createElement('nuxeo-tree-node');
+      node.setAttribute('role', 'treeitem');
+      tree.appendChild(node);
+      await flush();
+      expect(node.getAttribute('role')).to.equal('treeitem');
+      node.remove();
+    });
   });
 });

--- a/ui/test/nuxeo-tree.test.js
+++ b/ui/test/nuxeo-tree.test.js
@@ -112,5 +112,16 @@ suite('nuxeo-tree', () => {
       expect(node.getAttribute('role')).to.equal('treeitem');
       node.remove();
     });
+
+    // A blank role exposes no role at all, so honouring it would leave the untyped wrapper the
+    // default is meant to remove.
+    test('a blank role is treated as unset', async () => {
+      const node = document.createElement('nuxeo-tree-node');
+      node.setAttribute('role', '  ');
+      tree.appendChild(node);
+      await flush();
+      expect(node.getAttribute('role')).to.equal('none');
+      node.remove();
+    });
   });
 });


### PR DESCRIPTION
## Summary

`nuxeo-tree-node` builds its wrapper elements imperatively, which leaves untyped generic nodes sitting between `role="tree"` and the stamped `role="treeitem"`. That is not a valid tree structure under [WAI-ARIA's treeview pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/), and it can suppress the expanded/collapsed state a screen reader announces for each row.

Two wrappers are now typed:

| Element | Role | Why |
| --- | --- | --- |
| node host + `#content` wrapper | `none` | Layout-only, so they must not appear in the accessibility tree |
| `iron-collapse` holding children | `group` | The only role allowed between a `tree` and its `treeitem`s |

The result is an unbroken `tree` > `group` > `treeitem` chain.

The host role is only defaulted when the element does not already carry a usable one, so a consumer that sets its own role is left alone. A blank or whitespace-only role counts as unset, since an empty role exposes no role at all and would leave exactly the untyped wrapper this change removes.

## Cross-repo context

This is the `nuxeo-elements` half of a fix that spans both repos, tracked here as [ELEMENTS-2036](https://hyland.atlassian.net/browse/ELEMENTS-2036) and on the Web UI side as [WEBUI-1877](https://hyland.atlassian.net/browse/WEBUI-1877).

Web UI puts `aria-expanded` on each Browse tree row, but the state is only reliably announced once the surrounding structure is valid, so this change has to merge and publish first — Web UI consumes it as a published package rather than a source link.

## Related PRs

The fix ships as four PRs, covering both repos on both maintenance lines.

| Repo | Line | PR |
| --- | --- | --- |
| nuxeo-elements | LTS 2023 (`maintenance-3.1.x`) | https://github.com/nuxeo/nuxeo-elements/pull/1617 |
| nuxeo-elements | LTS 2025 | https://github.com/nuxeo/nuxeo-elements/pull/1618 |
| nuxeo-web-ui | LTS 2023 (`maintenance-3.1.x`) | https://github.com/nuxeo/nuxeo-web-ui/pull/3447 |
| nuxeo-web-ui | LTS 2025 | https://github.com/nuxeo/nuxeo-web-ui/pull/3448 |

## Test plan

- [ ] Lint passes (ESLint, Prettier, Polymer lint)
- [ ] Unit tests pass — 3740 passing locally, including new `nuxeo-tree` cases covering the presentational wrappers, the children group, role preservation, and a blank role being treated as unset
- [ ] Existing tree consumers are unaffected: a node with an explicit role keeps it
