### PR TITLE
ELEMENTS-2040: Pin GitHub Actions to full commit SHAs (SonarCloud S7637) [maintenance-3.1.x]

### DIFF
--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Crowdin Action
         id: crowdin-sync
-        uses: crowdin/github-action@v2.16.0
+        uses: crowdin/github-action@7ca9c452bfe9197d3bb7fa83a4d7e2b0c9ae835d # v2.16.0
         with:
           # Disable 'git checkout "${GITHUB_REF#refs/heads/}"'
           skip_ref_checkout: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,12 +17,12 @@ env:
 
 jobs:
   lint:
-    uses: nuxeo/nuxeo-elements/.github/workflows/lint.yaml@maintenance-3.1.x
+    uses: ./.github/workflows/lint.yaml
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
 
   test:
-    uses: nuxeo/nuxeo-elements/.github/workflows/test.yaml@maintenance-3.1.x
+    uses: ./.github/workflows/test.yaml
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -30,7 +30,7 @@ jobs:
       branch: maintenance-3.1.x
 
   storybook:
-    uses: nuxeo/nuxeo-elements/.github/workflows/storybook.yaml@maintenance-3.1.x
+    uses: ./.github/workflows/storybook.yaml
     secrets:
       NPM_PACKAGES_TOKEN: ${{ secrets.NPM_PACKAGES_TOKEN }}
       GIT_ADMIN_TOKEN: ${{ secrets.GIT_ADMIN_TOKEN }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -32,7 +32,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: catchpoint/workflow-telemetry-action@v2
+      - uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2
         with:
           comment_on_pr: false
 
@@ -82,7 +82,7 @@ jobs:
         id: sonar_scan
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         with:
           projectBaseDir: ${{ github.workspace }}
           args: >


### PR DESCRIPTION
## Problem
SonarCloud flags several GitHub Actions in `.github/workflows/*.yaml` that are referenced by a mutable tag/branch instead of an immutable full commit SHA (rule `githubactions:S7637`, SECURITY / MAJOR). Mutable tags can be repointed at malicious code — a supply-chain risk. This is the nuxeo-elements counterpart of [WEBUI-2198](https://github.com/nuxeo/nuxeo-web-ui/pull/3455).

## Root cause
Third-party actions were pinned to tags (`@v2`, `@v8.0.0`, `@v2.16.0`), and `main.yaml` called its own reusable workflows via the full `nuxeo/nuxeo-elements/...@maintenance-3.1.x` branch ref.

## Changes
Third-party actions pinned to full commit SHAs (human-readable version kept as a trailing comment):
- `sonar.yaml` — `catchpoint/workflow-telemetry-action` → `94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2`
- `sonar.yaml` — `SonarSource/sonarqube-scan-action` → `59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0`
- `crowdin.yaml` — `crowdin/github-action` → `7ca9c452bfe9197d3bb7fa83a4d7e2b0c9ae835d # v2.16.0`

First-party reusable workflows in `main.yaml` (`lint` / `test` / `storybook`) converted from `nuxeo/nuxeo-elements/.github/workflows/*.yaml@maintenance-3.1.x` to local `./.github/workflows/*.yaml` paths — matching `nuxeo-web-ui`'s `main.yaml` and the already-unflagged `sonar` job.

`actions/*` (GitHub-owned) actions are left as-is; S7637 does not flag them.

## Deliberate exception (crowdin.yaml, one line left)
`crowdin.yaml`'s `call-workflow-in-lts-2025` job uses a **first-party cross-branch** reusable-workflow call:

```yaml
uses: nuxeo/nuxeo-elements/.github/workflows/crowdin.yaml@lts-2025
```

This deliberately invokes the **lts-2025** version of the Crowdin workflow from the `maintenance-3.1.x` branch (see the in-file comment: owner/repo/ref are hardcoded on purpose). It therefore cannot be converted to a `./` local path (that would call the maintenance workflow instead), and being Nuxeo-owned it is not SHA-pinned. This single S7637 finding is left open by design.

## Result
S7637 resolved on `sonar.yaml` (35/85), `main.yaml` (20/25/33), and `crowdin.yaml`'s third-party `crowdin/github-action`. The only remaining S7637 finding is the intentional first-party cross-branch Crowdin call above. Other-rule findings (S6505/S8543/S8233/S7635) are out of scope.

## Test plan
- [ ] `Build` workflow (lint + test + storybook + sonar) runs green with the `./` reusable-workflow calls.
- [ ] SonarCloud re-scan shows only the documented first-party cross-branch Crowdin S7637 hit remaining on `maintenance-3.1.x`.

## Notes
Behaviour is preserved: `./` reusable-workflow calls resolve to the same repo/ref as the caller; SHA pins point to the exact commit each tag currently resolves to.

---
Jira: https://hyland.atlassian.net/browse/ELEMENTS-2040