### PR TITLE
ELEMENTS-2048: Replace 3 super-linear regexes with linear equivalents (SonarCloud S8786) [LTS-2023]

### DIFF
--- a/ui/nuxeo-filter.js
+++ b/ui/nuxeo-filter.js
@@ -29,6 +29,15 @@ import { FiltersBehavior } from './nuxeo-filters-behavior.js';
 import Interpreter from './js-interpreter/interpreter.js';
 
 {
+  // Splits a csv filter value. Equivalent to the previous regex split on /\s*,\s*/ but linear:
+  // those adjacent `\s*` quantifiers were ambiguous, so a long whitespace run backtracked
+  // super-linearly (SonarCloud javascript:S8786).
+  const splitCsv = (value) =>
+    value
+      .trim()
+      .split(',')
+      .map((part) => part.trim());
+
   /**
    * Stamps the template if and only if all of its conditions are met.
    *
@@ -222,7 +231,7 @@ import Interpreter from './js-interpreter/interpreter.js';
         if (v && filter) {
           const args = filter.ctx.map((arg) => this[arg]);
           // if filter supports multiple values apply the function to each one
-          const values = filter.multiple ? v.trim().split(/\s*,\s*/) : [v];
+          const values = filter.multiple ? splitCsv(v) : [v];
           const fn = this[filter.fn];
 
           // pass if any check returns true, basically Array.some()

--- a/ui/nuxeo-path-suggestion/nuxeo-path-suggestion.js
+++ b/ui/nuxeo-path-suggestion/nuxeo-path-suggestion.js
@@ -27,6 +27,22 @@ import { IronValidatableBehavior } from '@polymer/iron-validatable-behavior/iron
 import { FormatBehavior } from '../nuxeo-format-behavior.js';
 
 {
+  // A JS `.` never matches a line terminator, so the original `/(.+)\/$/` only stripped a trailing
+  // slash when a non-line-terminator character preceded it: '/' and '<LF>/' were left untouched.
+  const LINE_TERMINATORS = ['\n', '\r', '\u2028', '\u2029'];
+
+  /**
+   * Removes a single trailing slash, matching the previous `value.replace(/(.+)\/$/, '$1')` exactly
+   * but in linear time. That regex combined an unbounded greedy group with an anchored literal, so
+   * it backtracked super-linearly over user-typed input (SonarCloud javascript:S8786).
+   */
+  const stripTrailingSlash = (value) => {
+    if (typeof value !== 'string' || value.length < 2 || !value.endsWith('/')) {
+      return value;
+    }
+    return LINE_TERMINATORS.includes(value.charAt(value.length - 2)) ? value : value.slice(0, -1);
+  };
+
   /**
    * An element that provides path auto completion to nuxeo folderish documents.
    *
@@ -304,11 +320,15 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
     /* Override method from Polymer.IronValidatableBehavior. */
     _getValidity() {
       // XXX - paper-typeahead doesn't implement the IronValidatableBehavior, so there is no validate() method.
-      const valid =
-        (this.value && this.value === '/') ||
-        (this.parent ? this.value.replace(/(.+)\/$/, '$1') === this.parent.path : false) ||
-        (this.children ? this.children.some((child) => this.value.replace(/(.+)\/$/, '$1') === child.path) : false);
-      return valid;
+      if (this.value === '/') {
+        return true;
+      }
+      // Normalised once instead of once per child - the previous code re-ran the regex inside some().
+      const path = stripTrailingSlash(this.value);
+      return (
+        (this.parent ? path === this.parent.path : false) ||
+        (this.children ? this.children.some((child) => path === child.path) : false)
+      );
     }
   }
 

