### PR TITLE
ELEMENTS-2045: Make comment reconciliation explicit instead of shifting an aliased array (SonarCloud S2189) [maintenance-3.1.x]

### DIFF
--- a/ui/nuxeo-document-comments/nuxeo-document-comment-thread.js
+++ b/ui/nuxeo-document-comments/nuxeo-document-comment-thread.js
@@ -229,17 +229,20 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
       this.$.commentRequest
         .get()
         .then((response) => {
-          /* Reconciliation of local and server comments */
-          const olderComment = this.comments.length > 0 ? this.comments[0] : null;
-          const newComments = response.entries;
-          while (
-            newComments.length > 0 &&
-            !!olderComment &&
-            (newComments[0].creationDate > olderComment.creationDate || newComments[0].id === olderComment.id)
-          ) {
-            newComments.shift();
-          }
-          response.entries.forEach((entry) => {
+          /*
+           * Reconciliation of local and server comments.
+           * The server returns entries newest first, while `comments` is kept oldest first, so
+           * `comments[0]` is the oldest comment already loaded. Every leading server entry down to
+           * and including that one is therefore already held locally: skip them and prepend only
+           * the genuinely older entries, keeping the list oldest first.
+           */
+          const oldestLoadedComment = this.comments.length > 0 ? this.comments[0] : null;
+          const isAlreadyLoaded = (entry) =>
+            !!oldestLoadedComment &&
+            (entry.creationDate > oldestLoadedComment.creationDate || entry.id === oldestLoadedComment.id);
+          const firstNewIndex = response.entries.findIndex((entry) => !isAlreadyLoaded(entry));
+          const newComments = firstNewIndex === -1 ? [] : response.entries.slice(firstNewIndex);
+          newComments.forEach((entry) => {
             this.unshift('comments', entry);
           });
           this._setTotal(response.totalSize);

--- a/ui/test/nuxeo-document-comment-thread.test.js
+++ b/ui/test/nuxeo-document-comment-thread.test.js
@@ -197,7 +197,109 @@ suite('nuxeo-document-comment-thread', () => {
       });
 
       suite('Reconciliation', () => {
-        // TODO
+        // The server returns entries newest first, while the element keeps `comments` oldest first.
+        const buildComment = (id, creationDate) => {
+          return {
+            'entity-type': 'comment',
+            parentId: 'doc-id',
+            id,
+            numberOfReplies: 0,
+            author: 'John Doe',
+            creationDate,
+            text: `This is comment ${id}`,
+          };
+        };
+
+        const newest = buildComment('comment-id-5', '2019-12-05');
+        const newer = buildComment('comment-id-4', '2019-12-04');
+        const oldestLoaded = buildComment('comment-id-3', '2019-12-03');
+        const older = buildComment('comment-id-2', '2019-12-02');
+        const oldest = buildComment('comment-id-1', '2019-12-01');
+
+        const respondWith = (entries, totalSize) => {
+          server.respondWith('get', '/api/v1/id/doc-id/@comment/', {
+            'entity-type': 'comments',
+            entries,
+            totalSize,
+          });
+        };
+
+        const loadedIds = () => element.comments.map((entry) => entry.id);
+
+        test('Should prepend every entry, oldest first, when no comment is loaded yet', async () => {
+          respondWith([newest, newer, oldestLoaded], 3);
+
+          element._refresh();
+          await flush();
+
+          expect(loadedIds()).to.deep.equal(['comment-id-3', 'comment-id-4', 'comment-id-5']);
+        });
+
+        test('Should only prepend the entries older than the oldest loaded comment', async () => {
+          respondWith([newest, newer, oldestLoaded], 5);
+          element._refresh();
+          await flush();
+          expect(loadedIds()).to.deep.equal(['comment-id-3', 'comment-id-4', 'comment-id-5']);
+
+          // "Load all" replays the page already held plus the two older comments.
+          respondWith([newest, newer, oldestLoaded, older, oldest], 5);
+          element._loadMore();
+          await flush();
+
+          expect(loadedIds()).to.deep.equal([
+            'comment-id-1',
+            'comment-id-2',
+            'comment-id-3',
+            'comment-id-4',
+            'comment-id-5',
+          ]);
+          expect(element.allCommentsLoaded).to.be.true;
+        });
+
+        test('Should not duplicate comments when every entry is already loaded', async () => {
+          respondWith([newest, newer, oldestLoaded], 3);
+          element._refresh();
+          await flush();
+
+          element._loadMore();
+          await flush();
+
+          expect(loadedIds()).to.deep.equal(['comment-id-3', 'comment-id-4', 'comment-id-5']);
+        });
+
+        test('Should keep an entry sharing the creation date of the oldest loaded comment but not its id', async () => {
+          respondWith([oldestLoaded], 2);
+          element._refresh();
+          await flush();
+
+          respondWith([oldestLoaded, buildComment('comment-id-3-bis', '2019-12-03')], 2);
+          element._loadMore();
+          await flush();
+
+          expect(loadedIds()).to.deep.equal(['comment-id-3-bis', 'comment-id-3']);
+        });
+
+        test('Should not mutate the entries of the server response', async () => {
+          element.set('comments', [oldestLoaded]);
+          const response = {
+            'entity-type': 'comments',
+            entries: [newest, newer, oldestLoaded, older],
+            totalSize: 4,
+          };
+          const get = sinon.stub(element.$.commentRequest, 'get').returns(Promise.resolve(response));
+
+          element._fetchComments(true);
+          await flush();
+
+          expect(response.entries.map((entry) => entry.id)).to.deep.equal([
+            'comment-id-5',
+            'comment-id-4',
+            'comment-id-3',
+            'comment-id-2',
+          ]);
+          expect(loadedIds()).to.deep.equal(['comment-id-2', 'comment-id-3']);
+          get.restore();
+        });
       });
     });
   });


