### PR TITLE
ELEMENTS-1746: keep hierarchical indentation in multi-select suggestions [maintenance-3.1.x]

### DIFF
--- a/ui/test/nuxeo-selectivity.test.js
+++ b/ui/test/nuxeo-selectivity.test.js
@@ -1217,6 +1217,74 @@ suite('nuxeo-selectivity', () => {
       const items = dropdown.querySelectorAll('.selectivity-result-item');
       expect(items.length).to.be.at.least(1);
     });
+
+    // ELEMENTS-1746: MultipleSelectivity.filterResults() rebuilds each result item, and used to
+    // drop `depth`. The padding-left expression then evaluated to NaN, the inline style was
+    // discarded and every nested entry collapsed onto the single 17px stylesheet indent — so a
+    // grandchild looked like a sibling of its own parent.
+    const deepTree = [
+      {
+        id: 'documents-pca',
+        displayLabel: 'Documents PCA',
+        children: [
+          {
+            id: 'dtc',
+            displayLabel: 'Directives techniques',
+            children: [{ id: 'dtc-detail', displayLabel: 'Detail' }],
+          },
+          { id: 'modification', displayLabel: 'Modification' },
+        ],
+      },
+    ];
+
+    const openAndReadPadding = async (widget) => {
+      widget._selectivity.open();
+      await flush();
+      await new Promise((r) => setTimeout(r, 50));
+      const dropdown = findDropdown(widget);
+      expect(dropdown).to.not.be.null;
+      const rows = {};
+      dropdown.querySelectorAll('.selectivity-result-item').forEach((row) => {
+        rows[row.textContent.trim()] = row.style.paddingLeft;
+      });
+      return rows;
+    };
+
+    test('indents nested result items by depth when multiple is true', async () => {
+      selectivityWidget = await fixture(html`
+        <nuxeo-selectivity .data=${deepTree} multiple min-chars="0" frequency="0"></nuxeo-selectivity>
+      `);
+      const padding = await openAndReadPadding(selectivityWidget);
+      expect(padding['Documents PCA']).to.equal('7px');
+      expect(padding['Directives techniques']).to.equal('17px');
+      expect(padding.Detail).to.equal('27px');
+      // A child of the root must not be indented like a grandchild.
+      expect(padding.Modification).to.equal('17px');
+    });
+
+    test('indents nested result items identically in single and multiple mode', async () => {
+      selectivityWidget = await fixture(html`
+        <nuxeo-selectivity .data=${deepTree} min-chars="0" frequency="0"></nuxeo-selectivity>
+      `);
+      const single = await openAndReadPadding(selectivityWidget);
+      selectivityWidget = await fixture(html`
+        <nuxeo-selectivity .data=${deepTree} multiple min-chars="0" frequency="0"></nuxeo-selectivity>
+      `);
+      const multiple = await openAndReadPadding(selectivityWidget);
+      expect(multiple).to.deep.equal(single);
+    });
+
+    test('_resultPadding falls back to the root indent for a non-numeric depth', async () => {
+      selectivityWidget = await fixture(
+        html`
+          <nuxeo-selectivity .data=${deepTree}></nuxeo-selectivity>
+        `,
+      );
+      expect(selectivityWidget._resultPadding(0)).to.equal(7);
+      expect(selectivityWidget._resultPadding(2)).to.equal(27);
+      expect(selectivityWidget._resultPadding(undefined)).to.equal(7);
+      expect(selectivityWidget._resultPadding(NaN)).to.equal(7);
+    });
   });
 
   // --------------------------------------------------------------------------

--- a/ui/widgets/nuxeo-selectivity.js
+++ b/ui/widgets/nuxeo-selectivity.js
@@ -3202,6 +3202,9 @@ typedArrayTags[weakMapTag] = false;
               id: item.id,
               text: item.text,
               item: item.item,
