### PR TITLE
ELEMENTS-2059: RFC-compliant document permalink (remove hashbang)

### DIFF
--- a/ui/actions/nuxeo-share-button.js
+++ b/ui/actions/nuxeo-share-button.js
@@ -160,7 +160,11 @@ import '../nuxeo-button-styles.js';
     }
 
     _buildPermalink(document) {
-      return document ? `${window.location.origin + window.location.pathname}#!/doc/${document.uid}` : '';
+      // RFC 3986 compliant permalink (no `#!` fragment); the server redirects it to the
+      // hashbang route so the SPA can resolve the document (WEBUI-1726).
+      return document
+        ? `${window.location.origin + window.location.pathname}doc?id=${encodeURIComponent(document.uid)}`
+        : '';
     }
 
     _copyLink(e) {

--- a/ui/actions/nuxeo-share-button.js
+++ b/ui/actions/nuxeo-share-button.js
@@ -160,11 +160,13 @@ import '../nuxeo-button-styles.js';
     }
 
     _buildPermalink(document) {
+      if (!document) {
+        return '';
+      }
       // RFC 3986 compliant permalink (no `#!` fragment); the server redirects it to the
       // hashbang route so the SPA can resolve the document (WEBUI-1726).
-      return document
-        ? `${window.location.origin + window.location.pathname}doc?id=${encodeURIComponent(document.uid)}`
-        : '';
+      const base = window.location.origin + window.location.pathname;
+      return `${base}${base.endsWith('/') ? '' : '/'}doc?id=${encodeURIComponent(document.uid)}`;
     }
 
     _copyLink(e) {

--- a/ui/test/nuxeo-share-button.test.js
+++ b/ui/test/nuxeo-share-button.test.js
@@ -51,5 +51,25 @@ suite('nuxeo-share-button extras', () => {
     test('returns empty string for null document', () => {
       expect(el._buildPermalink(null)).to.equal('');
     });
+
+    test('does not duplicate the separator when the path ends with a slash', () => {
+      const { href, origin, search } = window.location;
+      window.history.replaceState({}, '', `/app/${search}`);
+      try {
+        expect(el._buildPermalink({ uid: 'doc1' })).to.equal(`${origin}/app/doc?id=doc1`);
+      } finally {
+        window.history.replaceState({}, '', href);
+      }
+    });
+
+    test('inserts a separator when the path has no trailing slash', () => {
+      const { href, origin, search } = window.location;
+      window.history.replaceState({}, '', `/app${search}`);
+      try {
+        expect(el._buildPermalink({ uid: 'doc1' })).to.equal(`${origin}/app/doc?id=doc1`);
+      } finally {
+        window.history.replaceState({}, '', href);
+      }
+    });
   });
 });

--- a/ui/test/nuxeo-share-button.test.js
+++ b/ui/test/nuxeo-share-button.test.js
@@ -39,7 +39,13 @@ suite('nuxeo-share-button extras', () => {
   suite('_buildPermalink', () => {
     test('builds permalink for document', () => {
       const result = el._buildPermalink({ uid: 'doc1' });
-      expect(result).to.include('#!/doc/doc1');
+      expect(result).to.include('doc?id=doc1');
+      expect(result).to.not.include('#!');
+    });
+
+    test('encodes the document id', () => {
+      const result = el._buildPermalink({ uid: 'a b/c' });
+      expect(result).to.include(`doc?id=${encodeURIComponent('a b/c')}`);
     });
 
     test('returns empty string for null document', () => {


### PR DESCRIPTION
## Ticket
WEBUI-1726 — Change the permalink format to remove the hashbang character

Root cause (NXP-33146): SSO/OAuth redirect URIs must not contain a URL fragment (RFC 6749 §3.1.2), so a `#!` permalink loses the document reference through login.

## Change
`nuxeo-share-button._buildPermalink` now produces the fragment-less, RFC-compliant permalink `<origin><pathname>doc?id=<encoded-id>` instead of `…#!/doc/<id>`.

Internal navigation (`urlFor` / routing) is unchanged — only the shareable "Copy link" value changes. Unit test updated.

## Companion PR
The server-side redirect (WEBUI-1728), easyshare permalink and notification-email codec ship in the **nuxeo-web-ui** PR. Branch names are kept identical across repos so the cross-repo preview co-builds both. This PR must land together with its nuxeo-web-ui counterpart.