### PR TITLE
task: block Cursor co-author trailers that fail CLA checks [lts-2025]

### DIFF
--- a/.cursor/rules/git-cla-commits.mdc
+++ b/.cursor/rules/git-cla-commits.mdc
@@ -1,0 +1,27 @@
+---
+description: Keep git commits CLA-clean for this repository
+alwaysApply: true
+---
+
+# CLA-safe commits
+
+`license/cla` (cla-assistant.io) fails when a PR contains commits or co-authors that are not covered by the contributor's signed CLA.
+
+## Never do this
+
+- Do **not** add `Co-authored-by: Cursor <cursoragent@cursor.com>` (or any `cursoragent@` trailer).
+- Do **not** create commits authored/committed as `Cursor Agent <cursoragent@cursor.com>`.
+- Do **not** let cloud agents push commits directly to PR branches.
+
+## Always do this
+
+- Author and commit as the human contributor only, using the email address covered by their signed CLA.
+- Before pushing a PR branch, inspect every author, committer, and commit message:
+  `gh api repos/<owner>/<repo>/pulls/<n>/commits --jq '.[] | {sha, author: .commit.author.email, committer: .commit.committer.email, message: .commit.message}'`,
+  and verify that no Cursor agent identity or co-author trailer is present.
+- If history is polluted, squash to one clean commit on the PR base, then rewrite with `git commit-tree` and a message file (normal `git commit` from the agent shell may re-inject Cursor co-author trailers).
+
+## Local guard
+
+This repository runs `scripts/git/commit-msg-cla.sh` via Husky `commit-msg`. Commits with Cursor co-author trailers
+are rejected before push.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@ npm test                   # @web/test-runner unit tests (all packages) — must
 - `npm run format` runs Polymer lint fix first, then Prettier write, then ESLint fix.
 - Always run `npm run format` before committing.
 - Do NOT commit `.only` in test files.
+
+## CLA-safe commits
+
+`license/cla` fails if any commit or `Co-authored-by` trailer names `cursoragent@cursor.com`. Never add `Co-authored-by: Cursor` and never commit as the Cursor agent user. Husky runs `scripts/git/commit-msg-cla.sh` on every commit to block those trailers. If a PR branch is already polluted, squash on the PR base and rewrite with `git commit-tree` + a message file (agent `git commit` may re-inject Cursor trailers).
+
 - To test a single package: `npm run test:core`, `npm run test:ui`, or `npm run test:dataviz`.
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "commit-msg": "scripts/git/commit-msg-cla.sh"
     }
   },
   "lint-staged": {

--- a/scripts/git/commit-msg-cla.sh
+++ b/scripts/git/commit-msg-cla.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Reject commit messages that would fail cla-assistant.io on nuxeo/* PRs.
+set -eu
+
+MSG_FILE=${1:-${HUSKY_GIT_PARAMS:-}}
+
+if [ -z "$MSG_FILE" ] || [ ! -f "$MSG_FILE" ]; then
+  echo "commit-msg-cla: missing commit message file" >&2
+  exit 1
+fi
+
+if grep -qiE '^Co-authored-by:[[:space:]]*[^<]*<[[:space:]]*cursoragent@cursor\.com[[:space:]]*>[[:space:]]*$' \
+  "$MSG_FILE"; then
+  echo "commit-msg-cla: remove the Cursor agent co-author trailer; its email is not CLA-covered." >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Add `scripts/git/commit-msg-cla.sh` Husky hook to reject commits with `Co-authored-by: Cursor` or `cursoragent@cursor.com` trailers that break `license/cla`
- Document CLA-safe commit rules in `AGENTS.md`
- Add `.cursor/rules/git-cla-commits.mdc` so agents stop injecting Cursor co-authors

## Test plan
- [x] Hook rejects a message containing `Co-authored-by: Cursor <cursoragent@cursor.com>`
- [x] Hook allows a normal commit message
- [x] `npm run lint` passes

Made with [Cursor](https://cursor.com)