### PR TITLE
ELEMENTS-2056: Exclude legacy demo pages, docs shells and layout fixtures from Sonar [lts-2025]

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,31 @@ sonar.javascript.lcov.reportPaths=coverage/core/lcov.info,coverage/ui/lcov.info,
 # File extensions to include
 sonar.inclusions=**/*.js,**/*.html,**/*.json,**/*.css,**/*.yaml,**/*.yml
 
-# Exclude build output, node_modules, generated files, vendor and coverage
+# Exclude build output, node_modules, generated files, vendor and coverage, plus
+# development-only pages that are not part of the shipped product (ELEMENTS-2056).
+#
+#  - **/demo/** — legacy `polymer serve` demo pages (69 pages under ui/, core/, dataviz/).
+#    Not imported by any module, not built, not run in CI, and not deployed; the public
+#    documentation at nuxeo.github.io/nuxeo-elements is published from storybook/ by
+#    .github/workflows/storybook.yaml. README calls these "the legacy demos"; they only
+#    render under `npm run docs` (polymer-cli `polymer serve`), which resolves their
+#    /components/... asset paths. Every finding currently raised here is a Web:* HTML
+#    page-boilerplate or a11y rule (missing lang / DOCTYPE / table header) on pages that have
+#    no end users, so there is no accessibility benefit to fixing them. The 6 demo .js helper
+#    files (nuxeo-demo.js, nuxeo-demo-theme.js and the 4 per-element demo elements) are
+#    currently clean and leave analysis scope along with the pages they serve.
+#    Already excluded from coverage below.
+#  - core|ui|dataviz/index.html — bare <iron-component-page> docs shells, served only by
+#    the same legacy `polymer serve` docs flow.
+#  - ui/test/layouts/** — unit-test fixtures fetched at runtime by the nuxeo-layout,
+#    nuxeo-document-layout, nuxeo-search-form-layout, nuxeo-search-results-layout and
+#    nuxeo-document-picker test suites. Not published (see ui/.npmignore). They carry
+#    role="widget" deliberately, to mirror real layouts: role="widget" is a functional
+#    selector in the layout engine (nuxeo-web-ui elements/bulk/nuxeo-edit-documents-button.js
+#    matches '[role="widget"], nuxeo-data-table[role="table"]'), so "fixing" the ARIA
+#    finding here would diverge the fixtures from production and break these tests. Whether
+#    role="widget" is acceptable at all is a product-wide decision tracked on WEBUI-2229,
+#    where all 528 shipped occurrences remain visible to Sonar.
 sonar.exclusions=\
   **/node_modules/**,\
   **/dist/**,\
@@ -26,7 +50,12 @@ sonar.exclusions=\
   storybook/**,\
   ui/viewers/pdfjs/**,\
   ui/js-interpreter/**,\
-  ui/i18n/**/*.json
+  ui/i18n/**/*.json,\
+  **/demo/**,\
+  core/index.html,\
+  ui/index.html,\
+  dataviz/index.html,\
+  ui/test/layouts/**
 
 # Exclude files from coverage metrics that cannot be practically covered by Web Test Runner unit tests.
 #


### PR DESCRIPTION
[ELEMENTS-2056](https://hyland.atlassian.net/browse/ELEMENTS-2056)

`lts-2025` counterpart of #1647 — identical `sonar-project.properties` content on both branches (the file was already byte-identical across the two bases). Config-only change: adds `**/demo/**`, the three `iron-component-page` docs shells and `ui/test/layouts/**` to `sonar.exclusions`, with the rationale recorded inline in the file.

### Effect

Verified by replaying SonarCloud's actual open findings (`/api/issues/search?componentKeys=nuxeo_nuxeo-elements&impactSoftwareQualities=RELIABILITY&issueStatuses=OPEN`) against the new pattern list using Ant-glob semantics:

| | Findings |
|---|---|
| `**/demo/**` | 164 |
| `core`/`ui`/`dataviz` `index.html` | 6 |
| `ui/test/layouts/**` | 19 |
| **Excluded** | **189** |
| **Kept** (all real product code, already ticketed) | **55** |

Seven rules go to zero project-wide: `Web:S5254` (72), `Web:DoctypePresenceCheck` (65), `Web:S6821` (17), `Web:S5256` (10), `Web:InputWithoutLabelCheck` (9), `Web:S6827` (1), `Web:PageWithoutTitleCheck` (1). `Web:S6853` drops 16 to 2, and those 2 are the real product findings in `nuxeo-view-user.html` tracked on ELEMENTS-2052.

No pre-existing pattern already matched any of the 189, so nothing here is redundant.

### Why these paths

These were already in `sonar.coverage.exclusions` but never in `sonar.exclusions` — that gap is the sole reason the findings existed.

**Demo pages and the `index.html` shells** are development-only. Not imported by any module, not built, not referenced anywhere in the 10 CI workflows, not deployed — the published docs at `nuxeo.github.io/nuxeo-elements` come from `storybook/` via `storybook.yaml`. `README.md` calls them "the legacy demos"; they only render under `npm run docs` (`polymer serve`), which is what resolves their `/components/...` asset paths. No functional change since 2023. All 170 findings on them are `Web:*` page-boilerplate/a11y rules — 137 of those are just a missing `lang` attribute or a missing `<!DOCTYPE>` on pages that have no end users.

**The layout fixtures** are unit-test fixtures, loaded at runtime by the `nuxeo-layout`, `nuxeo-document-layout`, `nuxeo-search-form-layout`, `nuxeo-search-results-layout` and `nuxeo-document-picker` suites, and already unpublished via `ui/.npmignore`. 17 of their 19 findings are `S6821` on `role="widget"` — **not a defect here**: `role="widget"` is a functional selector in the layout engine (`nuxeo-web-ui` `elements/bulk/nuxeo-edit-documents-button.js:524` matches `'[role="widget"], nuxeo-data-table[role="table"]'`). Changing it would diverge the fixtures from production and break the tests that consume them. Whether the abstract role is acceptable at all is a product-wide question tracked on WEBUI-2229, where all 528 shipped occurrences stay visible to Sonar — so excluding the fixtures hides nothing.

This supersedes ELEMENTS-2051's tentative "fix S6821" recommendation, written before the selector role was confirmed.

### Scope / risk

- No production code path leaves analysis. `sonar.sources` still covers all of `core/`, `ui/`, `dataviz/`, `testing-helpers/`, `.github/`.
- 92 files leave scope: 89 demo files + 3 docs shells + the 13 fixtures. Six of these are `.js` (the demo helper elements); Sonar currently reports them clean, and the inline comment records that they leave scope with the pages they serve.
- Coverage percentage is unaffected — all three groups are already in `sonar.coverage.exclusions`, so the 90% gate condition does not move.
- Precedent: same treatment as the existing `storybook/**`, `ui/viewers/pdfjs/**` and `ui/js-interpreter/**` entries, and as WEBUI-2231 for vendored three.js code.

### Testing

- Properties file re-parsed with `java.util.Properties` line-continuation semantics: all 16 exclusion patterns resolve, no comment text leaks into the value, no stray whitespace inside a pattern.
- `npm run lint:eslint` passes (exit 0).
- No test or lint path reads `sonar-project.properties`, so unit tests are unaffected by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)