### PR TITLE
ELEMENTS-2049: Remove redundant "async" from Mocha test suite callbacks (SonarCloud S8785) [lts-2025]

### DIFF
--- a/core/test/nuxeo-notify-behavior.test.js
+++ b/core/test/nuxeo-notify-behavior.test.js
@@ -47,7 +47,7 @@ suite('nuxeo-notify-behavior', () => {
     },
   );
 
-  suite('When notify is called', async () => {
+  suite('When notify is called', () => {
     test('Should fire "notify" event', async () => {
       const message = 'message';
       const outer = await fixture(html`

--- a/ui/test/nuxeo-data-table.test.js
+++ b/ui/test/nuxeo-data-table.test.js
@@ -497,7 +497,7 @@ suite('nuxeo-data-table', () => {
     });
   });
 
-  suite('table selection', async () => {
+  suite('table selection', () => {
     setup(async () => setupServer(1, 4));
 
     test('single selection', async () => {

--- a/ui/test/nuxeo-date.test.js
+++ b/ui/test/nuxeo-date.test.js
@@ -20,7 +20,7 @@ import moment from '@nuxeo/moment';
 import { config } from '@nuxeo/nuxeo-elements';
 import '../widgets/nuxeo-date.js';
 
-suite('nuxeo-date', async () => {
+suite('nuxeo-date', () => {
   test('Should hide the nuxeo-tooltip when provided format and tooltipFormat are equal', async () => {
     const element = await fixture(
       html`

--- a/ui/test/nuxeo-routing-behavior.test.js
+++ b/ui/test/nuxeo-routing-behavior.test.js
@@ -151,7 +151,7 @@ suite('Nuxeo.RoutingBehavior', () => {
       expect(router.document.notCalled).to.be.true;
     });
 
-    suite('with route key for "document" entity-type set to "uid"', async () => {
+    suite('with route key for "document" entity-type set to "uid"', () => {
       setup(async () => {
         setNuxeoRouterKey('document', 'uid');
       });
@@ -170,7 +170,7 @@ suite('Nuxeo.RoutingBehavior', () => {
       });
     });
 
-    suite('with one repository available', async () => {
+    suite('with one repository available', () => {
       setup(async () => {
         Nuxeo.UI.repositories = [{ name: 'repo', href: '/nuxeo/repo/repo/ui/' }];
       });
@@ -194,7 +194,7 @@ suite('Nuxeo.RoutingBehavior', () => {
       });
     });
 
-    suite('with more than one repository available', async () => {
+    suite('with more than one repository available', () => {
       setup(async () => {
         Nuxeo.UI.repositories = [
           { name: 'repo1', href: '/nuxeo/repo/repo1/ui/' },

--- a/ui/test/nuxeo-tooltip.test.js
+++ b/ui/test/nuxeo-tooltip.test.js
@@ -19,7 +19,7 @@ import { html, fixture, flush, isElementVisible } from '@nuxeo/testing-helpers';
 import '../widgets/nuxeo-tooltip.js';
 import { ensureClonedContentStyles } from '../widgets/nuxeo-tooltip.js';
 
-suite('nuxeo-tooltip', async () => {
+suite('nuxeo-tooltip', () => {
   test('Should not add paper-tooltip to the dom when hidden attribute is set', async () => {
     const tooltip = await fixture(
       html`


### PR DESCRIPTION
## Problem

SonarCloud reports 7 `javascript:S8785` findings (RELIABILITY) on `nuxeo_nuxeo-elements` — _"Remove the `async` keyword from this test suite callback; a test suite callback must be synchronous."_ The same 7 findings exist identically on `lts-2025` and `maintenance-3.1.x`.

Jira: [ELEMENTS-2049](https://hyland.atlassian.net/browse/ELEMENTS-2049)

## Root cause

Mocha calls a `suite()` callback **synchronously**, purely to collect the `test()` registrations inside it. It never awaits the promise an `async` callback returns. So any registration that happens after an `await` inside a suite callback lands *after* Mocha has already finished collecting that suite — those tests are silently never run, with no error and no skip marker.

## Analysis — no tests are being skipped today

Verified rather than assumed, and the reason this is Low priority rather than High:

* An `async` function body runs synchronously **up to its first `await`**. None of these 7 suite callbacks contains a top-level `await` — they only contain `setup()`, `teardown()` and `test()` registrations, whose own callbacks are separate functions that may legitimately be async.
* With no suspension point, every `test()` registration still happens synchronously, so all affected tests do currently run.

The `async` keyword here is therefore redundant and misleading, not actively harmful. The risk is latent: the moment anyone adds a top-level `await` inside one of these callbacks — which the `async` keyword actively invites — every `test()` after that point stops running and the suite still reports green. That silent coverage loss is why it is worth clearing now rather than leaving as a trap.

## Changes

Dropped `async` from 7 `suite()` callbacks. One-token change per site, no logic touched:

| File | Suites |
| --- | --- |
| `core/test/nuxeo-notify-behavior.test.js` | `When notify is called` |
| `ui/test/nuxeo-data-table.test.js` | `table selection` |
| `ui/test/nuxeo-date.test.js` | `nuxeo-date` |
| `ui/test/nuxeo-routing-behavior.test.js` | `with route key for "document" entity-type set to "uid"`, `with one repository available`, `with more than one repository available` |
| `ui/test/nuxeo-tooltip.test.js` | `nuxeo-tooltip` |

`async` is **intentionally kept** on the inner `test()`, `setup()` and `teardown()` callbacks — those are supposed to be async and Mocha awaits them correctly. No production element code is touched.

## Test plan

- [x] `npm run lint` (eslint + prettier) passes.
- [x] `npm test` passes.
- [x] **Test count unchanged before and after** — the check that proves nothing was silently gained or lost:

  | Package | Before | After |
  | --- | --- | --- |
  | core | 164 passed | 164 passed |
  | ui | 3842 passed | 3842 passed |
  | dataviz | 29 passed | 29 passed |

- [x] `git grep` confirms 0 remaining `suite(..., async ...)` callbacks in the repo.
- [ ] SonarCloud re-scan shows 0 open `javascript:S8785` findings on `lts-2025`.

## Notes

* Backport to `maintenance-3.1.x` (identical diff, cherry-picked): #1634 — one Jira ticket covers both LTS lines.
* `ui` line coverage fluctuates by ~11 lines between runs on this branch independently of this change (two consecutive runs of the *unmodified* base gave 80.12% and 80.22%). Not introduced here; flagging it as a pre-existing flake.
* Optional follow-up worth considering: an ESLint rule banning `async` on `suite()`/`describe()` callbacks would stop this recurring.

Made with [Cursor](https://cursor.com)
