### PR TITLE
ELEMENTS-2047: guard border-radius against non-finite values in nuxeo-user-avatar [LTS-2025]

### DIFF
--- a/ui/test/nuxeo-user-avatar.test.js
+++ b/ui/test/nuxeo-user-avatar.test.js
@@ -334,11 +334,35 @@ suite('nuxeo-user-avatar extras', () => {
       el.borderRadius = null;
       el.__obsBorderRadius();
       expect(el.borderRadius).to.equal(0);
+      expect(el.$.container.style.borderRadius).to.equal('0%');
+    });
+
+    test('__obsBorderRadius defaults to 0 when undefined', () => {
+      el.borderRadius = undefined;
+      el.__obsBorderRadius();
+      expect(el.borderRadius).to.equal(0);
+      expect(el.$.container.style.borderRadius).to.equal('0%');
+    });
+
+    test('__obsBorderRadius defaults to 0 for non-numeric input and never emits NaN', () => {
+      el.borderRadius = NaN;
+      el.__obsBorderRadius();
+      expect(el.borderRadius).to.equal(0);
+      expect(el.$.container.style.borderRadius).to.equal('0%');
+      expect(el.$.container.style.borderRadius).to.not.contain('NaN');
+    });
+
+    test('__obsBorderRadius keeps 0 as a valid value', () => {
+      el.borderRadius = 0;
+      el.__obsBorderRadius();
+      expect(el.borderRadius).to.equal(0);
+      expect(el.$.container.style.borderRadius).to.equal('0%');
     });
 
     test('__obsBorderRadius sets value when numeric', () => {
       el.borderRadius = 50;
       el.__obsBorderRadius();
+      expect(el.borderRadius).to.equal(50);
       expect(el.$.container.style.borderRadius).to.equal('50%');
     });
 

--- a/ui/widgets/nuxeo-user-avatar.js
+++ b/ui/widgets/nuxeo-user-avatar.js
@@ -241,7 +241,10 @@ import '../nuxeo-icons.js';
     }
 
     __obsBorderRadius() {
-      if (this.borderRadius === '' || this.borderRadius == null) {
+      // borderRadius is declared as a Number, so anything non-finite (missing, blank
+      // or non-numeric input deserialized to NaN) must fall back to 0. A falsy check
+      // would be wrong here because 0 is a legitimate value.
+      if (!Number.isFinite(this.borderRadius)) {
         this.borderRadius = 0;
       }
       this.$.container.style.borderRadius = `${this.borderRadius}%`;


### PR DESCRIPTION
## Problem
`nuxeo-user-avatar` can silently drop its rounded shape. When `border-radius` receives a non-numeric value, the avatar renders square instead of falling back to `0`. Jira: [ELEMENTS-2047](https://hyland.atlassian.net/browse/ELEMENTS-2047) (SonarCloud Reliability `javascript:S3403`, 1 finding).

## Root cause
`__obsBorderRadius` guarded with `this.borderRadius === ''`, but `borderRadius` is declared `{ type: Number }`. Comparing a number against a string with `===` is always false, so the first half of the guard is dead code. Only the `null`/`undefined` half worked, so non-numeric input survived: Polymer's `Number` deserializer produces `NaN`, and the template literal then writes `border-radius: NaN%` into the inline style, which the browser discards.

## Changes
* **`ui/widgets/nuxeo-user-avatar.js`**: replace the dead `=== ''` string check with `!Number.isFinite(this.borderRadius)`. This matches the declared `Number` type and catches missing/blank/`undefined`/`NaN` in one check, while preserving `0` (a naive falsy check would wrongly reset it) and every valid numeric value.
* **`ui/test/nuxeo-user-avatar.test.js`**: extend `__obsBorderRadius` coverage to `null`, `undefined`, empty, non-numeric (asserting `NaN` never reaches the inline style), the valid `0` case, and normal numeric input.

## Test plan
- [x] `eslint .` passes
- [x] `prettier --list-different` clean
- [x] `npm run test:ui` passes (3845 passed, 0 failed)
- [ ] SonarCloud `javascript:S3403` reads 0 on `lts-2025` after merge

## Notes
One ticket covers both LTS lines; the identical fix is opened against `maintenance-3.1.x` as a paired PR. `format:polymer`/`lint:polymer` were not run locally (the `polymer` CLI is no longer installed, per ELEMENTS-2018); the ESLint + Prettier gating checks were run directly. This file also carries a separate `javascript:S7758` finding (line 267, `charCodeAt`) tracked under the modern-JS-built-ins ticket — intentionally not touched here.

Made with [Cursor](https://cursor.com)