### PR TITLE
ELEMENTS-2050: Prefer modern JS built-ins over legacy globals (SonarCloud S7773/S7781/S7758/S7737) [lts-2025]

### DIFF
--- a/testing-helpers/nuxeo-mock-client.js
+++ b/testing-helpers/nuxeo-mock-client.js
@@ -20,6 +20,14 @@ import 'nuxeo/nuxeo.js';
 import sinon from 'sinon';
 
 /**
+ * Builds the default logged in user. A factory, rather than a shared object, so that each
+ * MockClient gets its own instance and cannot be affected by mutations from another test.
+ */
+const defaultUser = () => {
+  return { isAdministrator: true, properties: { username: 'Administrator' } };
+};
+
+/**
  * Helper class to mock and stub Nuxeo Client behaviors.
  *
  * @class MockClient
@@ -30,7 +38,7 @@ class MockClient {
    * @param {Object} user - The logged in user object with its properties
    * @param {string} nuxeoVersion - The expected Nuxeo Platform version
    */
-  constructor(user = { isAdministrator: true, properties: { username: 'Administrator' } }, nuxeoVersion = '11.1') {
+  constructor(user = defaultUser(), nuxeoVersion = '11.1') {
     this._responses = new Map();
     this._sandbox = sinon.createSandbox();
 

--- a/ui/actions/nuxeo-delete-blob-button.js
+++ b/ui/actions/nuxeo-delete-blob-button.js
@@ -166,7 +166,7 @@ import '../nuxeo-button-styles.js';
         let xpathArray = xpath.split(splitter);
 
         for (let i = 0; i < xpathArray.length; i++) {
-          if (!Number.isNaN(parseInt(xpathArray[i], 10))) {
+          if (!Number.isNaN(Number.parseInt(xpathArray[i], 10))) {
             xpathArray[i] = star;
           }
           transformedArray.push(xpathArray[i]);

--- a/ui/dataviz/randomColor.js
+++ b/ui/dataviz/randomColor.js
@@ -19,7 +19,7 @@ export function randomColor (options) {
 
   // Check if there is a seed and ensure it's an
   // integer. Otherwise, reset the seed value.
-  if (options.seed !== undefined && options.seed !== null && options.seed === parseInt(options.seed, 10)) {
+  if (options.seed !== undefined && options.seed !== null && options.seed === Number.parseInt(options.seed, 10)) {
     seed = options.seed;
 
   // A string was passed as a seed
@@ -85,7 +85,7 @@ function pickHue(options) {
     //Each of colorRanges.length ranges has a length equal approximatelly one step
     var step = (hueRange[1] - hueRange[0]) / colorRanges.length
 
-    var j = parseInt((hue - hueRange[0]) / step)
+    var j = Number.parseInt((hue - hueRange[0]) / step)
 
     //Check if the range j is taken
     if (colorRanges[j] === true) {
@@ -241,9 +241,9 @@ function getMinimumBrightness(H, S) {
 
 function getHueRange (colorInput) {
 
-  if (typeof parseInt(colorInput) === 'number') {
+  if (typeof Number.parseInt(colorInput) === 'number') {
 
-    var number = parseInt(colorInput);
+    var number = Number.parseInt(colorInput);
 
     if (number < 360 && number > 0) {
       return [number, number];
@@ -428,9 +428,9 @@ function HexToHSB (hex) {
   hex = hex.replace(/^#/, '');
   hex = hex.length === 3 ? hex.replace(/(.)/g, '$1$1') : hex;
 
-  var red = parseInt(hex.substr(0, 2), 16) / 255,
-        green = parseInt(hex.substr(2, 2), 16) / 255,
-        blue = parseInt(hex.substr(4, 2), 16) / 255;
+  var red = Number.parseInt(hex.substr(0, 2), 16) / 255,
+        green = Number.parseInt(hex.substr(2, 2), 16) / 255,
+        blue = Number.parseInt(hex.substr(4, 2), 16) / 255;
 
   var cMax = Math.max(red, green, blue),
         delta = cMax - Math.min(red, green, blue),
@@ -460,15 +460,17 @@ function stringToInteger (string) {
   var total = 0
   for (var i = 0; i !== string.length; i++) {
     if (total >= Number.MAX_SAFE_INTEGER) break;
-    total += string.charCodeAt(i)
+    total += string.codePointAt(i)
   }
   return total
 }
 
 // get The range of given hue when options.count!=0
+// colorHue may be a number, a numeric string, a colour name or a hex string, so it must be
+// coerced before the NaN check to keep named/hex colours out of the numeric branch below.
 function getRealHueRange(colorHue)
-{ if (!isNaN(colorHue)) {
-  var number = parseInt(colorHue);
+{ if (!Number.isNaN(Number(colorHue))) {
+  var number = Number.parseInt(colorHue);
 
   if (number < 360 && number > 0) {
     return getColorInfo(colorHue).hueRange

--- a/ui/dataviz/randomColor.js
+++ b/ui/dataviz/randomColor.js
@@ -241,7 +241,7 @@ function getMinimumBrightness(H, S) {
 
 function getHueRange (colorInput) {
 
-  if (typeof Number.parseInt(colorInput) === 'number') {
+  if (!Number.isNaN(Number.parseInt(colorInput))) {
 
     var number = Number.parseInt(colorInput);
 
@@ -456,11 +456,12 @@ function HSVtoHSL (hsv) {
   ];
 }
 
+// Iterates by code point, not by UTF-16 index, so a surrogate pair is counted once.
 function stringToInteger (string) {
   var total = 0
-  for (var i = 0; i !== string.length; i++) {
+  for (const character of string) {
     if (total >= Number.MAX_SAFE_INTEGER) break;
-    total += string.codePointAt(i)
+    total += character.codePointAt(0)
   }
   return total
 }

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1132,7 +1132,7 @@ import '../nuxeo-button-styles.js';
               // Set provider param
               if (entry.expression) {
                 // Use a function replacement to prevent $ in user values being treated as back-references (ELEMENTS-1966)
-                this.nxProvider.params[effectiveFilterBy] = entry.expression.replace(/\$term/g, () => entry.value);
+                this.nxProvider.params[effectiveFilterBy] = entry.expression.replaceAll(/\$term/g, () => entry.value);
               } else {
                 this.nxProvider.params[effectiveFilterBy] = entry.value;
               }
@@ -1691,7 +1691,7 @@ import '../nuxeo-button-styles.js';
 
       let minWidth = 10;
       if (column && column.minWidth != null) {
-        const parsed = parseInt(column.minWidth, 10);
+        const parsed = Number.parseInt(column.minWidth, 10);
         if (!Number.isNaN(parsed)) {
           minWidth = parsed;
         }

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1132,7 +1132,7 @@ import '../nuxeo-button-styles.js';
               // Set provider param
               if (entry.expression) {
                 // Use a function replacement to prevent $ in user values being treated as back-references (ELEMENTS-1966)
-                this.nxProvider.params[effectiveFilterBy] = entry.expression.replaceAll(/\$term/g, () => entry.value);
+                this.nxProvider.params[effectiveFilterBy] = entry.expression.replaceAll('$term', () => entry.value);
               } else {
                 this.nxProvider.params[effectiveFilterBy] = entry.value;
               }

--- a/ui/nuxeo-document-comments/nuxeo-document-comment-thread.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment-thread.js
@@ -335,8 +335,8 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
     }
 
     _computeMaxRows() {
-      const lineHeight = parseFloat(this.getComputedStyleValue('--nuxeo-comment-line-height'));
-      const maxHeight = parseFloat(this.getComputedStyleValue('--nuxeo-comment-max-height'));
+      const lineHeight = Number.parseFloat(this.getComputedStyleValue('--nuxeo-comment-line-height'));
+      const maxHeight = Number.parseFloat(this.getComputedStyleValue('--nuxeo-comment-max-height'));
       return Math.round((Number.isNaN(maxHeight) ? 80 : maxHeight) / (Number.isNaN(lineHeight) ? 20 : lineHeight));
     }
 

--- a/ui/nuxeo-document-comments/nuxeo-document-comment.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment.js
@@ -580,8 +580,8 @@ import '../nuxeo-button-styles.js';
     }
 
     _computeMaxRows() {
-      const lineHeight = parseFloat(this.getComputedStyleValue('--nuxeo-comment-line-height'));
-      const maxHeight = parseFloat(this.getComputedStyleValue('--nuxeo-comment-max-height'));
+      const lineHeight = Number.parseFloat(this.getComputedStyleValue('--nuxeo-comment-line-height'));
+      const maxHeight = Number.parseFloat(this.getComputedStyleValue('--nuxeo-comment-max-height'));
       return Math.round((Number.isNaN(maxHeight) ? 80 : maxHeight) / (Number.isNaN(lineHeight) ? 20 : lineHeight));
     }
 

--- a/ui/nuxeo-format-behavior.js
+++ b/ui/nuxeo-format-behavior.js
@@ -36,10 +36,10 @@ export const FormatBehavior = [
         return '';
       }
       if (size > 1048576) {
-        return `${parseFloat(size / 1048576).toFixed(2)} MB`;
+        return `${Number.parseFloat(size / 1048576).toFixed(2)} MB`;
       }
       if (size > 1024) {
-        return `${parseFloat(size / 1024).toFixed(2)} KB`;
+        return `${Number.parseFloat(size / 1024).toFixed(2)} KB`;
       }
       return `${size.toString()} Bytes`;
     },
@@ -181,7 +181,7 @@ export const FormatBehavior = [
      * Returns sanitized fulltext
      */
     formatFulltext(text) {
-      return text.replace(/-/g, ' ');
+      return text.replaceAll(/-/g, ' ');
     },
 
     _languageCode() {

--- a/ui/nuxeo-format-behavior.js
+++ b/ui/nuxeo-format-behavior.js
@@ -181,7 +181,7 @@ export const FormatBehavior = [
      * Returns sanitized fulltext
      */
     formatFulltext(text) {
-      return text.replaceAll(/-/g, ' ');
+      return text.replaceAll('-', ' ');
     },
 
     _languageCode() {

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -1523,7 +1523,7 @@ const FOCUS_SUPPRESSION_MS = 200;
       const expectedFormat = this._getDatePlaceholder(this.format);
       const combined = this.i18n('customDatePicker.incorrectFormatExpected');
       if (this._hasTranslation('incorrectFormatExpected', combined)) {
-        return combined.replace(/\{format\}/g, expectedFormat);
+        return combined.replaceAll(/\{format\}/g, expectedFormat);
       }
       const base = this.i18n('customDatePicker.incorrectFormat');
       const baseText = this._hasTranslation('incorrectFormat', base) ? base : 'Incorrect date format.';
@@ -1572,9 +1572,9 @@ const FOCUS_SUPPRESSION_MS = 200;
         if (typeof value === 'string') {
           const m = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
           if (m) {
-            const year = parseInt(m[1], 10);
-            const month = parseInt(m[2], 10) - 1;
-            const day = parseInt(m[3], 10);
+            const year = Number.parseInt(m[1], 10);
+            const month = Number.parseInt(m[2], 10) - 1;
+            const day = Number.parseInt(m[3], 10);
             const d = new Date(year, month, day);
             d.setHours(0, 0, 0, 0);
             return Number.isNaN(d.getTime()) ? null : d;
@@ -1598,9 +1598,9 @@ const FOCUS_SUPPRESSION_MS = 200;
         const match = isoString.match(/^(\d{4})-(\d{2})-(\d{2})$/);
         if (!match) return null;
 
-        const year = parseInt(match[1], 10);
-        const month = parseInt(match[2], 10);
-        const day = parseInt(match[3], 10);
+        const year = Number.parseInt(match[1], 10);
+        const month = Number.parseInt(match[2], 10);
+        const day = Number.parseInt(match[3], 10);
 
         // Validate ranges
         if (year < 1000 || year > 9999) return null;
@@ -3094,7 +3094,7 @@ const FOCUS_SUPPRESSION_MS = 200;
     }
 
     _changeYear(e) {
-      const newYear = parseInt(e.target.value, 10);
+      const newYear = Number.parseInt(e.target.value, 10);
       const newDate = new Date(this._viewDate);
       newDate.setFullYear(newYear);
       this._viewDate = newDate;
@@ -3819,7 +3819,7 @@ const FOCUS_SUPPRESSION_MS = 200;
         const rawLocale = this._getUserLocale();
 
         // Normalize: replace underscore with hyphen
-        let normalizedLocale = rawLocale.replace(/_/g, '-');
+        let normalizedLocale = rawLocale.replaceAll(/_/g, '-');
 
         try {
           // Canonicalize locale (handles casing, region format, etc.)
@@ -4810,7 +4810,7 @@ const FOCUS_SUPPRESSION_MS = 200;
         e.stopPropagation();
       }
       const button = e.target.closest('.year-option');
-      const year = button ? parseInt(button.dataset.year, 10) : null;
+      const year = button ? Number.parseInt(button.dataset.year, 10) : null;
       if (year && this._viewDate) {
         // Create new date with proper month/day preservation
         const currentMonth = this._viewDate.getMonth();
@@ -5045,12 +5045,12 @@ const FOCUS_SUPPRESSION_MS = 200;
       if (!format) return format;
 
       return format
-        .replace(/yyyy/g, 'YYYY')
-        .replace(/yy/g, 'YY')
-        .replace(/dd/g, 'DD')
-        .replace(/d(?![a-zA-Z])/g, 'D')
-        .replace(/mm/g, 'MM') // ⚠ careful: mm = minutes, MM = month
-        .replace(/m(?![a-zA-Z])/g, 'M');
+        .replaceAll(/yyyy/g, 'YYYY')
+        .replaceAll(/yy/g, 'YY')
+        .replaceAll(/dd/g, 'DD')
+        .replaceAll(/d(?![a-zA-Z])/g, 'D')
+        .replaceAll(/mm/g, 'MM') // ⚠ careful: mm = minutes, MM = month
+        .replaceAll(/m(?![a-zA-Z])/g, 'M');
     }
 
     // Professional date parser for user input with comprehensive format support

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -1523,7 +1523,7 @@ const FOCUS_SUPPRESSION_MS = 200;
       const expectedFormat = this._getDatePlaceholder(this.format);
       const combined = this.i18n('customDatePicker.incorrectFormatExpected');
       if (this._hasTranslation('incorrectFormatExpected', combined)) {
-        return combined.replaceAll(/\{format\}/g, expectedFormat);
+        return combined.replaceAll('{format}', expectedFormat);
       }
       const base = this.i18n('customDatePicker.incorrectFormat');
       const baseText = this._hasTranslation('incorrectFormat', base) ? base : 'Incorrect date format.';
@@ -3819,7 +3819,7 @@ const FOCUS_SUPPRESSION_MS = 200;
         const rawLocale = this._getUserLocale();
 
         // Normalize: replace underscore with hyphen
-        let normalizedLocale = rawLocale.replaceAll(/_/g, '-');
+        let normalizedLocale = rawLocale.replaceAll('_', '-');
 
         try {
           // Canonicalize locale (handles casing, region format, etc.)
@@ -5045,11 +5045,11 @@ const FOCUS_SUPPRESSION_MS = 200;
       if (!format) return format;
 
       return format
-        .replaceAll(/yyyy/g, 'YYYY')
-        .replaceAll(/yy/g, 'YY')
-        .replaceAll(/dd/g, 'DD')
+        .replaceAll('yyyy', 'YYYY')
+        .replaceAll('yy', 'YY')
+        .replaceAll('dd', 'DD')
         .replaceAll(/d(?![a-zA-Z])/g, 'D')
-        .replaceAll(/mm/g, 'MM') // ⚠ careful: mm = minutes, MM = month
+        .replaceAll('mm', 'MM') // ⚠ careful: mm = minutes, MM = month
         .replaceAll(/m(?![a-zA-Z])/g, 'M');
     }
 

--- a/ui/widgets/nuxeo-user-avatar.js
+++ b/ui/widgets/nuxeo-user-avatar.js
@@ -262,10 +262,12 @@ import '../nuxeo-icons.js';
     __generateHue() {
       let hash = 0;
       const userId = this._id(this.user);
-      Object.keys(userId).forEach((user) => {
+      // Iterate by code point, not by UTF-16 index, so a surrogate pair is hashed once.
+      for (const character of userId) {
+        // Truncates the running hash back to int32 before the next round.
         hash &= hash;
-        hash = userId.codePointAt(user) + ((hash << 5) - hash);
-      });
+        hash = character.codePointAt(0) + ((hash << 5) - hash);
+      }
       return Math.abs(hash % 360);
     }
 

--- a/ui/widgets/nuxeo-user-avatar.js
+++ b/ui/widgets/nuxeo-user-avatar.js
@@ -264,7 +264,7 @@ import '../nuxeo-icons.js';
       const userId = this._id(this.user);
       Object.keys(userId).forEach((user) => {
         hash &= hash;
-        hash = userId.charCodeAt(user) + ((hash << 5) - hash);
+        hash = userId.codePointAt(user) + ((hash << 5) - hash);
       });
       return Math.abs(hash % 360);
     }

--- a/ui/widgets/nuxeo-user-tag.js
+++ b/ui/widgets/nuxeo-user-tag.js
@@ -266,8 +266,9 @@ import './nuxeo-tooltip.js';
 
     _calculateElementWidth(element) {
       const currrentElement = getComputedStyle(element);
-      const paddingX = parseFloat(currrentElement.paddingLeft) + parseFloat(currrentElement.paddingRight);
-      const borderX = parseFloat(currrentElement.borderLeftWidth) + parseFloat(currrentElement.borderRightWidth);
+      const paddingX = Number.parseFloat(currrentElement.paddingLeft) + Number.parseFloat(currrentElement.paddingRight);
+      const borderX =
+        Number.parseFloat(currrentElement.borderLeftWidth) + Number.parseFloat(currrentElement.borderRightWidth);
       const scrollBarWidth = element.offsetWidth - element.clientWidth;
       const elementWidth = element.offsetWidth - paddingX - borderX - scrollBarWidth;
       return elementWidth;


### PR DESCRIPTION
## Problem

SonarCloud's RELIABILITY triage on `nuxeo_nuxeo-elements` reports 40 findings from four MINOR modern-JavaScript-practice rules. Jira: [ELEMENTS-2050](https://hyland.atlassian.net/browse/ELEMENTS-2050)

| Rule | Count | Ask |
| --- | --- | --- |
| `javascript:S7773` | 29 | `Number.parseInt` / `Number.parseFloat` / `Number.isNaN` over the globals |
| `javascript:S7781` | 8 | `String#replaceAll()` over `String#replace()` |
| `javascript:S7758` | 2 | `String#codePointAt()` over `String#charCodeAt()` |
| `javascript:S7737` | 1 | no object literal as a default parameter |

The four rules are handled together because they land in the same files — `custom-date-picker.js`, `randomColor.js`, `iron-data-table.js` and `nuxeo-format-behavior.js` each carry findings from two of them — so splitting per rule would mean four PRs editing the same lines.

## Root cause

Pre-existing style: the code predates these rules. No functional defect.

## Changes

* **`ui/widgets/custom-date-picker.js`**: 8 `parseInt` → `Number.parseInt`; the `replace` calls in `_buildIncorrectFormatError`, `_getUserLocale` normalisation and the `_normalizeFormat` chain → `replaceAll`.
* **`ui/dataviz/randomColor.js`**: 8 `parseInt` → `Number.parseInt`, `charCodeAt` → `codePointAt` in `stringToInteger`, and `getRealHueRange`'s NaN check rewritten (see below).
* **`ui/nuxeo-format-behavior.js`**: `parseFloat` → `Number.parseFloat` in `formatSize`; `formatFulltext` → `replaceAll`.
* **`ui/nuxeo-data-table/iron-data-table.js`**: `parseInt` → `Number.parseInt`; the restored-filter `replace` → `replaceAll`, **keeping the function replacer** so the ELEMENTS-1966 fix (a `$` in a user value must not act as a back-reference) is preserved.
* **`ui/widgets/nuxeo-user-avatar.js`**: `charCodeAt` → `codePointAt` in `__generateHue`.
* **`ui/widgets/nuxeo-user-tag.js`**, **`ui/actions/nuxeo-delete-blob-button.js`**, **`ui/nuxeo-document-comments/nuxeo-document-comment.js`**, **`ui/nuxeo-document-comments/nuxeo-document-comment-thread.js`**: `parseInt`/`parseFloat` → the `Number.*` equivalents.
* **`testing-helpers/nuxeo-mock-client.js`**: the default `user` is now produced by a `defaultUser()` factory instead of an inline object literal, so each instance still gets its own object and cannot be affected by another test mutating a shared default.

### Not a blind find-and-replace

**`randomColor.js` `getRealHueRange` deliberately keeps the coercion.** It relied on global `isNaN`'s type coercion to route colour *names* and *hex strings* to its string branch. Rewriting it as `Number.isNaN(colorHue)` — the literal reading of S7773 — would have sent `'red'`, `'monochrome'` and `'#ff0000'` down the numeric branch, where `parseInt` yields `NaN`, the range test fails, and the function returns the `[0, 360]` fallback instead of the colour's real hue range. The coercion is therefore made explicit as `Number.isNaN(Number(colorHue))`, which is equivalent to global `isNaN` by definition.

**Every `replace` → `replaceAll` site already used a `/g` regex**, so none of them changes how many occurrences are replaced — this is not the string-pattern "first vs all" behaviour change the rule can imply, and no site risks the `TypeError` that `replaceAll` throws on a non-global regex. The two lookahead links of the `_normalizeFormat` chain (`/d(?![a-zA-Z])/g`, `/m(?![a-zA-Z])/g`) are not flagged by Sonar (it only reports simple literal patterns) but were converted too, so the chain does not read as half-migrated.

**`charCodeAt` → `codePointAt` is the only intentional behaviour change**, and it is inert in practice:
* `nuxeo-user-avatar.js` — identical for all BMP input; the avatar background hue shifts only for usernames containing astral characters (emoji, rare CJK extensions). Still deterministic and still within 0–359.
* `randomColor.js` `stringToInteger` — only reachable through a **string `seed`**, and no shipped caller passes one (`nuxeo-document-distribution-chart.js` passes only `hue`/`luminosity`). Zero production impact.

## Test plan

- [x] `npm run lint:eslint` and `npm run lint:prettier` pass (`lint:polymer` needs `polymer-cli`, not installed locally; no new syntax is introduced, only member expressions, so the analyser is unaffected)
- [x] `npm test` passes on this branch: **164** core / **3842** ui (+2 skipped) / **29** dataviz
- [x] **No drop in test count** — no test file is touched by this PR, and the equivalent baseline comparison on `maintenance-3.1.x` was identical before and after (164 / 3843 / 29, same 2 skips). The ui count differs between the two LTS lines by design, not because of this change.
- [x] Verified independently of the suite with a standalone equivalence harness:
  - `Number.parseInt === parseInt` and `Number.parseFloat === parseFloat` are the *same function objects* per spec, making all 27 of those swaps provable no-ops
  - `!Number.isNaN(Number(x))` matches legacy `!isNaN(x)` across 29 inputs (numbers, numeric strings, colour names, hex, `''`, `null`, `undefined`, `NaN`, `Infinity`, arrays, objects); the naive `!Number.isNaN(x)` differs on 10 of them
  - `replace` vs `replaceAll` produce identical output for all 10 converted regexes, and the full `_normalizeFormat` chain matches over 11 realistic format strings
  - avatar hue unchanged for BMP usernames including accents, Greek and CJK
- [x] Browser support checked: the shipped library already requires `AbortSignal`-based `addEventListener`, `matchAll`, `globalThis` and optional chaining, so the support floor is already above `replaceAll` (ES2021). `codePointAt` and `Number.parseInt/parseFloat` are ES6. The app ships modern JS untranspiled (only `@webcomponents` polyfills, no `core-js`), so this was verified rather than assumed.
- [ ] Post-merge: confirm S7773 / S7781 / S7758 / S7737 all read 0 on the next SonarCloud analysis

## Notes

* Backport pair — the same commit is opened against `maintenance-3.1.x`. The SonarCloud finding sets are byte-identical on both branches (same 40 file+line pairs), and the cherry-pick applied cleanly.
* Coordinate merge order with the other tickets in this triage that touch the same files on different lines: `nuxeo-document-comment-thread.js` (ELEMENTS-2045, S2189) and `nuxeo-user-avatar.js` (S3403).
* `randomColor.js` is a vendored library copy and is excluded from Prettier and ESLint, so its original formatting is preserved in the diff.

Made with [Cursor](https://cursor.com)

---

## Review follow-up (`f55b28a` / `0beec24`)

Three points raised on the `codePointAt` swaps, all addressed:

* **Both hash helpers now iterate by code point.** The first pass kept the UTF-16 index loop while calling `codePointAt(i)`, so a surrogate pair was counted twice — once as the full code point at the high-surrogate index, then again as the bare low surrogate on the next index. `for...of` walks code points, so each character contributes once. Re-verified against the **pre-PR `charCodeAt` code**: identical result for every BMP input (ASCII, accents, Greek, CJK, long strings), which is all a shipped username or seed contains.
* **`nuxeo-user-avatar.js` keeps `hash &= hash`.** It looks like a no-op but bitwise AND applies `ToInt32`, making it the truncation of the running hash; without it the accumulator grows ~32x per character and long usernames drift past `2**53`. Removing it changed the hue for a 69-character username (248 → 264), so it stayed, now with a comment.
* **`randomColor.js` `getHueRange`'s outer gate was always true.** `typeof Number.parseInt(x) === 'number'` holds even when the result is `NaN`, so the real numeric test was the `number < 360 && number > 0` check inside. Replaced with an explicit `!Number.isNaN(...)`. Both variants of the full function were run over 33 inputs (integers in and out of range, numeric strings, colour names, hex in three forms, `'12abc'`, `'1e3'`, `'0x10'`, empty/whitespace, `NaN`, `±Infinity`, `null`, `undefined`, booleans, arrays, objects) and returned the same hue range for every one.

`npm run lint:eslint`, `npm run lint:prettier` and `npm test` (core / ui / dataviz, all green) re-run on both branches after this commit.