+              // `depth` drives the indentation of hierarchical entries in the result templates;
+              // rebuilding the item without it would flatten the tree to a single indent level.
+              depth: item.depth,
             };
             if (item.children) {
               result.children = this.filterResults(item.children);
@@ -6812,6 +6815,11 @@ typedArrayTags[weakMapTag] = false;
   }, {}, [75]))(75);
 }));
 {
+  // Indentation of hierarchical result rows: the root level padding and the extra padding
+  // added per nesting level. Kept in sync with the .selectivity-result-item stylesheet rule.
+  const RESULT_BASE_PADDING = 7;
+  const RESULT_DEPTH_PADDING = 10;
+
   /**
    * An element wrapping selectivity.js and relying on an operation for suggestions
    *
@@ -7421,14 +7429,14 @@ typedArrayTags[weakMapTag] = false;
             const itemId = `selectivity-option-${escapeHTML(opts.id)}`;
             return `<div class="selectivity-result-item${opts.disabled ? ' disabled' : ''}"
                   id="${itemId}"
-                  style="padding-left: ${7 + (10 * opts.depth)}px"
+                  style="padding-left: ${this._resultPadding(opts.depth)}px"
                   data-item-id="${escapeHTML(opts.id)}"
                   aria-selected="false">${this.resultFormatter(opts.item)}</div>`;
           },
 
           resultLabel: (opts) => (
             `<div class="preserve-white-space selectivity-result-label"
-                  style="padding-left: ${7 + (10 * opts.depth)}px">${escapeHTML(opts.text)}</div>`
+                  style="padding-left: ${this._resultPadding(opts.depth)}px">${escapeHTML(opts.text)}</div>`
           ),
 
           singleSelectedItem: (opts) => (
@@ -7763,6 +7771,14 @@ typedArrayTags[weakMapTag] = false;
 
     _resultFormatter(item) {
       return escapeHTML(item.displayLabel || item.title || item.text || item);
+    }
+
+    /**
+     * Left padding, in pixels, that indents a hierarchical result row at the given depth.
+     * A non-numeric depth falls back to the root level so the inline style stays valid CSS.
+     */
+    _resultPadding(depth) {
+      return RESULT_BASE_PADDING + RESULT_DEPTH_PADDING * (Number.isFinite(depth) ? depth : 0);
     }
 
     _wrap(value) {


### PR DESCRIPTION
## Problem

In a hierarchical vocabulary rendered by `nuxeo-directory-suggestion` (or any `nuxeo-selectivity`)
with `multiple="true"`, the dropdown entries lose their indentation: every nested entry is drawn at
one single indent level, so a grandchild appears to be a sibling of its own parent. Removing
`multiple="true"` renders the same vocabulary correctly.

Reported on ELEMENTS-1746 / SUPNXP-50706: "Modification" (a child of "Documents PCA") was shown at
the same indentation as the deeper entries under "Directives techniques complémentaires".

## Root cause

`MultipleSelectivity.filterResults()` rebuilds every result item so that already-selected entries
can be filtered out, but it only copied `id`, `text` and `item` — it dropped the `depth` property
that `_wrap()` computes while walking the tree.

The `resultItem` / `resultLabel` templates then evaluated `padding-left: ${7 + 10 * undefined}px`
to the literal string `NaNpx`. That is an invalid inline style, so the browser discarded it and
every nested row fell back to the stylesheet rule
`.selectivity-result-children .selectivity-result-item { padding-left: 17px }` — a single flat
indent for all depths.

Single-select mode is unaffected because it uses the base `Selectivity.filterResults()`, which
returns the results untouched and therefore keeps `depth`.

## Changes

`ui/widgets/nuxeo-selectivity.js`

- `MultipleSelectivity.filterResults()` now preserves `depth` when rebuilding a result item.
- The indentation is computed through a new `_resultPadding(depth)` helper backed by the
  `RESULT_BASE_PADDING` / `RESULT_DEPTH_PADDING` constants. It falls back to the root level for a
  non-numeric depth, so an invalid `NaNpx` padding can never be emitted again.

`ui/test/nuxeo-selectivity.test.js`

- Regression test asserting depth-based padding (7 / 17 / 27px) on a three-level tree with
  `multiple`.
- Test asserting single-select and multi-select produce identical indentation.
- Unit test for the `_resultPadding` fallback.

## Test plan

Automated:

- `npm run lint` — clean (`lint:eslint`, `lint:prettier`, `polymer lint` on the changed files).
- `nuxeo-elements` unit suites — `ui` 3852 passed / 0 failed, `core` 164 passed / 0 failed,
  `dataviz` 29 passed / 0 failed. (Locally the `ui` suite has to be run in chunks because
  `nuxeo-document-distribution-chart.test.js` crashes the local Chromium renderer — reproduced on a
  pristine base branch, unrelated to this change.)
- `nuxeo-web-ui` unit suite against this branch — 2680 passed / 0 failed.

Manual, on a throwaway Nuxeo 2025 instance with Web UI built from this branch:

1. Add a third level to the `l10nsubjects` hierarchical vocabulary, e.g. two entries with
   `parent=cinema` (`cinema` itself has `parent=art`).
2. Open any document's **Edit** form — the **Subjects** widget is
   `nuxeo-directory-suggestion directory-name="l10nsubjects" multiple="true" min-chars="0"`.
3. Open the Subjects dropdown.

Before: `Documentary` / `Short film` (depth 2) render at `padding-left: 17px`, identical to
`Comics` / `Culture` (depth 1); every row carries the invalid inline style `padding-left: NaNpx`.

After: depth 0 → `7px`, depth 1 → `17px`, depth 2 → `27px`, matching single-select mode. The
`Cinema` group header is also correctly nested under `Art`.

## Notes

- Behaviour in single-select mode is byte-for-byte unchanged.
- `Selectivity.matcher()` performs a similar item rebuild for locally-filtered `data` and also drops
  `depth`; that path is not exercised by directory suggestions (which query the server) and is left
  out of scope for this fix.
- Same change is raised against both bases: this PR and the companion PR on the other base.
