### PR TITLE
ELEMENTS-2040: Pin GitHub Actions to full commit SHAs (SonarCloud S7637) [lts-2025]

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -26,7 +26,7 @@ jobs:
           ref: lts-2025
 
       - name: Crowdin Action
-        uses: crowdin/github-action@v2.16.0
+        uses: crowdin/github-action@7ca9c452bfe9197d3bb7fa83a4d7e2b0c9ae835d # v2.16.0
         with:
           # Disable 'git checkout "${GITHUB_REF#refs/heads/}"'
           skip_ref_checkout: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,12 +17,12 @@ env:
 
 jobs:
   lint:
-    uses: nuxeo/nuxeo-elements/.github/workflows/lint.yaml@lts-2025
+    uses: ./.github/workflows/lint.yaml
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
 
   test:
-    uses: nuxeo/nuxeo-elements/.github/workflows/test.yaml@lts-2025
+    uses: ./.github/workflows/test.yaml
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -30,7 +30,7 @@ jobs:
       branch: lts-2025
 
   storybook:
-    uses: nuxeo/nuxeo-elements/.github/workflows/storybook.yaml@lts-2025
+    uses: ./.github/workflows/storybook.yaml
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
       GIT_ADMIN_TOKEN: ${{ secrets.GIT_ADMIN_TOKEN }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -32,7 +32,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
         with:
           comment_on_pr: false
 
@@ -82,7 +82,7 @@ jobs:
         id: sonar_scan
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         with:
           projectBaseDir: ${{ github.workspace }}
           args: >


### PR DESCRIPTION
## Problem
SonarCloud flags several GitHub Actions in `.github/workflows/*.yaml` that are referenced by a mutable tag/branch instead of an immutable full commit SHA (rule `githubactions:S7637`, SECURITY / MAJOR). Mutable tags can be repointed at malicious code — a supply-chain risk. This is the nuxeo-elements counterpart of [WEBUI-2198](https://github.com/nuxeo/nuxeo-web-ui/pull/3456).

## Root cause
Third-party actions were pinned to tags (`@v2`, `@v8.0.0`, `@v2.16.0`), and `main.yaml` called its own reusable workflows via the full `nuxeo/nuxeo-elements/...@lts-2025` branch ref.

## Changes
Third-party actions pinned to full commit SHAs (human-readable version kept as a trailing comment):
- `sonar.yaml` — `catchpoint/workflow-telemetry-action` → `94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2`
- `sonar.yaml` — `SonarSource/sonarqube-scan-action` → `59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0`
- `crowdin.yaml` — `crowdin/github-action` → `7ca9c452bfe9197d3bb7fa83a4d7e2b0c9ae835d # v2.16.0`

First-party reusable workflows in `main.yaml` (`lint` / `test` / `storybook`) converted from `nuxeo/nuxeo-elements/.github/workflows/*.yaml@lts-2025` to local `./.github/workflows/*.yaml` paths — matching `nuxeo-web-ui`'s `main.yaml` and the already-unflagged `sonar` job. This clears S7637 for our own workflows **without** SHA-pinning first-party yaml.

`actions/*` (GitHub-owned) actions are intentionally left as-is; S7637 does not flag them.

## Result
All 6 S7637 findings on `lts-2025` (sonar.yaml 35/85, main.yaml 20/25/33, crowdin.yaml 29) are resolved. Other-rule findings (S6505/S8543/S8233) are out of scope for this ticket.

## Test plan
- [ ] `Build` workflow (lint + test + storybook + sonar) runs green with the `./` reusable-workflow calls.
- [ ] SonarCloud re-scan shows 0 open `githubactions:S7637` findings on `lts-2025`.

## Notes
Behaviour is preserved: `./` reusable-workflow calls resolve to the same repo/ref as the caller; SHA pins point to the exact commit each tag currently resolves to.

---
Jira: https://hyland.atlassian.net/browse/ELEMENTS-2040

Made with [Cursor](https://cursor.com)