### PR TITLE
ELEMENTS-2052: Associate the view-user field names with their values (SonarCloud S6853) [maintenance-3.1.x]

### DIFF
--- a/ui/nuxeo-user-group-management/nuxeo-view-user.html
+++ b/ui/nuxeo-user-group-management/nuxeo-view-user.html
@@ -34,17 +34,27 @@ Used by `nuxeo-user-management`
       :host {
         display: block;
       }
+
+      /* These fields are read-only text, not form controls, so a label element could never
+         be associated with anything here. A description list carries the name/value
+         relationship natively (WCAG 1.3.1), and the aria-labelledby gives each value an
+         explicit accessible name. The inner span elements are kept so that existing value
+         selectors still resolve. UA list margins are reset so the rendering is unchanged. */
+      dl,
+      dd {
+        margin: 0;
+      }
     </style>
-    <div class="layout horizontal">
+    <dl class="layout horizontal">
       <div class="layout vertical flex" name="email">
-        <label>[[i18n('viewUser.email')]]</label>
-        <span>[[user.properties.email]]</span>
+        <dt id="emailLabel">[[i18n('viewUser.email')]]</dt>
+        <dd aria-labelledby="emailLabel"><span>[[user.properties.email]]</span></dd>
       </div>
       <div class="layout vertical flex" name="company">
-        <label>[[i18n('viewUser.company')]]</label>
-        <span>[[user.properties.company]]</span>
+        <dt id="companyLabel">[[i18n('viewUser.company')]]</dt>
+        <dd aria-labelledby="companyLabel"><span>[[user.properties.company]]</span></dd>
       </div>
-    </div>
+    </dl>
   </template>
 
   <script>