### PR DESCRIPTION
## Problem
SonarCloud raises the only BLOCKER in the Reliability set on `nuxeo-document-comment-thread.js` — `javascript:S2189` (_Loops should not be infinite_), message _"'olderComment' is not modified in this loop"_. Jira: [ELEMENTS-2045](https://hyland.atlassian.net/browse/ELEMENTS-2045).

## Analysis
**The BLOCKER itself is a false positive.** The loop terminates: `newComments.shift()` shrinks the array on every iteration, so the `newComments.length > 0` guard always fires. Sonar's heuristic only tracks `olderComment` — the one variable in the exit condition that is never reassigned — and cannot follow that the state actually driving the loop is `newComments[0]`.

**The fragility it points at is real, though, so this is fixed in code rather than marked won't-fix.** `newComments` is an *alias* of `response.entries`, not a copy:

```js
const newComments = response.entries;
while (...) { newComments.shift(); }     // mutates response.entries
response.entries.forEach(...)            // iterates the same, now-shortened array
```

De-duplication works purely by side effect. The code reads as "shift from one list, then iterate the full list", which is not what happens. Any future refactor that copies the array (`[...response.entries]`) or reorders those two statements silently breaks comment de-duplication on reload/poll — with no test to catch it, since the `Reconciliation` suite was an empty `// TODO`.

## Changes
* **`ui/nuxeo-document-comments/nuxeo-document-comment-thread.js`**: replace the `while`/`shift` with `findIndex` for the first genuinely-new entry plus a `slice`. The exit condition is now visible to a reader, `response.entries` is left untouched, and the S2189 finding disappears naturally (there is no loop). A comment records the invariant the logic depends on — the server returns entries newest first while `comments` is kept oldest first, so `comments[0]` is the oldest entry already loaded.
* **`ui/test/nuxeo-document-comment-thread.test.js`**: fill the pre-existing `Reconciliation` placeholder — empty thread, partial overlap on "load all", fully-overlapping response, an entry sharing the oldest loaded comment's `creationDate` but not its id, and a regression guard asserting `response.entries` is not mutated.

## Why behaviour is identical
The new predicate is the **exact negation** of the old loop condition, applied to the same entries in the same order:

| | old | new |
|---|---|---|
| stops at | first entry where `!(newer \|\| sameId)` | `findIndex` of first entry where `!(newer \|\| sameId)` |
| all entries duplicate | loop empties the array → `[]` | `findIndex` → `-1` → `[]` |
| `comments` empty | `!!olderComment` false → loop never runs → all entries | `isAlreadyLoaded` always false → index `0` → `slice(0)` → all entries |
| `entries` empty | loop never runs → `[]` | `findIndex` → `-1` → `[]` |

The negation is kept explicit (`!(a > b || c)`) rather than flipped to `a <= b && !c`. Those are equivalent for well-formed ISO date strings, but **not** for a missing `creationDate`: `undefined > x` and `undefined <= x` are both `false`, so flipping the comparison would have changed behaviour on malformed entries.

## Test plan
- [x] `npm run test:ui` — 3848 passed, 0 failed, 2 skipped
- [x] `npm run lint:eslint` passes (repo-wide)
- [x] `npm run lint:prettier` clean (repo-wide)
- [x] Coverage on the touched file: lines 75/76, branches 38/39, functions 32/32. Every changed line and every new branch is covered; the single uncovered line (253) is the pre-existing `fetch` 404 `notFound` path, untouched here.
- [ ] SonarCloud `javascript:S2189` reads 0 on `maintenance-3.1.x` after merge

## Notes
Backport of the paired `lts-2025` PR (#1641) — one ticket covers both LTS lines. The file is byte-identical on both branches, so the cherry-pick applied cleanly and the resulting diff is identical (verified with `git diff` between the two branches: empty).

`lint:polymer` / `format:polymer` were not run locally (the `polymer` CLI is no longer installed); the ESLint + Prettier gating checks were run directly.

This file also carries 2 separate `javascript:S7773` findings tracked under the modern-JS-built-ins ticket (ELEMENTS-2050) — different lines, intentionally not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
