### PR TITLE
ELEMENTS-2057: Clear 7 Veracode static findings in unit test and test tooling (CWE-259/312/798) [lts-2025]

### DIFF
--- a/core/test/nuxeo-connection.test.js
+++ b/core/test/nuxeo-connection.test.js
@@ -30,8 +30,9 @@ const userResponse = [200, responseHeaders.json, '{"entity-type":"user","usernam
 const cmisResponse = [200, responseHeaders.json, '{}'];
 
 // Generated at runtime so no literal username/password value exists in this source (Veracode
-// CWE-259/798 flags any literal assigned to such a key). Only distinctness matters here, so a
-// counter suffices — Math.random() would read as a SonarCloud S2245 hotspot.
+// CWE-259/798 flags any literal assigned to such a key). The counter is what keeps the values
+// distinct; Date.now() keeps them non-constant, so constant propagation cannot fold them back into
+// effective literals. Math.random() would read as a SonarCloud S2245 hotspot.
 let credentialSeq = 0;
 const throwawayCredential = (label) => {
   credentialSeq += 1;

--- a/core/test/nuxeo-connection.test.js
+++ b/core/test/nuxeo-connection.test.js
@@ -29,6 +29,15 @@ const userResponse = [200, responseHeaders.json, '{"entity-type":"user","usernam
 
 const cmisResponse = [200, responseHeaders.json, '{}'];
 
+// Generated at runtime so no literal username/password value exists in this source (Veracode
+// CWE-259/798 flags any literal assigned to such a key). Only distinctness matters here, so a
+// counter suffices — Math.random() would read as a SonarCloud S2245 hotspot.
+let credentialSeq = 0;
+const throwawayCredential = (label) => {
+  credentialSeq += 1;
+  return `${label}-${Date.now().toString(36)}-${credentialSeq}`;
+};
+
 suite('nuxeo-connection', () => {
   let server;
 
@@ -178,19 +187,30 @@ suite('nuxeo-connection', () => {
     });
 
     test('overrides the cached client when credentials change', async () => {
+      const user = throwawayCredential('user');
+      const firstSecret = throwawayCredential('secret');
+      const secondSecret = throwawayCredential('secret');
       const first = await fixture(
         html`
-          <nuxeo-connection connection-id="nxc-override" username="A" password="P1"></nuxeo-connection>
+          <nuxeo-connection
+            connection-id="nxc-override"
+            username="${user}"
+            password="${firstSecret}"
+          ></nuxeo-connection>
         `,
       );
       await first.connect();
       const second = await fixture(
         html`
-          <nuxeo-connection connection-id="nxc-override" username="A" password="P2"></nuxeo-connection>
+          <nuxeo-connection
+            connection-id="nxc-override"
+            username="${user}"
+            password="${secondSecret}"
+          ></nuxeo-connection>
         `,
       );
       await second.connect();
-      expect(second.client._auth).to.deep.equal({ method: 'basic', username: 'A', password: 'P2' });
+      expect(second.client._auth).to.deep.equal({ method: 'basic', username: user, password: secondSecret });
     });
 
     test('exposes client helpers (active, request, operation, http, batchUpload)', async () => {

--- a/scripts/test/unit/inject-zero-coverage.js
+++ b/scripts/test/unit/inject-zero-coverage.js
@@ -17,7 +17,17 @@ const fs = require('fs');
 const path = require('path');
 
 const root = path.join(__dirname, '../../..');
-const pkg = process.env.NX_PACKAGE || 'core';
+const VALID_PACKAGES = ['core', 'ui', 'dataviz'];
+
+// Selected out of the allow-list instead of used as given, so the name is provably one of the three
+// known packages before it reaches a filesystem path or an output line. The rejected value is
+// deliberately not echoed — it is untrusted input, and Veracode reports it as CWE-312 in a log sink.
+const requested = process.env.NX_PACKAGE || 'core';
+const pkg = VALID_PACKAGES.find((name) => name === requested);
+if (!pkg) {
+  throw new Error(`Unknown NX_PACKAGE — expected one of: ${VALID_PACKAGES.join(', ')}`);
+}
+
 const lcovFile = path.join(root, 'coverage', pkg, 'lcov.info');
 const manifestFile = path.join(root, 'test', 'coverage-imports-data.js');
 

--- a/scripts/test/unit/print-test-runner-notice.js
+++ b/scripts/test/unit/print-test-runner-notice.js
@@ -3,13 +3,22 @@
  * Prints a short explanation before Web Test Runner starts for a given package.
  * WTR progress shows "1/1 test files" even though dozens of Mocha tests run — this clarifies that.
  *
- * Usage: node scripts/test/unit/print-test-runner-notice.js <package>
+ * Usage: node scripts/test/unit/print-test-runner-notice.js <core|ui|dataviz>
  */
 const glob = require('glob');
 const path = require('path');
 
 const root = path.join(__dirname, '../../..');
-const pkg = process.argv[2] || process.env.NX_PACKAGE || 'core';
+const VALID_PACKAGES = ['core', 'ui', 'dataviz'];
+
+// Selected out of the allow-list instead of used as given, so the name is provably one of the three
+// known packages before it reaches a filesystem path or an output line. The rejected value is
+// deliberately not echoed — it is untrusted input, and Veracode reports it as CWE-312 in a log sink.
+const requested = process.argv[2] || process.env.NX_PACKAGE || 'core';
+const pkg = VALID_PACKAGES.find((name) => name === requested);
+if (!pkg) {
+  throw new Error(`Unknown package requested — expected one of: ${VALID_PACKAGES.join(', ')}`);
+}
 
 const suiteFiles = new Set();
 for (const file of glob.sync('**/*.test.js', { cwd: path.join(root, pkg, 'test'), nodir: true })) {


### PR DESCRIPTION
# Veracode static findings: unit test + unit-test tooling

## Summary

Clears all **7 medium static findings** (flaw IDs 39–45) from the Veracode static scan of the **Nuxeo Web UI** application on 24 Aug 2026 (`Nuxeo WebUI - LTS2025 - 32660175969 Promoted`, engine `20260806120029`, module `JS files within nuxeo-web-ui.zip`).

All 7 land in `nuxeo-elements` — they are reported against the Web UI application because the scanned `nuxeo-web-ui.zip` artifact embeds an installed `nuxeo-elements` tree. They sit in three files: one unit test and two unit-test tooling scripts.

These 7 findings are the **entire static-analysis contribution to the current policy failure**. The `Max Severity: Medium` rule reads *"Flaws found: 7 – Did not pass"*, and the score fell from 100 (29 Apr 2026 scan, zero static flaws) to 97. Both flagged scripts were added on 2026-07-09 by ELEMENTS-1972 (Karma → Web Test Runner migration), which is why the findings are new since April.

## Findings addressed

| Flaw | CWE | Location | What the scanner matched |
| --- | --- | --- | --- |
| 39 | 259 Use of Hard-coded Password | `core/test/nuxeo-connection.test.js:193` | `password: 'P2'` string literal |
| 40 | 798 Use of Hard-coded Credentials | `core/test/nuxeo-connection.test.js:193` | `username: 'A'` string literal |
| 41, 42 | 312 Cleartext Storage | `scripts/test/unit/inject-zero-coverage.js:124`, `:109` | `console.log` interpolating `pkg` |
| 43, 44, 45 | 312 Cleartext Storage | `scripts/test/unit/print-test-runner-notice.js:24`, `:21`, `:20` | `console.log` carrying `pkg` |

## Root cause

**Flaws 39–40 — throwaway credentials in a Mocha assertion.** The test `overrides the cached client when credentials change` proves `nuxeo-connection` discards its cached client when the password changes. It mounted two fixtures with `password="P1"` then `password="P2"` and asserted `{ method: 'basic', username: 'A', password: 'P2' }`. Veracode's credential rules match any string literal assigned to a `password`/`username` key and have no test-directory exclusion. `A`/`P1`/`P2` are throwaway values asserted against a `sinon` fake server — no account, no environment, no credential to compromise.

**Flaws 41–45 — external input reaching a `console.log` sink.** Both scripts derived a package name from the process environment (`process.env.NX_PACKAGE`, plus `process.argv[2]` in `print-test-runner-notice.js`) and passed it straight through to output. Veracode traces that untrusted value into `console.log` and reports CWE-312. That the finding is about the *taint path* rather than the data is confirmed by exactly which lines it selected: only the five `console.log` calls that carry `pkg`. Calls that don't are untouched — `console.log('')`, the one interpolating only `suiteFiles.size`, the plain string constant, and the `console.warn` at `inject-zero-coverage.js:58`.

## Why fixed in code rather than mitigated in Veracode

None of these files ship in the runtime bundle, and no other scanner considers them defects:

- **CodeQL** — **0 open alerts** on `lts-2025`, so none on these three files. Note this corrects the ticket, which said CodeQL was not enabled and had "no SAST opinion" here: it *is* enabled, via GitHub **default setup**, which is easy to miss because it needs no workflow file in the repo — `lts-2025` carries 10 CodeQL analyses alongside the 10 SonarCloud SARIF uploads. That strengthens the case rather than weakening it: CodeQL does look at this code and finds nothing.
- **SonarCloud** — **0** security hotspots on all three files (re-verified on `lts-2025` against project `nuxeo_nuxeo-elements`).

So all 7 are scanner-pattern matches rather than exploitable defects. They are fixed in code anyway so the policy passes on the next scan without a mitigation-review cycle, and so the findings don't reappear on every future scan. Both changes stand on their own merits as better code.

## Changes

**1. `core/test/nuxeo-connection.test.js` — remove the literals.** The throwaway credentials are generated at runtime, so no literal is assigned to a `username`/`password` key, and the expected auth object is built from the same values the fixtures were given. The assertion keeps its meaning — it still proves the second value replaced the first — and gets marginally stronger, since it can no longer pass by coincidence on a shared constant.

`Math.random()` (as sketched in the ticket) is deliberately **not** used: it would introduce a SonarCloud S2245 hotspot into a file the ticket confirms is currently hotspot-free. Unpredictability isn't needed here, so the helper mixes a counter with `Date.now()` instead — the counter is what guarantees the three values are distinct (monotonic, so it holds even within one millisecond), and `Date.now()` is what keeps them non-constant, so constant propagation can't fold them back into effective literals.

**2. Both scripts — validate the package name before use.** `pkg` is now *selected out of* an allow-list (`['core', 'ui', 'dataviz']`) rather than used as given, so its value is provably one of three known constants before it reaches a filesystem path or an output line. That breaks the taint path, and Veracode recognises allow-list selection as sanitisation. `inject-zero-coverage.js` reads only `process.env.NX_PACKAGE`, so the `process.argv[2]` term was dropped there.

This is a genuine improvement independent of the scanner. Previously `print-test-runner-notice.js` accepted `NX_PACKAGE=iu` and printed a misleading notice claiming *"Suite modules: 0 *.test.js files"* before exiting 0; `inject-zero-coverage.js` failed later with a confusing `Missing …/coverage/iu/lcov.info` rather than naming the real problem. Both now fail loudly and name the valid values. The naming (`VALID_PACKAGES`) matches the existing guard in `web-test-runner.config.mjs`.

The rejected value is **deliberately not echoed** in either error message. It is untrusted input, and Veracode reports it as CWE-312 in any log sink — the ticket anticipates this and asks for the value to be dropped from the message if the `throw` were flagged. Pre-empting it costs nothing: the value is visible in the operator's own command or environment.

## Scope

- **Three files, all test or test tooling** — two build-time scripts and one unit test.
- **No production element code is touched.** Nothing under `core/`, `ui/` or `dataviz/` source changes, and nothing in the published `@nuxeo/*` packages changes.
- No dependency, manifest or lockfile changes.
- Identical, byte-for-byte, on `lts-2025` and `maintenance-3.1.x` (verified: the two branch diffs are identical, and the three files were already identical on both lines before this change).

**Deliberately left unchanged** (each not flagged by this engine; changing them would widen a security PR beyond the reported findings):

- `core/test/nuxeo-connection.test.js:159,166` — `token="abc"` / `token: 'abc'`. Veracode's CWE-798 rule selected only the `username`/`password` keys at line 193. Worth revisiting if a future scan flags `token` keys.
- `core/test/nuxeo-connection.test.js:26,28` — `"username":"Administrator"` inside the fake-server JSON response bodies. These are HTTP response payloads, not credential assignments, and rewriting them would change what the `sinon` fake server returns and the `/api/v1/user/Administrator` route it matches.

## Local validation

Both gates run per branch on a clean tree.

**Lint** — `npm run lint` (polymer lint + eslint + prettier): ✅ exit 0.

> Local gotcha, not a change-caused failure: if a previous `npm test` left the gitignored barrels `{core,ui,dataviz}/test/load-all-tests.js` on disk, `lint:polymer` fails with `parse-error - await is a reserved word` on all three. They don't exist on a fresh CI checkout. Removing them and re-running gives exit 0.

**Unit tests** — `npm test` (full suite: core + ui + dataviz), before vs after on each line. Test count is the acceptance criterion and is **unchanged**:

| Line | Package | Baseline | After | Coverage baseline → after |
| --- | --- | --- | --- | --- |
| `lts-2025` | core | 164 passed, 0 failed | 164 passed, 0 failed | 98.40% → 98.40% (555/564) |
| `lts-2025` | ui | 3842 passed, 2 skipped | 3842 passed, 2 skipped | 80.13% → 80.13% (8660/10808) |
| `lts-2025` | dataviz | 29 passed, 0 failed | 29 passed, 0 failed | 93.49% → 93.49% (158/169) |
| `lts-2025` | **total** | **4035 passed** | **4035 passed** | 81.21% → 81.21% (9373/11541) |
| `maintenance-3.1.x` | core | 164 passed, 0 failed | 164 passed, 0 failed | 98.40% → 98.40% (555/564) |
| `maintenance-3.1.x` | ui | 3843 passed, 2 skipped | 3843 passed, 2 skipped | 80.22% → 80.12–80.23% (see below) |
| `maintenance-3.1.x` | dataviz | 29 passed, 0 failed | 29 passed, 0 failed | 93.49% → 93.49% (158/169) |
| `maintenance-3.1.x` | **total** | **4036 passed** | **4036 passed** | 81.30% → 81.21–81.31% |

`coverage/<package>/lcov.info` is still written for all three packages on both lines, and `inject-zero-coverage` still injects the same 5 zero records for `ui`.

**On the `ui` coverage wobble on `maintenance-3.1.x`:** the `ui` line-coverage figure there is nondeterministic run-to-run *on an unchanged tree*. Three consecutive runs of the identical fixed branch produced 80.12%, 80.21% and 80.23%, straddling the 80.22% baseline, while the test count stayed at exactly 3843 every time. This change touches only `core/test/` and `scripts/` and cannot execute any `ui` source line, so it cannot be the cause. `core` — the package whose test file actually changed — and `dataviz` are byte-stable and identical before and after, and the `lts-2025` line reproduced identical figures across the board.

**Not verifiable locally:** the Veracode re-scan itself. See below.

## Verification still required

The ticket's final acceptance criterion — *"the next Veracode static scan reports 0 static findings for the Web UI application, `Max Severity: Medium` moves to Passed, and the score returns to 100"* — can only be confirmed against a **re-scan of a Web UI build that contains this change**. The current result is from build `32660175969` (24 Aug 2026). This is outside the repo's CI and owned by whoever runs the next promoted scan.

## Out of scope

- **The SCA half of the same Veracode report.** The `Disallow CVSS Score 4 and Above` and `Disallow Vulnerabilities by Severity: High and Above` rules also fail, on `brace-expansion`, `js-yaml`, `uuid` and `serialize-javascript` (7 CVEs). All are already fixed on `security-fixes-Q3-lts-2025` (elements) and `security-fixes-lts-2025` (web-ui) and await merge only — see ELEMENTS-2021, ELEMENTS-2023, ELEMENTS-2024, ELEMENTS-2025 and WEBUI-2185.
- The `inflight` SCA finding (`SRCCLR-SID-41137`) already carries an approved "potential false positive" mitigation from Jul 2025 under WEBUI-1678. No action.
- **Noted follow-up, not filed here:** adding `**/test/**` and `scripts/**` to the Veracode scan exclusions for this application would have prevented all 7 of these findings and would prevent the next batch of test-code pattern matches from failing the policy.

---

Jira: https://hyland.atlassian.net/browse/ELEMENTS-2057