--- a/ui/test/nuxeo-view-user.test.js
+++ b/ui/test/nuxeo-view-user.test.js
@@ -1,0 +1,152 @@
+/**
+@license
+©2026 Hyland Software, Inc. and its affiliates. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Accessibility contract for the `nuxeo-view-user` template (SonarCloud Web:S6853).
+ *
+ * `nuxeo-view-user` ships as a Polymer HTML import so that deployments can override it, and the
+ * `nuxeo-view-user` tag is already claimed by lightweight stubs in the `nuxeo-user-management` and
+ * `nuxeo-user-profile` suites, which load earlier in the aggregate run. Rather than fight over the
+ * tag name, this suite reads the shipped `nuxeo-view-user.html`, lifts the template out of its
+ * `dom-module`, and stamps it under a test-only tag. The markup under test is therefore exactly the
+ * markup that ships.
+ */
+import { fixture, flush, html } from '@nuxeo/testing-helpers';
+import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
+import { Polymer } from '@polymer/polymer/polymer-legacy.js';
+import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
+
+// Export Polymer for 1.x/2.x compat, as the other legacy suites do.
+window.Polymer = Polymer;
+
+window.Nuxeo = window.Nuxeo || {};
+Nuxeo.I18nBehavior = I18nBehavior;
+
+const TAG = 'nuxeo-view-user-shipped-template';
+const SOURCE = '../nuxeo-user-group-management/nuxeo-view-user.html';
+
+/** Fetches the shipped element and returns its `dom-module` template, adopted into this document. */
+async function importShippedTemplate() {
+  const response = await fetch(new URL(SOURCE, import.meta.url).href);
+  if (!response.ok) {
+    throw new Error(`Could not read ${SOURCE}: ${response.status}`);
+  }
+  const source = await response.text();
+  const parsed = new DOMParser().parseFromString(source, 'text/html');
+  const template = parsed.querySelector('dom-module#nuxeo-view-user > template');
+  if (!template) {
+    throw new Error(`No dom-module template found in ${SOURCE}`);
+  }
+  return document.importNode(template, true);
+}
+
+const LABELS = { 'viewUser.email': 'Email', 'viewUser.company': 'Company' };
+
+suite('nuxeo-view-user template accessibility', () => {
+  let el;
+  let originalLanguage;
+
+  suiteSetup(async () => {
+    if (!customElements.get(TAG)) {
+      Polymer({
+        is: TAG,
+        _template: await importShippedTemplate(),
+        behaviors: [I18nBehavior],
+        properties: {
+          user: {
+            type: Object,
+            value: {},
+          },
+        },
+      });
+    }
+    // Add only the two keys under test to the shared bundle, so no other suite's messages are lost.
+    originalLanguage = window.nuxeo.I18n.language;
+    window.nuxeo.I18n.language = 'en';
+    window.nuxeo.I18n.en = window.nuxeo.I18n.en || {};
+    Object.assign(window.nuxeo.I18n.en, LABELS);
+  });
+
+  suiteTeardown(() => {
+    Object.keys(LABELS).forEach((key) => delete window.nuxeo.I18n.en[key]);
+    window.nuxeo.I18n.language = originalLanguage;
+  });
+
+  setup(async () => {
+    el = await fixture(
+      html`
+        <nuxeo-view-user-shipped-template
+          .user="${{ properties: { email: 'jdoe@example.com', company: 'Hyland' } }}"
+        ></nuxeo-view-user-shipped-template>
+      `,
+    );
+    await flush();
+  });
+
+  /** Resolves the term/definition pair of the field wrapper carrying `name="<field>"`. */
+  const fieldOf = (name) => {
+    const wrapper = el.shadowRoot.querySelector(`[name="${name}"]`);
+    expect(wrapper, `no wrapper for field "${name}"`).to.not.be.null;
+    return { wrapper, term: wrapper.querySelector('dt'), definition: wrapper.querySelector('dd') };
+  };
+
+  test('uses no orphan label element', () => {
+    // Web:S6853 — a label with no associated control has no accessible text.
+    expect(el.shadowRoot.querySelectorAll('label')).to.have.lengthOf(0);
+  });
+
+  test('wraps the fields in a description list', () => {
+    const list = el.shadowRoot.querySelector('dl');
+    expect(list).to.not.be.null;
+    expect(list.querySelectorAll('dt')).to.have.lengthOf(2);
+    expect(list.querySelectorAll('dd')).to.have.lengthOf(2);
+  });
+
+  ['email', 'company'].forEach((name) => {
+    test(`associates the "${name}" value with its name`, () => {
+      const { term, definition } = fieldOf(name);
+      expect(term, `no dt for "${name}"`).to.not.be.null;
+      expect(definition, `no dd for "${name}"`).to.not.be.null;
+
+      // Non-empty accessible text, and an explicit association on top of the dt/dd pairing.
+      expect(term.textContent.trim()).to.not.be.empty;
+      expect(term.id).to.not.be.empty;
+      expect(definition.getAttribute('aria-labelledby')).to.equal(term.id);
+      expect(el.shadowRoot.getElementById(term.id)).to.equal(term);
+    });
+  });
+
+  test('keeps the field names and value spans that existing selectors rely on', () => {
+    expect(fieldOf('email').definition.querySelector('span').textContent).to.equal('jdoe@example.com');
+    expect(fieldOf('company').definition.querySelector('span').textContent).to.equal('Hyland');
+  });
+
+  test('keeps the original layout: name above value, fields side by side, no list indentation', () => {
+    const email = fieldOf('email');
+    const company = fieldOf('company');
+    // UA margins on dl/dd would otherwise shift and indent the fields.
+    expect(getComputedStyle(el.shadowRoot.querySelector('dl')).marginTop).to.equal('0px');
+    expect(getComputedStyle(email.definition).marginInlineStart).to.equal('0px');
+    expect(email.term.getBoundingClientRect().top).to.be.below(email.definition.getBoundingClientRect().top);
+    expect(email.wrapper.getBoundingClientRect().left).to.be.below(company.wrapper.getBoundingClientRect().left);
+  });
+
+  test('renders the translated field names', () => {
+    expect(fieldOf('email').term.textContent).to.equal('Email');
+    expect(fieldOf('company').term.textContent).to.equal('Company');
+  });
+});