--- a/ui/nuxeo-path-suggestion/nuxeo-path-suggestion.js
+++ b/ui/nuxeo-path-suggestion/nuxeo-path-suggestion.js
@@ -29,7 +29,7 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
 {
   // A JS `.` never matches a line terminator, so the original `/(.+)\/$/` only stripped a trailing
   // slash when a non-line-terminator character preceded it: '/' and '<LF>/' were left untouched.
-  const LINE_TERMINATORS = ['\n', '\r', '\u2028', '\u2029'];
+  const LINE_TERMINATORS = new Set(['\n', '\r', '\u2028', '\u2029']);
 
   /**
    * Removes a single trailing slash, matching the previous `value.replace(/(.+)\/$/, '$1')` exactly
@@ -40,7 +40,8 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
     if (typeof value !== 'string' || value.length < 2 || !value.endsWith('/')) {
       return value;
     }
-    return LINE_TERMINATORS.includes(value.charAt(value.length - 2)) ? value : value.slice(0, -1);
+    const stripped = value.slice(0, -1);
+    return LINE_TERMINATORS.has(stripped.slice(-1)) ? value : stripped;
   };
 
   /**

--- a/ui/test/nuxeo-filter.test.js
+++ b/ui/test/nuxeo-filter.test.js
@@ -543,4 +543,71 @@ suite('nuxeo-filter', () => {
       expect(span[0].innerHTML).to.be.equal(' ');
     });
   });
+  // ELEMENTS-2048 - pin the csv-splitting semantics of `check()` for `multiple` filters. The
+  // original `v.trim().split(/\s*,\s*/)` had ambiguous adjacent quantifiers around the comma
+  // (SonarCloud javascript:S8786); these cover the whitespace shapes it used to absorb.
+  suite('multiple-value splitting (S8786 rewrite)', () => {
+    test('absorbs whitespace of every kind around the separators', async () => {
+      const filter = await fixture(html`
+        <div>
+          <nuxeo-filter document='{"facets":["Versionable"]}' facet="Folderish ,  Versionable">
+            <template><div class="ok"></div></template>
+          </nuxeo-filter>
+          <nuxeo-filter document='{"facets":["Versionable"]}' facet="Folderish,${'\t'}Versionable">
+            <template><div class="ok"></div></template>
+          </nuxeo-filter>
+          <nuxeo-filter document='{"facets":["Versionable"]}' facet="${'  Folderish , Versionable  '}">
+            <template><div class="ok"></div></template>
+          </nuxeo-filter>
+        </div>
+      `);
+      expect(stamped(filter, '.ok').length).to.be.equal(3);
+    });
+
+    test('keeps empty segments so a stray comma never matches', async () => {
+      const filter = await fixture(html`
+        <div>
+          <!-- 'Folderish' still matches even with an empty segment in the list -->
+          <nuxeo-filter document='{"facets":["Folderish"]}' facet="Folderish,,Versionable">
+            <template><div class="ok"></div></template>
+          </nuxeo-filter>
+          <!-- a whitespace-only value must not become an empty list that matches everything -->
+          <nuxeo-filter document='{"facets":["Folderish"]}' facet="${'   '}">
+            <template><div class="notok"></div></template>
+          </nuxeo-filter>
+          <nuxeo-filter document='{"facets":["Folderish"]}' facet=",">
+            <template><div class="notok"></div></template>
+          </nuxeo-filter>
+        </div>
+      `);
+      expect(stamped(filter, '.ok').length).to.be.equal(1);
+      expect(stamped(filter, '.notok')).to.be.empty;
+    });
+
+    test('preserves whitespace inside a value', async () => {
+      // wrapped in a div: _render() stamps into the filter's parent node, not into the filter
+      const filter = await fixture(html`
+        <div>
+          <nuxeo-filter document='{"facets":["Two Words"]}' facet="One, Two Words">
+            <template><div class="ok"></div></template>
+          </nuxeo-filter>
+        </div>
+      `);
+      expect(stamped(filter, '.ok').length).to.be.equal(1);
+    });
+
+    test('checks a pathological whitespace run without super-linear backtracking', async () => {
+      const filter = await fixture(html`
+        <nuxeo-filter document='{"facets":["Folderish"]}'>
+          <template><div class="ok"></div></template>
+        </nuxeo-filter>
+      `);
+      filter.facet = `a${' '.repeat(100000)}b`;
+      const started = performance.now();
+      const result = filter.check();
+      const elapsed = performance.now() - started;
+      expect(result).to.be.false;
+      expect(elapsed).to.be.below(1000);
+    });
+  });
 });

--- a/ui/test/nuxeo-path-suggestion.test.js
+++ b/ui/test/nuxeo-path-suggestion.test.js
@@ -136,6 +136,75 @@ suite('nuxeo-path-suggestion', () => {
       el.children = [{ path: '/parent/child' }];
       expect(el._getValidity()).to.be.false;
     });
+
+    // ELEMENTS-2048 - these pin the exact trailing-slash semantics of the original
+    // `value.replace(/(.+)\/$/, '$1')` so the S8786 rewrite provably cannot drift.
+
+    test('strips a single trailing slash before comparing with the parent path', () => {
+      el.value = '/parent/';
+      el.parent = { path: '/parent' };
+      el.children = null;
+      expect(el._getValidity()).to.be.true;
+    });
+
+    test('strips only the last slash, so "//" normalises to "/"', () => {
+      el.value = '//';
+      el.parent = { path: '/' };
+      el.children = null;
+      expect(el._getValidity()).to.be.true;
+    });
+
+    test('accepts "/" through the explicit root branch even without a parent', () => {
+      el.value = '/';
+      el.parent = null;
+      el.children = null;
+      expect(el._getValidity()).to.be.true;
+    });
+
+    test('returns false for an empty value instead of throwing', () => {
+      el.value = '';
+      el.parent = { path: '/parent' };
+      el.children = null;
+      expect(el._getValidity()).to.be.false;
+    });
+
+    test('matches a child when the typed value carries a trailing slash', () => {
+      el.value = '/a/b/';
+      el.parent = { path: '/a' };
+      el.children = [{ path: '/a/x' }, { path: '/a/b' }];
+      expect(el._getValidity()).to.be.true;
+    });
+
+    test('does not strip a trailing slash preceded by a line terminator', () => {
+      // `.` never matches a line terminator, so `/(.+)\/$/` could not match here and the
+      // value was compared unstripped. A naive `replace(/\/$/, '')` would strip it and flip
+      // both assertions below, so this is the guard against that rewrite.
+      el.parent = { path: '/a\n/' };
+      el.children = null;
+      el.value = '/a\n/';
+      expect(el._getValidity()).to.be.true;
+
+      el.parent = { path: '/a\n' };
+      el.value = '/a\n/';
+      expect(el._getValidity()).to.be.false;
+    });
+
+    test('validates a pathological value without super-linear backtracking', () => {
+      // The old regex was quadratic and re-ran once per child, so ~20k chars x 20 children
+      // blocked the main thread for seconds.
+      el.$.typeahead.tryDisplayResults = sinon.spy();
+      const long = `/${'a'.repeat(20000)}`;
+      el.parent = { path: '/parent' };
+      el.children = Array.from({ length: 20 }, (_, i) => {
+        return { path: `/parent/child${i}` };
+      });
+      el.value = long;
+      const started = performance.now();
+      const valid = el._getValidity();
+      const elapsed = performance.now() - started;
+      expect(valid).to.be.false;
+      expect(elapsed).to.be.below(1000);
+    });
   });
 
   suite('_disabledChanged', () => {


### PR DESCRIPTION
Closes [ELEMENTS-2048](https://hyland.atlassian.net/browse/ELEMENTS-2048) — SonarCloud `javascript:S8786`, all 3 findings.

## The problem

Both regexes run on user-controlled input and backtrack quadratically. Measured in Chromium:

| Call site | Input | Before | After |
|---|---|---|---|
| `nuxeo-path-suggestion._getValidity` | 20k-char path, 20 children | **3497 ms** | ~0 ms |
| `nuxeo-filter.check` | 100k-char whitespace run | **4616 ms** | ~0 ms |

`_getValidity` was the worse of the two: it re-ran the regex *once per child* inside `some()`.

## The fix

**`nuxeo-path-suggestion`** — `value.replace(/(.+)\/$/, '$1')` → a `stripTrailingSlash()` helper, hoisted out of the `some()` callback so it runs once instead of once per child.

This is deliberately **not** the obvious `replace(/\/$/, '')`. A JS `.` never matches a line terminator, so the original only stripped the trailing slash when a non-line-terminator character preceded it — it left `/` and `…<LF>/` untouched. Differential-testing every candidate over all 2801 strings of length ≤ 4 from `{a, /, LF, CR, U+2028, U+2029, space}`:

```
A naive regex   /\/$/ -> ""       229 MISMATCH  e.g. in="aa\n/" old="aa\n/" new="aa\n"
B endsWith + slice                229 MISMATCH
C + length>1 guard                228 MISMATCH
D + prev char !== \n              171 MISMATCH  e.g. in="aa\r/" old="aa\r/" new="aa\r"
E + prev char not LineTerminator  EQUIVALENT   <- shipped
F linear lookbehind regex         EQUIVALENT   <- rejected, Safari < 16.4
```

**`nuxeo-filter`** — `split(/\s*,\s*/)` (ambiguous adjacent quantifiers around the comma) → `splitCsv()`: split on the bare comma, trim each part. Identical over 14,762 exhaustive cases plus a 200,000-string randomised sweep, in both `multiple` and single modes.

## Proof that behaviour is unchanged

Rather than trusting a re-typed copy, the real `_getValidity` bodies were text-extracted from `origin/lts-2025` and from this change, then compared over 1512 `(value, parent, children)` combinations:

```
truthiness differences (WOULD BE A REGRESSION): 0
exact-value-only differences:                   0
old threw / new returns a value:              132
```

Those **132 cases are a latent bug this fix removes**: when `value` was `undefined`/`null` while `parent` or `children` was set, `this.value.replace(...)` threw a `TypeError` — reachable if a form calls `validate()` before anything is typed. The new code returns `false`. That is the one intentional behaviour change, and it is strictly a robustness fix.

No lookbehind is used, so Safari < 16.4 is unaffected. `endsWith`/`includes` are already used throughout `ui/`.

## Tests

Added tests pin the semantics **and were verified to fail against the old code** — they are real guards, not decoration:

- The two pathological-input tests fail on the old regexes at 3497 ms / 4616 ms.
- `does not strip a trailing slash preceded by a line terminator` fails if anyone later "simplifies" this to `replace(/\/$/, '')`.

Also covered: trailing/no trailing slash, `/`, `//`, empty value, parent match, child match; and for the filter: single value, csv with/without surrounding whitespace of every kind, empty segments, whitespace-only, whitespace inside a value.

## Verification

- `nuxeo-elements` ui suite on **lts-2025**: 3853 passed, 0 failed
- `nuxeo-elements` ui suite on **maintenance-3.1.x**: 3854 passed, 0 failed
- `nuxeo-web-ui` suite against this checkout (its `node_modules/@nuxeo/nuxeo-ui-elements` symlinks here): **2654 passed, 0 failed**
- `npx eslint` + `npx prettier --list-different` clean on all 4 files

## Out of scope — follow-up needed

SonarCloud reports **9 open S8786 findings on `nuxeo_nuxeo-web-ui`**, four of which are this exact trailing-slash regex in the same feature area, so the create-document dialog will still block on a pathological path after this merge:

- `elements/nuxeo-document-creation/nuxeo-document-creation-behavior.js:118,154,155`
- `elements/nuxeo-document-create-popup/nuxeo-document-create-popup.js:231`

Plus `elements/nuxeo-grid/nuxeo-grid.js:160`, `elements/diff/nuxeo-diff-behavior.js:27`, two in `addons/nuxeo-platform-3d/`, one in `addons/nuxeo-imap-connector/`. These need a WEBUI ticket.
