### PR TITLE
WEBUI-1726: RFC-compliant document permalink (remove hashbang)

### DIFF
--- a/ui/actions/nuxeo-share-button.js
+++ b/ui/actions/nuxeo-share-button.js
@@ -160,7 +160,11 @@ import '../nuxeo-button-styles.js';
     }
 
     _buildPermalink(document) {
-      return document ? `${window.location.origin + window.location.pathname}#!/doc/${document.uid}` : '';
+      // RFC 3986 compliant permalink (no `#!` fragment); the server redirects it to the
+      // hashbang route so the SPA can resolve the document (WEBUI-1726).
+      return document
+        ? `${window.location.origin + window.location.pathname}doc?id=${encodeURIComponent(document.uid)}`
+        : '';
     }
 
     _copyLink(e) {

--- a/ui/test/nuxeo-share-button.test.js
+++ b/ui/test/nuxeo-share-button.test.js
@@ -39,7 +39,13 @@ suite('nuxeo-share-button extras', () => {
   suite('_buildPermalink', () => {
     test('builds permalink for document', () => {
       const result = el._buildPermalink({ uid: 'doc1' });
-      expect(result).to.include('#!/doc/doc1');
+      expect(result).to.include('doc?id=doc1');
+      expect(result).to.not.include('#!');
+    });
+
+    test('encodes the document id', () => {
+      const result = el._buildPermalink({ uid: 'a b/c' });
+      expect(result).to.include(`doc?id=${encodeURIComponent('a b/c')}`);
     });
 
     test('returns empty string for null document', () => {


### PR DESCRIPTION
## Ticket
WEBUI-1726 — Change the permalink format to remove the hashbang character

Root cause (NXP-33146): SSO/OAuth redirect URIs must not contain a URL fragment (RFC 6749 §3.1.2), so a `#!` permalink loses the document reference through login.

## Change
`nuxeo-share-button._buildPermalink` now produces the fragment-less, RFC-compliant permalink `<origin><pathname>doc?id=<encoded-id>` instead of `…#!/doc/<id>`.

Internal navigation (`urlFor` / routing) is unchanged — only the shareable "Copy link" value changes. Unit test updated.

## Companion PR
The server-side redirect, easyshare permalink and notification-email codec ship in the **nuxeo-web-ui** PR (WEBUI-1726 / WEBUI-1728). This PR must land together with it.