### PR TITLE
ELEMENTS-2046: Provide a compare function for the quick filters snapshot sort [maintenance-3.1.x]

### DIFF
--- a/ui/nuxeo-page-provider-display-behavior.js
+++ b/ui/nuxeo-page-provider-display-behavior.js
@@ -24,6 +24,11 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { config } from '@nuxeo/nuxeo-elements';
 import { I18nBehavior } from './nuxeo-i18n-behavior.js';
 
+// Locale independent ordering, matching the default `Array.prototype.sort()` comparison of UTF-16
+// code units. Used to build signatures that are compared across invocations, so the resulting order
+// must never depend on the environment locale. Yields -1, 0 or 1 from the two comparisons.
+const compareKeys = (a, b) => Number(a > b) - Number(a < b);
+
 /**
  * @polymerBehavior Nuxeo.PageProviderDisplayBehavior
  */
@@ -643,7 +648,7 @@ export const PageProviderDisplayBehavior = [
       // Build a stable signature based only on active states
       const snapshot = this.quickFilters
         ? Object.keys(this.quickFilters)
-            .sort()
+            .sort(compareKeys)
             .map((key) => `${key}:${Boolean(this.quickFilters[key].active)}`)
             .join('|')
         : '';

--- a/ui/test/nuxeo-page-provider-display-behavior.test.js
+++ b/ui/test/nuxeo-page-provider-display-behavior.test.js
@@ -2047,10 +2047,14 @@ suite('PageProviderDisplayBehavior extras', () => {
       return ctx._lastQuickFiltersSnapshot;
     };
 
+    // 'É' (U+00C9) sorts after 'z' by code unit but next to 'e' under locale collation, so these
+    // suites fail if the comparator is ever swapped for a locale aware one.
+    const accentedKey = 'É';
+
     test('orders the snapshot by code unit, whatever the ambient locale', () => {
       const snapshot = snapshotOf({
         b: { active: true },
-        É: { active: false },
+        [accentedKey]: { active: false },
         A: { active: true },
         a: { active: false },
       });
@@ -2058,14 +2062,14 @@ suite('PageProviderDisplayBehavior extras', () => {
     });
 
     test('produces the same snapshot whatever the key order', () => {
-      const first = snapshotOf({ a: { active: true }, É: { active: false }, b: { active: true } });
-      const second = snapshotOf({ b: { active: true }, a: { active: true }, É: { active: false } });
+      const first = snapshotOf({ a: { active: true }, [accentedKey]: { active: false }, b: { active: true } });
+      const second = snapshotOf({ b: { active: true }, a: { active: true }, [accentedKey]: { active: false } });
       expect(first).to.equal(second);
     });
 
     test('does not call _quickFilterChanged when the same quick filters are re-evaluated', () => {
       const ctx = {
-        quickFilters: { a: { active: true }, É: { active: false } },
+        quickFilters: { a: { active: true }, [accentedKey]: { active: false } },
         _lastQuickFiltersSnapshot: null,
         paginable: true,
         _quickFilterChanged: sinon.stub(),
@@ -2079,13 +2083,13 @@ suite('PageProviderDisplayBehavior extras', () => {
 
     test('calls _quickFilterChanged when an active state flips', () => {
       const ctx = {
-        quickFilters: { a: { active: true }, É: { active: false } },
+        quickFilters: { a: { active: true }, [accentedKey]: { active: false } },
         _lastQuickFiltersSnapshot: null,
         paginable: true,
         _quickFilterChanged: sinon.stub(),
       };
       b._quickFiltersChangedDeep.call(ctx);
-      ctx.quickFilters.É.active = true;
+      ctx.quickFilters[accentedKey].active = true;
       b._quickFiltersChangedDeep.call(ctx);
       expect(ctx._quickFilterChanged).to.have.been.calledTwice;
     });

--- a/ui/test/nuxeo-page-provider-display-behavior.test.js
+++ b/ui/test/nuxeo-page-provider-display-behavior.test.js
@@ -2035,6 +2035,60 @@ suite('PageProviderDisplayBehavior extras', () => {
       };
       b._quickFiltersChangedDeep.call(ctx);
     });
+
+    const snapshotOf = (quickFilters) => {
+      const ctx = {
+        quickFilters,
+        _lastQuickFiltersSnapshot: null,
+        paginable: false,
+        _quickFilterChanged: sinon.stub(),
+      };
+      b._quickFiltersChangedDeep.call(ctx);
+      return ctx._lastQuickFiltersSnapshot;
+    };
+
+    test('orders the snapshot by code unit, whatever the ambient locale', () => {
+      const snapshot = snapshotOf({
+        b: { active: true },
+        É: { active: false },
+        A: { active: true },
+        a: { active: false },
+      });
+      expect(snapshot).to.equal('A:true|a:false|b:true|É:false');
+    });
+
+    test('produces the same snapshot whatever the key order', () => {
+      const first = snapshotOf({ a: { active: true }, É: { active: false }, b: { active: true } });
+      const second = snapshotOf({ b: { active: true }, a: { active: true }, É: { active: false } });
+      expect(first).to.equal(second);
+    });
+
+    test('does not call _quickFilterChanged when the same quick filters are re-evaluated', () => {
+      const ctx = {
+        quickFilters: { a: { active: true }, É: { active: false } },
+        _lastQuickFiltersSnapshot: null,
+        paginable: true,
+        _quickFilterChanged: sinon.stub(),
+      };
+      b._quickFiltersChangedDeep.call(ctx);
+      expect(ctx._quickFilterChanged).to.have.been.calledOnce;
+      b._quickFiltersChangedDeep.call(ctx);
+      b._quickFiltersChangedDeep.call(ctx);
+      expect(ctx._quickFilterChanged).to.have.been.calledOnce;
+    });
+
+    test('calls _quickFilterChanged when an active state flips', () => {
+      const ctx = {
+        quickFilters: { a: { active: true }, É: { active: false } },
+        _lastQuickFiltersSnapshot: null,
+        paginable: true,
+        _quickFilterChanged: sinon.stub(),
+      };
+      b._quickFiltersChangedDeep.call(ctx);
+      ctx.quickFilters.É.active = true;
+      b._quickFiltersChangedDeep.call(ctx);
+      expect(ctx._quickFilterChanged).to.have.been.calledTwice;
+    });
   });
 
   suite('_isIndexSelected', () => {


### PR DESCRIPTION
## Problem

SonarCloud reports `javascript:S2871` — _A compare function should be provided when using `Array.prototype.sort()`_ — on `ui/nuxeo-page-provider-display-behavior.js`. It is the single CRITICAL finding in the Reliability set for this repository, present identically on `maintenance-3.1.x` and `lts-2025`.

Jira: [ELEMENTS-2046](https://hyland.atlassian.net/browse/ELEMENTS-2046)

## Root cause

`_quickFiltersChangedDeep()` decides whether the quick filters actually changed by building a signature string and comparing it to the previous one:

```js
const snapshot = this.quickFilters
  ? Object.keys(this.quickFilters)
      .sort()
      .map((key) => `${key}:${Boolean(this.quickFilters[key].active)}`)
      .join('|')
  : '';
```

The bare `.sort()` relies on the implicit default comparator. That default is well defined for the strings `Object.keys()` returns, but Sonar flags it because implicit code-unit ordering is a genuine trap in the general case.

Two constraints shaped the comparator that replaces it, and both are easy to get wrong:

**1. The order must be locale-independent.** The sorted keys are never displayed; they only produce a signature compared across separate invocations. So the ordering does not need to be linguistically correct, but it must not vary between invocations or environments. Sonar's own message suggests `String.localeCompare`, and taking that suggestion naively would be the wrong fix here: without a pinned locale it follows the ambient locale, so the same filters could produce two different signatures in two sessions, making `_quickFilterChanged()` fire spuriously and issue extra page-provider queries.

**2. The comparator must not contain an arm that can never run.** A branching form such as `if (a < b) return -1; return a > b ? 1 : 0;` looks natural, but its `: 0` arm is unreachable from this call site — `Object.keys()` never yields duplicate keys, so the comparator is never asked to compare a key with itself. That is dead code, and no test can reach it.

## Changes

* **`ui/nuxeo-page-provider-display-behavior.js`**: added a module-level `compareKeys` comparator and passed it to `.sort()`.

  ```js
  const compareKeys = (a, b) => Number(a > b) - Number(a < b);
  ```

  It derives `-1` / `0` / `1` arithmetically from the two comparisons, so it reproduces the default UTF-16 code-unit ordering **exactly** — byte-for-byte identical to what the code produced before, no behaviour change, only an explicit contract. Being branchless it has no unreachable arm, and it honours the full comparator contract by returning `0` for equal inputs. It also avoids trading `S2871` for `S3358` (nested ternary).

* **`ui/test/nuxeo-page-provider-display-behavior.test.js`**: four tests in the existing `_quickFiltersChangedDeep` suite covering the ordering contract and change detection (details below).

## Test plan

- [x] `npm run lint` passes (eslint + prettier) on both branches.
- [x] `npm run test:ui` passes — 3846 tests, 0 failures.
- [x] **Ordering is unchanged.** Fuzzed the comparator against the previous implicit `.sort()` over 300,000 randomised key sets drawn from mixed-case ASCII, digits, numeric-looking keys (`10` vs `2`), punctuation, accented Latin (`é`, `É`, `ß`), CJK, ligatures and `U+0000`: **0 mismatches**. The signature produced today is identical to the one produced before this change.
- [x] **Ordering is locale-independent.** Produced the snapshot under `LC_ALL` of `en_US`, `tr_TR`, `sv_SE` and `de_DE` (resolved collator locales `en-US`, `tr-TR`, `sv-SE`, `de-DE`): identical in all four. For contrast, an unpinned `localeCompare` returns a *different* order from the current behaviour (`a:false|A:true|…` instead of `A:true|a:false|…`), which is why it was not used.
- [x] **Comparator contract checked directly**: `compare('a','b') === -1`, `compare('b','a') === 1`, `compare('a','a') === 0`, plus antisymmetry spot-checks.
- [x] **Change detection verified through the real Polymer observer**, not just direct calls — mounted a host element with the behavior and a stubbed page provider, then drove the `quickFilters.*` observer: activating a filter fetches once; re-setting the same value and calling `notifyPath` does not fetch; editing an unrelated field (`name`) does not fetch; deactivating fetches again; replacing the whole array with identical active states keeps the same snapshot and does not re-fetch; a 12-filter set (which exercises `'10' < '2'` code-unit ordering) stays stable and still detects a flip on the 12th filter.
- [x] **Mutation-tested the new tests.** Temporarily swapped in a locale-dependent `a.localeCompare(b)` comparator and re-ran the suite: `orders the snapshot by code unit, whatever the ambient locale` fails as intended. The new tests genuinely guard the contract rather than passing vacuously.
- [x] **Quality gate checked locally before pushing.** The changed lines were read back out of `coverage/ui/lcov.info`: the comparator line is covered (17 hits) and contributes **no branches**, so new-code coverage is 100% and clears the repo's 90% gate condition.

## Notes

* Tests are excluded from coverage in `sonar-project.properties`, so the entire new-code coverage measurement rests on the handful of added source lines. That is why a branchless comparator matters here: a single unreachable arm in a 5-line addition is enough on its own to sink the gate below 90%.
* Backport pair — this is the same commit as [#1637](https://github.com/nuxeo/nuxeo-elements/pull/1637) (`lts-2025`), cherry-picked cleanly; the two diffs are byte-identical. Per the ticket, one ticket covers both LTS lines.
* Since the two branches carry the same code, the unit suite was run in full on one line only; lint was run on both.
* `npm run format` cannot run end-to-end locally because `format:polymer` needs the `polymer` CLI, which is not installed here. Prettier and ESLint were run directly on the changed files and the repo-wide `lint:eslint` / `lint:prettier` gates pass; CI still runs `lint:polymer`.