--- a/ui/test/nuxeo-view-user.test.js
+++ b/ui/test/nuxeo-view-user.test.js
@@ -59,6 +59,8 @@ const LABELS = { 'viewUser.email': 'Email', 'viewUser.company': 'Company' };
 suite('nuxeo-view-user template accessibility', () => {
   let el;
   let originalLanguage;
+  let createdEnDict;
+  let originalLabels;
 
   suiteSetup(async () => {
     if (!customElements.get(TAG)) {
@@ -74,15 +76,36 @@ suite('nuxeo-view-user template accessibility', () => {
         },
       });
     }
-    // Add only the two keys under test to the shared bundle, so no other suite's messages are lost.
+    // Add only the two keys under test to the shared bundle, remembering the prior state of the `en`
+    // dict and of each key so the teardown restores it exactly. This matters because another suite may
+    // have loaded a real i18n bundle already; blindly deleting these keys would clobber its messages.
     originalLanguage = window.nuxeo.I18n.language;
     window.nuxeo.I18n.language = 'en';
+    createdEnDict = !window.nuxeo.I18n.en;
     window.nuxeo.I18n.en = window.nuxeo.I18n.en || {};
+    originalLabels = Object.keys(LABELS).map((key) => {
+      return {
+        key,
+        existed: Object.prototype.hasOwnProperty.call(window.nuxeo.I18n.en, key),
+        value: window.nuxeo.I18n.en[key],
+      };
+    });
     Object.assign(window.nuxeo.I18n.en, LABELS);
   });
 
   suiteTeardown(() => {
-    Object.keys(LABELS).forEach((key) => delete window.nuxeo.I18n.en[key]);
+    // Restore each key to its prior state rather than deleting unconditionally, and drop the `en`
+    // dict only if this suite created it, so the shared dictionary is left exactly as we found it.
+    originalLabels.forEach(({ key, existed, value }) => {
+      if (existed) {
+        window.nuxeo.I18n.en[key] = value;
+      } else {
+        delete window.nuxeo.I18n.en[key];
+      }
+    });
+    if (createdEnDict) {
+      delete window.nuxeo.I18n.en;
+    }
     window.nuxeo.I18n.language = originalLanguage;
   });
 


### PR DESCRIPTION
## Problem

SonarCloud reports two `Web:S6853` findings (RELIABILITY / _"A form label must be associated with a control and have accessible text"_) in `ui/nuxeo-user-group-management/nuxeo-view-user.html`, lines 40 and 44 — the only two a11y findings of the [ELEMENTS-2052](https://hyland.atlassian.net/browse/ELEMENTS-2052) triage set that sit in shipped product code rather than a demo page or a test fixture.

`nuxeo-view-user` renders the read-only Email and Company fields on **Administration → Users & Groups → _user_** and on the **user profile** page, so this is customer-facing administrative UI.

## Root cause

Each field was a bare `<label>` followed by a `<span>`:

```html
<div class="layout vertical flex" name="email">
  <label>[[i18n('viewUser.email')]]</label>
  <span>[[user.properties.email]]</span>
</div>
```

`<label>` is only meaningful for a *labelable form control*, and this screen has none — the values are static text. So the element could never satisfy S6853's association requirement, and the field name was purely visual with no programmatic link to the value it names. That is a **WCAG 2.1 SC 1.3.1 (Info and Relationships)** failure: in a screen reader's browse/reading mode the name and the value are two unrelated runs of text.

Note the finding is **not** "add `for`/`id`" as one might read the rule message — there is no control to point `for` at, and `for` may only reference a labelable element. The defect is the use of `<label>` for something that is not a form field.

## Fix

Use a description list, the native markup for read-only name/value pairs, and add an explicit `aria-labelledby` from each value to its name so the association does not depend on how a particular screen reader conveys `<dl>` semantics:

```html
<dl class="layout horizontal">
  <div class="layout vertical flex" name="email">
    <dt id="emailLabel">[[i18n('viewUser.email')]]</dt>
    <dd aria-labelledby="emailLabel"><span>[[user.properties.email]]</span></dd>
  </div>
  <div class="layout vertical flex" name="company">
    <dt id="companyLabel">[[i18n('viewUser.company')]]</dt>
    <dd aria-labelledby="companyLabel"><span>[[user.properties.company]]</span></dd>
  </div>
</dl>
```

`dl`/`dd` UA margins are reset to `0` in the element's `<style>`, since `dl` defaults to `margin: 1em 0` and `dd` to `margin-inline-start: 40px`.

## Why this cannot regress anything

- **No JS change.** The `Polymer({...})` definition, the `user` property and the i18n keys (`viewUser.email`, `viewUser.company`) are untouched.
- **Selectors preserved.** The field wrappers keep `class="layout vertical flex"` and `name="email"` / `name="company"`, and the value `<span>` elements are kept. The only external consumer, the nuxeo-web-ui ftest step `nuxeo-view-user [name="email"]` → first `span` (`packages/nuxeo-web-ui-ftest/features/step_definitions/user.js`), still resolves to the email value: the ftest shadow-DOM plugin walks descendants in document order, and the first `span` under the wrapper is still the value.
- **Rendering identical.** `label`/`span` (inline) and `dt`/`dd` (block) are both blockified into flex items by the `layout vertical` parent, so the name still sits above the value and the two fields still sit side by side. The only behavioural difference the swap could introduce is the UA list margins, and those are reset. `<dl>` is a valid host for `<div>` wrappers containing `dt`/`dd` in HTML5.
- **Encapsulated.** `nuxeo-view-user` renders into a shadow root, and the only outside rule targeting it is `nuxeo-view-user { margin: 2em; }` in `nuxeo-user-management` / `nuxeo-user-profile`, which applies to the host, not to the internals. No outside stylesheet was matching `label` or will match `dt`/`dd`.

## Tests

New `ui/test/nuxeo-view-user.test.js` (7 tests). `nuxeo-view-user` ships as a Polymer HTML import so deployments can override it, and the `nuxeo-view-user` tag is already claimed by stubs in the `nuxeo-user-management` and `nuxeo-user-profile` suites, which load earlier in the aggregate run. The suite therefore fetches the shipped `nuxeo-view-user.html`, lifts the template out of its `dom-module` and stamps it under a test-only tag — so the markup under test is exactly the markup that ships — and asserts:

- no orphan `<label>` remains (the S6853 regression guard);
- the fields are wrapped in a `<dl>` with two `dt`/`dd` pairs;
- per field: a non-empty accessible name, a non-empty `dt` id, and `dd[aria-labelledby]` resolving to that `dt` inside the shadow root;
- the `name="…"` wrappers and value `<span>` elements still resolve to the right values (the ftest contract);
- the layout is unchanged — `dl` margin `0px`, `dd` `margin-inline-start` `0px`, name above value, fields side by side;
- the field names are still translated through `I18nBehavior`.

Results:

- `NX_PACKAGE=ui web-test-runner --coverage` → **3850 passed, 0 failed, 2 skipped**.
- `npm run lint:eslint`, `npm run lint:prettier` → clean. (`lint:polymer` only reports the three pre-existing `await is a reserved word` parse errors in the gitignored generated `*/test/load-all-tests.js` barrels, which do not exist in a CI checkout.)

Coverage on new code is unaffected: `sonar.coverage.exclusions` already excludes `**/*.html` and `**/*.test.js`, and no new `.js` production code is added.

## Test plan

- [ ] SonarCloud re-scan: `Web:S6853` on `ui/nuxeo-user-group-management/nuxeo-view-user.html` reads 0, no new issues on new code, quality gate green.
- [ ] Administration → Users & Groups → pick a user: Email and Company still render as before (name above value, two columns).
- [ ] User profile page: same.
- [ ] Screen reader (VoiceOver / NVDA) in browse mode: each value is announced with its field name.
- [ ] ftest `I can see the user has the email "…"` still passes.

## Out of scope (follow-ups)

- `ui/nuxeo-video/nuxeo-video-info.js` (5 occurrences), `ui/nuxeo-document-permissions/nuxeo-popup-permission.js` and `ui/nuxeo-video/nuxeo-video-conversions.js` use the same orphan-`<label>`-for-read-only-text pattern. Sonar does not flag them because its HTML analyzer does not parse templates inside JS template literals, but they are the same defect and deserve their own ticket.
- The sibling screens in `ui/nuxeo-user-group-management/` were checked as the ticket asked: `nuxeo-edit-user.html`, `nuxeo-create-user.js` and `nuxeo-create-group.js` use `nuxeo-input` / `nuxeo-user-suggestion`, which own their label wiring, and `nuxeo-create-user.js`'s "Set password" `<label id="label">` is already associated to its `paper-toggle-button` via `aria-labelledby`. Nothing further to fix there.

---
Jira: https://hyland.atlassian.net/browse/ELEMENTS-2052
