### PR TITLE
ELEMENTS-2077: Clear 31 SonarCloud findings in custom-date-picker, incl. 8 complexity refactors [lts-2025]

### DIFF
--- a/ui/test/custom-date-picker.test.js
+++ b/ui/test/custom-date-picker.test.js
@@ -7354,3 +7354,223 @@ suite('custom-date-picker autocomplete', () => {
     expect(getDateInput(el).getAttribute('autocomplete')).to.equal('bday');
   });
 });
+
+// ELEMENTS-2077: every `catch` in custom-date-picker.js recovers rather than rethrows, but until
+// now none of them inspected the caught error (SonarCloud S2486) - a malformed value, an
+// unsupported format string or an unexpected locale was indistinguishable from "no value" and
+// nothing reached the log. Each recovery path now routes through _logRecoveredError. One test per
+// site: force the throw, assert the documented fallback is still what comes out, and assert the
+// cause is surfaced. These are also the branches that were previously uncovered, which is why
+// branch coverage for the file was the weak spot.
+suite('custom-date-picker error recovery (ELEMENTS-2077)', () => {
+  const newPicker = () =>
+    fixture(html`
+      <custom-date-picker></custom-date-picker>
+    `);
+
+  const BOOM = 'forced failure';
+  const boom = () => {
+    throw new Error(BOOM);
+  };
+
+  let warn;
+
+  setup(() => {
+    warn = sinon.stub(console, 'warn');
+  });
+
+  teardown(() => {
+    if (warn && warn.restore) {
+      warn.restore();
+    }
+  });
+
+  // Asserts the caught error reached the console, labelled with its call site.
+  const expectLogged = (site) => {
+    expect(warn.callCount, `console.warn for ${site}`).to.be.at.least(1);
+    const labels = warn.getCalls().map((call) => String(call.args[0]));
+    expect(labels.join('\n'), `log label for ${site}`).to.contain(site);
+    expect(labels.join('\n'), 'log prefix').to.contain('[custom-date-picker]');
+  };
+
+  test('pickerI18n.formatDate falls back to toLocaleDateString', async () => {
+    const el = await newPicker();
+    const date = new Date(2024, 3, 12);
+    sinon.stub(el, '_formatDateForDisplay').callsFake(boom);
+    expect(el.pickerI18n.formatDate(date)).to.equal(date.toLocaleDateString());
+    expectLogged('pickerI18n.formatDate');
+  });
+
+  test('pickerI18n.parseDate falls back to the current date', async () => {
+    const el = await newPicker();
+    const realMoment = el._moment.bind(el);
+    // Only the parsing call throws; the fallback's no-arg _moment() must still work.
+    sinon.stub(el, '_moment').callsFake((...args) => (args.length ? boom() : realMoment()));
+    const today = new Date();
+    expect(el.pickerI18n.parseDate('12/04/2024')).to.deep.equal({
+      day: today.getDate(),
+      month: today.getMonth(),
+      year: today.getFullYear(),
+    });
+    expectLogged('pickerI18n.parseDate');
+  });
+
+  test('_formatAriaDate falls back to toDateString on a broken locale', async () => {
+    const el = await newPicker();
+    const date = new Date(2024, 3, 12);
+    el._locale = 'not a locale';
+    expect(el._formatAriaDate(date)).to.equal(date.toDateString());
+    expectLogged('_formatAriaDate');
+  });
+
+  test('_parseDateOnly returns null for a value it cannot read', async () => {
+    const el = await newPicker();
+    const unreadable = {
+      valueOf: boom,
+      toString: boom,
+    };
+    expect(el._parseDateOnly(unreadable)).to.be.null;
+    expectLogged('_parseDateOnly');
+  });
+
+  test('_parseDateFromISO returns null when date construction fails', async () => {
+    const el = await newPicker();
+    const originalSetHours = Date.prototype.setHours;
+    // The body is otherwise unthrowable for a string input, so break the one call it makes.
+    Date.prototype.setHours = boom;
+    try {
+      expect(el._parseDateFromISO('2024-04-12')).to.be.null;
+    } finally {
+      Date.prototype.setHours = originalSetHours;
+    }
+    expectLogged('_parseDateFromISO');
+  });
+
+  test('_getMonthName falls back to the i18n month names on a broken en locale', async () => {
+    const el = await newPicker();
+    // Malformed enough for Intl to reject, but still resolves to the "en" language branch.
+    el._locale = 'en-';
+    expect(el._getMonthName(new Date(2024, 0, 15))).to.not.equal('');
+    expectLogged('_getMonthName');
+  });
+
+  test('_getMonthName returns an empty name for a broken non-en locale', async () => {
+    const el = await newPicker();
+    el._locale = 'not a locale';
+    expect(el._getMonthName(new Date(2024, 0, 15))).to.equal('');
+    expectLogged('_getMonthName');
+  });
+
+  test('_parseWithFormat returns null when moment throws', async () => {
+    const el = await newPicker();
+    sinon.stub(el, '_moment').callsFake(boom);
+    expect(el._parseWithFormat('12/04/2024', 'DD/MM/YYYY')).to.be.null;
+    expectLogged('_parseWithFormat');
+  });
+
+  test('_safeSetValue falls back to direct assignment when set() throws', async () => {
+    const el = await newPicker();
+    sinon.stub(el, 'set').callsFake(boom);
+    el._safeSetValue('2024-04-12');
+    expect(el.value).to.equal('2024-04-12');
+    expectLogged('_safeSetValue');
+  });
+
+  test('_getDatePlaceholder falls back to en-US when the locale cannot be canonicalised', async () => {
+    const el = await newPicker();
+    sinon.stub(el, '_getUserLocale').returns('!!!');
+    expect(el._getDatePlaceholder('')).to.match(/dd|mm|yyyy/);
+    expectLogged('_getDatePlaceholder (locale canonicalisation)');
+  });
+
+  test('_getDatePlaceholder falls back to the navigator locale when locale lookup throws', async () => {
+    const el = await newPicker();
+    sinon.stub(el, '_getUserLocale').callsFake(boom);
+    expect(el._getDatePlaceholder('')).to.match(/dd|mm|yyyy/);
+    expectLogged('_getDatePlaceholder');
+  });
+
+  test('_getDatePlaceholder falls back to dd/mm/yyyy when Intl is unusable', async () => {
+    const el = await newPicker();
+    sinon.stub(el, '_getUserLocale').callsFake(boom);
+    const OriginalDateTimeFormat = Intl.DateTimeFormat;
+    Intl.DateTimeFormat = boom;
+    try {
+      expect(el._getDatePlaceholder('')).to.equal('dd/mm/yyyy');
+    } finally {
+      Intl.DateTimeFormat = OriginalDateTimeFormat;
+    }
+    expectLogged('_getDatePlaceholder (locale fallback)');
+  });
+
+  test('_valueChanged clears the selection when the value cannot be parsed at all', async () => {
+    const el = await newPicker();
+    el._userIsTyping = false;
+    el._errorPersists = false;
+    el.value = '2024-04-12';
+    await flush();
+    sinon.stub(el, '_moment').callsFake(boom);
+    el._preventInputUpdate = false;
+    el._valueChanged();
+    expect(el._selectedDate).to.be.null;
+    expect(el._inputValue).to.equal('');
+    expect(el._preventInputUpdate, 'reentrancy guard must be released').to.be.false;
+    expectLogged('_valueChanged');
+  });
+
+  test('_formatDateForDisplay falls back to the navigator locale', async () => {
+    const el = await newPicker();
+    sinon.stub(el, '_getUserLocale').callsFake(boom);
+    const date = new Date(2024, 3, 12);
+    expect(el._formatDateForDisplay(date)).to.equal(new Intl.DateTimeFormat(navigator.language).format(date));
+    expectLogged('_formatDateForDisplay');
+  });
+
+  test('_parseUserInput returns null when locale lookup throws', async () => {
+    const el = await newPicker();
+    sinon.stub(el, '_getUserLocale').callsFake(boom);
+    expect(el._parseUserInput('12/04/2024')).to.be.null;
+    expectLogged('_parseUserInput');
+  });
+
+  // Guards against the flip side of the S2486 fix: a recovery path that fires during *normal*
+  // use would now turn into console noise on every interaction.
+  test('an ordinary interaction logs nothing', async () => {
+    const el = await newPicker();
+    await flush();
+    el.value = '2024-04-12';
+    await flush();
+    el._openCalendar();
+    await flush();
+    el._selectDate(new Date(2024, 3, 15));
+    await flush();
+    el._closeCalendar();
+    await flush();
+    el._inputValue = '20/04/2024';
+    el._validateAndParseInput();
+    await flush();
+    el.validate();
+    await flush();
+    const ours = warn.getCalls().filter((call) => String(call.args[0]).includes('[custom-date-picker]'));
+    expect(ours.map((call) => call.args[0]).join('\n'), 'no recovery path should fire').to.equal('');
+  });
+
+  test('repeated failures at the same site are logged once per element', async () => {
+    const el = await newPicker();
+    sinon.stub(el, '_getUserLocale').callsFake(boom);
+    el._parseUserInput('12/04/2024');
+    el._parseUserInput('13/04/2024');
+    el._parseUserInput('14/04/2024');
+    expect(warn.callCount, 'de-duplicated per call site').to.equal(1);
+  });
+
+  test('a fresh element logs again', async () => {
+    const first = await newPicker();
+    sinon.stub(first, '_getUserLocale').callsFake(boom);
+    first._parseUserInput('12/04/2024');
+    const second = await newPicker();
+    sinon.stub(second, '_getUserLocale').callsFake(boom);
+    second._parseUserInput('12/04/2024');
+    expect(warn.callCount, 'dedupe is per element instance').to.equal(2);
+  });
+});

--- a/ui/test/custom-date-picker.test.js
+++ b/ui/test/custom-date-picker.test.js
@@ -7402,17 +7402,21 @@ suite('custom-date-picker error recovery (ELEMENTS-2077)', () => {
   });
 
   test('pickerI18n.parseDate falls back to the current date', async () => {
-    const el = await newPicker();
-    const realMoment = el._moment.bind(el);
-    // Only the parsing call throws; the fallback's no-arg _moment() must still work.
-    sinon.stub(el, '_moment').callsFake((...args) => (args.length ? boom() : realMoment()));
-    const today = new Date();
-    expect(el.pickerI18n.parseDate('12/04/2024')).to.deep.equal({
-      day: today.getDate(),
-      month: today.getMonth(),
-      year: today.getFullYear(),
-    });
-    expectLogged('pickerI18n.parseDate');
+    const clock = sinon.useFakeTimers(new Date(2024, 3, 12).getTime());
+    try {
+      const el = await newPicker();
+      const realMoment = el._moment.bind(el);
+      // Only the parsing call throws; the fallback's no-arg _moment() must still work.
+      sinon.stub(el, '_moment').callsFake((...args) => (args.length ? boom() : realMoment()));
+      expect(el.pickerI18n.parseDate('12/04/2024')).to.deep.equal({
+        day: 12,
+        month: 3,
+        year: 2024,
+      });
+      expectLogged('pickerI18n.parseDate');
+    } finally {
+      clock.restore();
+    }
   });
 
   test('_formatAriaDate falls back to toDateString on a broken locale', async () => {

--- a/ui/test/custom-date-picker.test.js
+++ b/ui/test/custom-date-picker.test.js
@@ -7435,13 +7435,14 @@ suite('custom-date-picker error recovery (ELEMENTS-2077)', () => {
 
   test('_parseDateFromISO returns null when date construction fails', async () => {
     const el = await newPicker();
-    const originalSetHours = Date.prototype.setHours;
-    // The body is otherwise unthrowable for a string input, so break the one call it makes.
-    Date.prototype.setHours = boom;
+    // Unlike _parseDateOnly, this method rejects non-strings before its try/catch, so a
+    // throwing toString/valueOf object cannot reach the recovery path. For a valid ISO
+    // string the only throwable step inside the try is date.setHours(0, 0, 0, 0).
+    const setHoursStub = sinon.stub(Date.prototype, 'setHours').callsFake(boom);
     try {
       expect(el._parseDateFromISO('2024-04-12')).to.be.null;
     } finally {
-      Date.prototype.setHours = originalSetHours;
+      setHoursStub.restore();
     }
     expectLogged('_parseDateFromISO');
   });

--- a/ui/test/custom-date-picker.test.js
+++ b/ui/test/custom-date-picker.test.js
@@ -2838,6 +2838,109 @@ suite('custom-date-picker extras', () => {
     });
   });
 
+  // ELEMENTS-2077: characterisation tests for _positionPopover's horizontal placement. The two
+  // viewport-edge branches ran byte-identical centering blocks (SonarCloud S1871) and were merged
+  // into one `||` condition; the `left`/`top` dead initialisers were dropped (S1854). These pin the
+  // computed geometry so both changes - and the later extraction of the placement helpers - are
+  // provably behaviour-preserving. Rects are stubbed because the test page cannot be resized.
+  suite('_positionPopover horizontal placement (ELEMENTS-2077)', () => {
+    const POP_W = 280;
+    const POP_H = 320;
+    const MIN_PADDING = 8;
+
+    const viewport = () => {
+      return {
+        w: window.innerWidth || document.documentElement.clientWidth,
+        h: window.innerHeight || document.documentElement.clientHeight,
+      };
+    };
+
+    // Opens the calendar, then replaces the trigger/popover rects with fixed geometry so the
+    // assertions do not depend on the real layout of the test page.
+    const openWithStubbedRects = async (triggerRect) => {
+      const el = await newPicker();
+      el._openCalendar();
+      flush();
+      const popover = el.shadowRoot.querySelector('#calendarPopover');
+      const trigger = el.shadowRoot.querySelector('.input-wrapper');
+      expect(popover, '#calendarPopover').to.exist;
+      expect(trigger, '.input-wrapper').to.exist;
+      popover.getBoundingClientRect = () => {
+        return { width: POP_W, height: POP_H };
+      };
+      trigger.getBoundingClientRect = () => triggerRect;
+      return { el, popover };
+    };
+
+    const rect = (left, right) => {
+      return { top: 100, bottom: 130, left, right, width: right - left, height: 30 };
+    };
+
+    test('aligns with the trigger when it sits comfortably inside the viewport', async () => {
+      const { el, popover } = await openWithStubbedRects(rect(40, 240));
+      el._positionPopover();
+      expect(popover.style.position).to.equal('fixed');
+      expect(popover.style.left).to.equal('40px');
+      expect(popover.style.top).to.equal('134px'); // rect.bottom + 4
+    });
+
+    test('centers when clamped to the left edge and the trigger overflows to the left', async () => {
+      const { w } = viewport();
+      const maxLeft = w - POP_W - MIN_PADDING;
+      const centerLeft = (w - POP_W) / 2;
+      const { el, popover } = await openWithStubbedRects(rect(-50, 150));
+      el._positionPopover();
+      // Clamped to minLeft, and the trigger is also past that edge, so the popover is centered.
+      // Asserted as a precondition so a narrow runner viewport fails loudly instead of silently
+      // making this test vacuous.
+      expect(centerLeft, 'needs a runner viewport wider than ~576px').to.be.within(MIN_PADDING, maxLeft);
+      expect(popover.style.left).to.equal(`${centerLeft}px`);
+    });
+
+    test('centers when clamped to the right edge and the trigger overflows to the right', async () => {
+      const { w } = viewport();
+      const maxLeft = w - POP_W - MIN_PADDING;
+      const centerLeft = (w - POP_W) / 2;
+      const { el, popover } = await openWithStubbedRects(rect(w, w + 100));
+      el._positionPopover();
+      expect(centerLeft, 'needs a runner viewport wider than ~576px').to.be.within(MIN_PADDING, maxLeft);
+      expect(popover.style.left).to.equal(`${centerLeft}px`);
+    });
+
+    test('right-aligns with the trigger in RTL', async () => {
+      const { w } = viewport();
+      const maxLeft = w - POP_W - MIN_PADDING;
+      const { el, popover } = await openWithStubbedRects(rect(400, 600));
+      el._isRTL = true;
+      el._positionPopover();
+      // preferredLeft = inputRight - popWidth = 600 - 280 = 320, clamped into [8, maxLeft].
+      const preferred = Math.min(Math.max(600 - POP_W, MIN_PADDING), maxLeft);
+      expect(popover.style.left).to.equal(`${preferred}px`);
+    });
+
+    test('flips above the trigger when there is no room below', async () => {
+      const { h } = viewport();
+      // bottom close to the viewport floor => not enough space below, plenty above.
+      const { el, popover } = await openWithStubbedRects({
+        top: h - 40,
+        bottom: h - 10,
+        left: 40,
+        right: 240,
+        width: 200,
+        height: 30,
+      });
+      el._positionPopover();
+      const spaceAbove = h - 40;
+      if (spaceAbove >= POP_H + MIN_PADDING) {
+        expect(popover.classList.contains('open-up'), 'open-up').to.be.true;
+        expect(popover.style.top).to.equal(`${h - 40 - POP_H - 4}px`);
+      } else {
+        // Very short viewport: falls through to the "more space above" clamp.
+        expect(popover.style.top).to.equal(`${MIN_PADDING}px`);
+      }
+    });
+  });
+
   suite('_positionPopover branch coverage', () => {
     test('positions below when enough space', async () => {
       const el = await newPicker();
@@ -4892,6 +4995,35 @@ suite('custom-date-picker extras', () => {
       });
       expect(spy).to.have.been.called;
       spy.restore();
+    });
+
+    // ELEMENTS-2077: the Enter/Space and ArrowDown/F4 branches of _handleCalendarIconKeydown were
+    // merged into a single condition (SonarCloud S1871). Enter/Space activate the icon and
+    // ArrowDown/F4 are the WAI-ARIA combobox shortcuts, so all four must still open the calendar
+    // *and* swallow the event - otherwise the keystroke also scrolls the page or reaches a parent
+    // list/dialog handler. _openCalendar suppresses the event a second time, hence `at.least(1)`.
+    ['Enter', ' ', 'ArrowDown', 'F4'].forEach((key) => {
+      test(`opens the calendar and suppresses the event for "${key}"`, async () => {
+        const el = await newPicker();
+        const preventDefault = sinon.spy();
+        const stopPropagation = sinon.spy();
+        el._handleCalendarIconKeydown({ key, preventDefault, stopPropagation });
+        expect(el._isCalendarOpen, 'calendar open').to.be.true;
+        expect(preventDefault.callCount, 'preventDefault').to.be.at.least(1);
+        expect(stopPropagation.callCount, 'stopPropagation').to.be.at.least(1);
+      });
+    });
+
+    ['Escape', 'Tab', 'ArrowUp', 'ArrowLeft', 'F2', 'a'].forEach((key) => {
+      test(`leaves the calendar closed and the event untouched for "${key}"`, async () => {
+        const el = await newPicker();
+        const preventDefault = sinon.spy();
+        const stopPropagation = sinon.spy();
+        el._handleCalendarIconKeydown({ key, preventDefault, stopPropagation });
+        expect(el._isCalendarOpen, 'calendar open').to.be.false;
+        expect(preventDefault.callCount, 'preventDefault').to.equal(0);
+        expect(stopPropagation.callCount, 'stopPropagation').to.equal(0);
+      });
     });
 
     test('does nothing on unrelated key', async () => {

--- a/ui/test/custom-date-picker.test.js
+++ b/ui/test/custom-date-picker.test.js
@@ -7402,9 +7402,9 @@ suite('custom-date-picker error recovery (ELEMENTS-2077)', () => {
   });
 
   test('pickerI18n.parseDate falls back to the current date', async () => {
+    const el = await newPicker();
     const clock = sinon.useFakeTimers(new Date(2024, 3, 12).getTime());
     try {
-      const el = await newPicker();
       const realMoment = el._moment.bind(el);
       // Only the parsing call throws; the fallback's no-arg _moment() must still work.
       sinon.stub(el, '_moment').callsFake((...args) => (args.length ? boom() : realMoment()));

--- a/ui/test/custom-date-picker.test.js
+++ b/ui/test/custom-date-picker.test.js
@@ -2299,32 +2299,6 @@ suite('custom-date-picker extras', () => {
     });
   });
 
-  suite('_handleCalendarIconKeydown', () => {
-    test('opens calendar on Enter', async () => {
-      const el = await newPicker();
-      el._handleCalendarIconKeydown({ key: 'Enter', preventDefault() {}, stopPropagation() {} });
-      expect(el._isCalendarOpen).to.be.true;
-    });
-
-    test('opens calendar on Space', async () => {
-      const el = await newPicker();
-      el._handleCalendarIconKeydown({ key: ' ', preventDefault() {}, stopPropagation() {} });
-      expect(el._isCalendarOpen).to.be.true;
-    });
-
-    test('opens calendar on ArrowDown', async () => {
-      const el = await newPicker();
-      el._handleCalendarIconKeydown({ key: 'ArrowDown', preventDefault() {}, stopPropagation() {} });
-      expect(el._isCalendarOpen).to.be.true;
-    });
-
-    test('opens calendar on F4', async () => {
-      const el = await newPicker();
-      el._handleCalendarIconKeydown({ key: 'F4', preventDefault() {}, stopPropagation() {} });
-      expect(el._isCalendarOpen).to.be.true;
-    });
-  });
-
   suite('resetErrorState', () => {
     test('clears all error flags and DOM', async () => {
       const el = await newPicker();
@@ -4949,54 +4923,6 @@ suite('custom-date-picker extras', () => {
   });
 
   suite('_handleCalendarIconKeydown', () => {
-    test('opens calendar on Enter', async () => {
-      const el = await newPicker();
-      const spy = sinon.spy(el, '_openCalendar');
-      el._handleCalendarIconKeydown({
-        key: 'Enter',
-        preventDefault() {},
-        stopPropagation() {},
-      });
-      expect(spy).to.have.been.called;
-      spy.restore();
-    });
-
-    test('opens calendar on Space', async () => {
-      const el = await newPicker();
-      const spy = sinon.spy(el, '_openCalendar');
-      el._handleCalendarIconKeydown({
-        key: ' ',
-        preventDefault() {},
-        stopPropagation() {},
-      });
-      expect(spy).to.have.been.called;
-      spy.restore();
-    });
-
-    test('opens calendar on ArrowDown', async () => {
-      const el = await newPicker();
-      const spy = sinon.spy(el, '_openCalendar');
-      el._handleCalendarIconKeydown({
-        key: 'ArrowDown',
-        preventDefault() {},
-        stopPropagation() {},
-      });
-      expect(spy).to.have.been.called;
-      spy.restore();
-    });
-
-    test('opens calendar on F4', async () => {
-      const el = await newPicker();
-      const spy = sinon.spy(el, '_openCalendar');
-      el._handleCalendarIconKeydown({
-        key: 'F4',
-        preventDefault() {},
-        stopPropagation() {},
-      });
-      expect(spy).to.have.been.called;
-      spy.restore();
-    });
-
     // ELEMENTS-2077: the Enter/Space and ArrowDown/F4 branches of _handleCalendarIconKeydown were
     // merged into a single condition (SonarCloud S1871). Enter/Space activate the icon and
     // ArrowDown/F4 are the WAI-ARIA combobox shortcuts, so all four must still open the calendar
@@ -5024,18 +4950,6 @@ suite('custom-date-picker extras', () => {
         expect(preventDefault.callCount, 'preventDefault').to.equal(0);
         expect(stopPropagation.callCount, 'stopPropagation').to.equal(0);
       });
-    });
-
-    test('does nothing on unrelated key', async () => {
-      const el = await newPicker();
-      const spy = sinon.spy(el, '_openCalendar');
-      el._handleCalendarIconKeydown({
-        key: 'a',
-        preventDefault() {},
-        stopPropagation() {},
-      });
-      expect(spy).not.to.have.been.called;
-      spy.restore();
     });
   });
 

--- a/ui/test/custom-date-picker.test.js
+++ b/ui/test/custom-date-picker.test.js
@@ -7579,3 +7579,485 @@ suite('custom-date-picker error recovery (ELEMENTS-2077)', () => {
     expect(warn.callCount, 'dedupe is per element instance').to.equal(2);
   });
 });
+
+/*
+ * Characterisation tests for the code paths touched by ELEMENTS-2077's S3776 refactors.
+ *
+ * These exist because the refactored functions had branches that no test exercised - most
+ * starkly _moveYearOptionFocus, where only 2 of 15 lines ran. A green suite therefore said
+ * nothing about whether those extractions preserved behaviour.
+ *
+ * Every test below drives a PRE-EXISTING entry point (_handleGridKeydown,
+ * _handleYearDropdownKeydown, _updateErrorDisplay, _parseUserInput) rather than any newly
+ * extracted helper, so this file runs unchanged against both the refactored code and the
+ * commit before it. Green on both is the actual evidence of equivalence.
+ */
+suite('custom-date-picker characterisation (ELEMENTS-2077 S3776)', () => {
+  // A minimal keydown stand-in: the handlers only ever read `key` and `target`, and call
+  // preventDefault/stopPropagation. Mirrors makeEscapeEvent() above.
+  function keyEvent(key, target) {
+    let prevented = false;
+    let stopped = false;
+    return {
+      key,
+      target,
+      preventDefault() {
+        prevented = true;
+      },
+      stopPropagation() {
+        stopped = true;
+      },
+      wasPrevented: () => prevented,
+      wasStopped: () => stopped,
+    };
+  }
+
+  suite('year dropdown roving focus', () => {
+    // min/max narrow _generateYearOptions to 2020..2029, so index arithmetic is assertable.
+    let el;
+    let buttons;
+
+    setup(async () => {
+      el = await fixture(html`
+        <custom-date-picker min="2020-01-01" max="2029-12-31"></custom-date-picker>
+      `);
+      await flush();
+      el._viewDate = new Date(2024, 0, 1);
+      el._openCalendar();
+      await flush();
+
+      const panel = el.shadowRoot.querySelector('#yearOptions');
+      panel.classList.add('open');
+      el._isYearDropdownOpen = true;
+
+      buttons = Array.from(el.shadowRoot.querySelectorAll('.year-option'));
+      buttons.forEach((b, i) => {
+        b.tabIndex = i === 0 ? 0 : -1;
+      });
+    });
+
+    const focusedIndex = () => buttons.findIndex((b) => b.tabIndex === 0);
+
+    test('renders one option per year in the min/max range', () => {
+      expect(buttons.length).to.equal(10);
+      expect(buttons[0].textContent.trim()).to.equal('2020');
+      expect(buttons[9].textContent.trim()).to.equal('2029');
+    });
+
+    test('ArrowDown moves the roving tabindex forward one option', () => {
+      el._handleYearDropdownKeydown(keyEvent('ArrowDown'));
+      expect(focusedIndex()).to.equal(1);
+    });
+
+    test('ArrowUp moves the roving tabindex back one option', () => {
+      buttons[0].tabIndex = -1;
+      buttons[3].tabIndex = 0;
+      el._handleYearDropdownKeydown(keyEvent('ArrowUp'));
+      expect(focusedIndex()).to.equal(2);
+    });
+
+    test('ArrowUp clamps at the first option instead of wrapping', () => {
+      el._handleYearDropdownKeydown(keyEvent('ArrowUp'));
+      expect(focusedIndex()).to.equal(0);
+    });
+
+    test('ArrowDown clamps at the last option instead of wrapping', () => {
+      buttons[0].tabIndex = -1;
+      buttons[9].tabIndex = 0;
+      el._handleYearDropdownKeydown(keyEvent('ArrowDown'));
+      expect(focusedIndex()).to.equal(9);
+    });
+
+    test('Home jumps to the first option', () => {
+      buttons[0].tabIndex = -1;
+      buttons[7].tabIndex = 0;
+      el._handleYearDropdownKeydown(keyEvent('Home'));
+      expect(focusedIndex()).to.equal(0);
+    });
+
+    test('End jumps to the last option', () => {
+      el._handleYearDropdownKeydown(keyEvent('End'));
+      expect(focusedIndex()).to.equal(9);
+    });
+
+    test('PageDown moves ten options, clamped to the last', () => {
+      el._handleYearDropdownKeydown(keyEvent('PageDown'));
+      expect(focusedIndex()).to.equal(9);
+    });
+
+    test('PageUp moves ten options back, clamped to the first', () => {
+      buttons[0].tabIndex = -1;
+      buttons[5].tabIndex = 0;
+      el._handleYearDropdownKeydown(keyEvent('PageUp'));
+      expect(focusedIndex()).to.equal(0);
+    });
+
+    test('exactly one option carries tabindex 0 after a move', () => {
+      el._handleYearDropdownKeydown(keyEvent('ArrowDown'));
+      expect(buttons.filter((b) => b.tabIndex === 0).length).to.equal(1);
+    });
+
+    test('moves focus as well as the tabindex', () => {
+      el._handleYearDropdownKeydown(keyEvent('ArrowDown'));
+      expect(el.shadowRoot.activeElement).to.equal(buttons[1]);
+    });
+
+    test('Enter activates the option holding the roving tabindex', () => {
+      buttons[0].tabIndex = -1;
+      buttons[6].tabIndex = 0; // 2026
+      el._handleYearDropdownKeydown(keyEvent('Enter'));
+      expect(el._viewDate.getFullYear()).to.equal(2026);
+    });
+
+    test('Space activates the focused option too', () => {
+      buttons[0].tabIndex = -1;
+      buttons[2].tabIndex = 0; // 2022
+      el._handleYearDropdownKeydown(keyEvent(' '));
+      expect(el._viewDate.getFullYear()).to.equal(2022);
+    });
+
+    test('ArrowDown opens the dropdown instead of moving when it is closed', () => {
+      el.shadowRoot.querySelector('#yearOptions').classList.remove('open');
+      el._isYearDropdownOpen = false;
+      el._handleYearDropdownKeydown(keyEvent('ArrowDown'));
+      expect(el._isYearDropdownOpen).to.be.true;
+      expect(focusedIndex()).to.equal(0);
+    });
+
+    test('Enter opens the dropdown when it is closed', () => {
+      el.shadowRoot.querySelector('#yearOptions').classList.remove('open');
+      el._isYearDropdownOpen = false;
+      el._handleYearDropdownKeydown(keyEvent('Enter'));
+      expect(el._isYearDropdownOpen).to.be.true;
+    });
+
+    test('Home still consumes the event when the panel is closed, but moves nothing', () => {
+      el.shadowRoot.querySelector('#yearOptions').classList.remove('open');
+      buttons[0].tabIndex = -1;
+      buttons[4].tabIndex = 0;
+      const event = keyEvent('Home');
+      el._handleYearDropdownKeydown(event);
+      expect(event.wasPrevented()).to.be.true;
+      expect(focusedIndex()).to.equal(4);
+    });
+  });
+
+  suite('day grid navigation within the viewed month', () => {
+    // April 2024: the 1st is a Monday and the month has 30 days, so every boundary case
+    // below is reachable inside one month.
+    let el;
+    let focusDate;
+
+    setup(async () => {
+      el = await fixture(html`
+        <custom-date-picker></custom-date-picker>
+      `);
+      await flush();
+      el._openCalendar();
+      el._viewDate = new Date(2024, 3, 1);
+      el._generateCalendar();
+      await flush();
+      focusDate = sinon.spy(el, '_focusDate');
+    });
+
+    teardown(() => {
+      focusDate.restore();
+    });
+
+    const dayButton = (iso) => el.shadowRoot.querySelector(`[data-date="${iso}"]`);
+    const movedTo = () => focusDate.getCall(0).args[0];
+
+    test('ArrowLeft moves back one day', () => {
+      el._handleGridKeydown(keyEvent('ArrowLeft', dayButton('2024-04-15')));
+      expect(focusDate.calledOnce).to.be.true;
+      expect(movedTo().getDate()).to.equal(14);
+    });
+
+    test('ArrowRight moves forward one day', () => {
+      el._handleGridKeydown(keyEvent('ArrowRight', dayButton('2024-04-15')));
+      expect(movedTo().getDate()).to.equal(16);
+    });
+
+    test('ArrowUp moves back one week', () => {
+      el._handleGridKeydown(keyEvent('ArrowUp', dayButton('2024-04-15')));
+      expect(movedTo().getDate()).to.equal(8);
+    });
+
+    test('ArrowDown moves forward one week', () => {
+      el._handleGridKeydown(keyEvent('ArrowDown', dayButton('2024-04-15')));
+      expect(movedTo().getDate()).to.equal(22);
+    });
+
+    test('Home moves to the start of the focused week', () => {
+      // The 15th is a Monday, so the week starts on Sunday the 14th.
+      el._handleGridKeydown(keyEvent('Home', dayButton('2024-04-15')));
+      expect(movedTo().getDate()).to.equal(14);
+    });
+
+    test('End moves to the end of the focused week', () => {
+      el._handleGridKeydown(keyEvent('End', dayButton('2024-04-15')));
+      expect(movedTo().getDate()).to.equal(20);
+    });
+
+    test('ArrowLeft does not cross into the previous month', () => {
+      el._handleGridKeydown(keyEvent('ArrowLeft', dayButton('2024-04-01')));
+      expect(focusDate.called).to.be.false;
+    });
+
+    test('ArrowRight does not cross into the next month', () => {
+      el._handleGridKeydown(keyEvent('ArrowRight', dayButton('2024-04-30')));
+      expect(focusDate.called).to.be.false;
+    });
+
+    test('ArrowUp does not cross into the previous month', () => {
+      el._handleGridKeydown(keyEvent('ArrowUp', dayButton('2024-04-01')));
+      expect(focusDate.called).to.be.false;
+    });
+
+    test('ArrowDown does not cross into the next month', () => {
+      el._handleGridKeydown(keyEvent('ArrowDown', dayButton('2024-04-30')));
+      expect(focusDate.called).to.be.false;
+    });
+
+    test('Home does not cross into the previous month', () => {
+      // The 1st is a Monday, so its week starts on 31 March.
+      el._handleGridKeydown(keyEvent('Home', dayButton('2024-04-01')));
+      expect(focusDate.called).to.be.false;
+    });
+
+    test('End does not cross into the next month', () => {
+      // The 30th is a Tuesday, so its week ends on 4 May.
+      el._handleGridKeydown(keyEvent('End', dayButton('2024-04-30')));
+      expect(focusDate.called).to.be.false;
+    });
+
+    test('every navigation key consumes the event', () => {
+      ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End'].forEach((key) => {
+        const event = keyEvent(key, dayButton('2024-04-15'));
+        el._handleGridKeydown(event);
+        expect(event.wasPrevented(), `${key} preventDefault`).to.be.true;
+        expect(event.wasStopped(), `${key} stopPropagation`).to.be.true;
+      });
+    });
+
+    test('Enter selects the focused day', () => {
+      const selectDate = sinon.spy(el, '_selectDate');
+      el._handleGridKeydown(keyEvent('Enter', dayButton('2024-04-15')));
+      expect(selectDate.calledOnce).to.be.true;
+      expect(selectDate.getCall(0).args[0].getDate()).to.equal(15);
+      selectDate.restore();
+    });
+
+    test('an unhandled key neither moves nor selects', () => {
+      const selectDate = sinon.spy(el, '_selectDate');
+      el._handleGridKeydown(keyEvent('a', dayButton('2024-04-15')));
+      expect(focusDate.called).to.be.false;
+      expect(selectDate.called).to.be.false;
+      selectDate.restore();
+    });
+  });
+
+  suite('error display: show / clear / keep', () => {
+    let el;
+    let errorEl;
+
+    setup(async () => {
+      el = await fixture(html`
+        <custom-date-picker></custom-date-picker>
+      `);
+      await flush();
+      errorEl = el.shadowRoot.querySelector('#errorText');
+    });
+
+    test('shows the required message for an empty required field', () => {
+      el.required = true;
+      el.value = '';
+      el._showErrors = true;
+      // _getValidity sets errorMessage before _updateErrorDisplay runs in the real flow.
+      // It matters: setAttribute('invalid') fires _invalidChanged, which recomputes the
+      // element's hidden state from errorMessage, and an empty one re-hides the row.
+      el.errorMessage = el._generateRequiredMessage();
+      el._updateErrorDisplay(false);
+      expect(errorEl.hidden).to.be.false;
+      expect(errorEl.textContent).to.not.equal('');
+      expect(el.hasAttribute('invalid')).to.be.true;
+    });
+
+    test('shows errorMessage for a non-required validation failure', () => {
+      el.required = false;
+      el.value = 'nonsense';
+      el.errorMessage = 'Incorrect date format';
+      el._showErrors = true;
+      el._updateErrorDisplay(false);
+      expect(errorEl.textContent).to.equal('Incorrect date format');
+      expect(errorEl.hidden).to.be.false;
+    });
+
+    test('KEEPS the existing message when invalid but there is nothing new to say', () => {
+      // The load-bearing third case: invalid, errors are showing, but the field is neither
+      // an empty-required nor carrying an errorMessage. The previous text must survive.
+      el.required = false;
+      el.value = 'something';
+      el.errorMessage = '';
+      el._showErrors = true;
+      errorEl.textContent = 'Previously shown error';
+      errorEl.hidden = false;
+
+      el._updateErrorDisplay(false);
+
+      expect(errorEl.textContent).to.equal('Previously shown error');
+      expect(errorEl.hidden).to.be.false;
+    });
+
+    test('clears when the field is valid', () => {
+      el.setAttribute('invalid', '');
+      errorEl.hidden = false;
+      el._showErrors = true;
+      el._updateErrorDisplay(true);
+      expect(errorEl.hidden).to.be.true;
+      expect(el.hasAttribute('invalid')).to.be.false;
+    });
+
+    test('clears when errors are not being shown yet, even if invalid', () => {
+      el.setAttribute('invalid', '');
+      errorEl.hidden = false;
+      el._showErrors = false;
+      el._updateErrorDisplay(false);
+      expect(errorEl.hidden).to.be.true;
+      expect(el.hasAttribute('invalid')).to.be.false;
+    });
+  });
+
+  suite('outside-click dismissal', () => {
+    let el;
+
+    setup(async () => {
+      el = await fixture(html`
+        <custom-date-picker></custom-date-picker>
+      `);
+      await flush();
+      el._openCalendar();
+      await flush();
+      el._interactingWithCalendar = false;
+    });
+
+    test('a click on the calendar popover leaves it open', () => {
+      const popover = el.shadowRoot.querySelector('#calendarPopover');
+      el._handleDocumentClick({ target: popover, composedPath: () => [popover] });
+      expect(el._isCalendarOpen).to.be.true;
+    });
+
+    test('a click reaching the host only via the composed path leaves it open', () => {
+      // The path sees through shadow boundaries that the retargeted target does not, which
+      // is the whole reason that fourth check exists.
+      el._handleDocumentClick({ target: document.body, composedPath: () => [document.body, el] });
+      expect(el._isCalendarOpen).to.be.true;
+    });
+
+    test('a click genuinely outside closes the calendar', () => {
+      el._handleDocumentClick({ target: document.body, composedPath: () => [document.body] });
+      expect(el._isCalendarOpen).to.be.false;
+    });
+
+    test('a click outside is ignored while interacting with the calendar', () => {
+      el._interactingWithCalendar = true;
+      el._handleDocumentClick({ target: document.body, composedPath: () => [document.body] });
+      expect(el._isCalendarOpen).to.be.true;
+    });
+
+    test('closing via an outside click also closes an open year dropdown', () => {
+      el.shadowRoot.querySelector('#yearOptions').classList.add('open');
+      el._isYearDropdownOpen = true;
+      el._handleDocumentClick({ target: document.body, composedPath: () => [document.body] });
+      expect(el._isCalendarOpen).to.be.false;
+      expect(el._isYearDropdownOpen).to.be.false;
+    });
+  });
+
+  suite('input parsing: format resolution and the plausible-year window', () => {
+    let el;
+
+    setup(async () => {
+      el = await fixture(html`
+        <custom-date-picker></custom-date-picker>
+      `);
+      await flush();
+    });
+
+    test('an exact match on the primary format is kept verbatim', () => {
+      el.format = 'DD MMMM YYYY';
+      const result = el._parseUserInput('12 April 2024');
+      expect(result).to.not.be.null;
+      expect(result.isExactFormat).to.be.true;
+      expect(result.date.getFullYear()).to.equal(2024);
+      expect(result.date.getMonth()).to.equal(3);
+      expect(result.date.getDate()).to.equal(12);
+    });
+
+    test('the strict path does NOT apply the 1900-2200 window', () => {
+      // Deliberate asymmetry, and the reason _momentToStartOfDay is parameterised: an input
+      // that matches the primary format exactly is taken at face value, however odd the year.
+      el.format = 'YYYY-MM-DD';
+      const result = el._parseUserInput('1850-12-04');
+      expect(result).to.not.be.null;
+      expect(result.isExactFormat).to.be.true;
+      expect(result.date.getFullYear()).to.equal(1850);
+    });
+
+    test('the strict path accepts a year above 2200 as well', () => {
+      el.format = 'YYYY-MM-DD';
+      const result = el._parseUserInput('2500-12-04');
+      expect(result).to.not.be.null;
+      expect(result.isExactFormat).to.be.true;
+      expect(result.date.getFullYear()).to.equal(2500);
+    });
+
+    test('a recovery path rejects a year below 1900', () => {
+      // Numeric primary format, so the ISO input reaches the recovery attempts, which do
+      // apply the window.
+      el.format = 'MM/DD/YYYY';
+      expect(el._parseUserInput('1850-12-04')).to.be.null;
+      expect(el._parseUserInput('1899-12-31')).to.be.null;
+    });
+
+    test('a recovery path rejects a year above 2200', () => {
+      el.format = 'MM/DD/YYYY';
+      expect(el._parseUserInput('2500-12-04')).to.be.null;
+      expect(el._parseUserInput('2201-01-01')).to.be.null;
+    });
+
+    test('a recovery path inside the window is accepted and marked non-exact', () => {
+      el.format = 'MM/DD/YYYY';
+      const result = el._parseUserInput('2024-04-12');
+      expect(result).to.not.be.null;
+      expect(result.isExactFormat).to.be.false;
+      expect(result.date.getFullYear()).to.equal(2024);
+      expect(result.date.getMonth()).to.equal(3);
+      expect(result.date.getDate()).to.equal(12);
+    });
+
+    test('an unusable format flags the field and still falls back to the locale format', () => {
+      el.format = 'qqqq';
+      el.invalid = false;
+      el.errorMessage = '';
+      const result = el._parseUserInput('2024-04-12');
+      expect(el.invalid).to.be.true;
+      expect(el.errorMessage).to.contain('Invalid date format');
+      expect(result).to.not.be.null;
+      expect(result.date.getFullYear()).to.equal(2024);
+    });
+
+    test('start of day is normalised on every accepted path', () => {
+      el.format = 'DD MMMM YYYY';
+      const exact = el._parseUserInput('12 April 2024');
+      el.format = 'MM/DD/YYYY';
+      const recovered = el._parseUserInput('2024-04-12');
+      [exact, recovered].forEach((r) => {
+        expect(r.date.getHours()).to.equal(0);
+        expect(r.date.getMinutes()).to.equal(0);
+        expect(r.date.getSeconds()).to.equal(0);
+        expect(r.date.getMilliseconds()).to.equal(0);
+      });
+    });
+  });
+});

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -1378,6 +1378,31 @@ const VALID_MOMENT_TOKENS = new Set([
       this._today.setHours(0, 0, 0, 0); // Normalize to start of day
       this._viewDate = new Date();
       this._focusedDate = null;
+      // Call sites already reported by _logRecoveredError (see there).
+      this._loggedRecoveries = new Set();
+    }
+
+    /**
+     * Surfaces an exception that a recovery path would otherwise discard (SonarCloud S2486).
+     *
+     * Every `catch` in this element recovers rather than rethrows, deliberately: a malformed
+     * value, an unsupported format string or an unexpected locale must degrade to a sensible
+     * default instead of breaking the field. Until now none of them logged anything, which made
+     * a field report of "the date picker just clears my input" undiagnosable. Warnings are
+     * de-duplicated per element instance and per call site, so a persistently broken locale
+     * cannot flood the console from a path that runs once per rendered day cell.
+     *
+     * @param {string} context Call site, used both as the log label and as the dedupe key.
+     * @param {*} error The caught error.
+     */
+    _logRecoveredError(context, error) {
+      if (this._loggedRecoveries && this._loggedRecoveries.has(context)) {
+        return;
+      }
+      if (this._loggedRecoveries) {
+        this._loggedRecoveries.add(context);
+      }
+      console.warn(`[custom-date-picker] recovered from an error in ${context}:`, error);
     }
 
     ready() {
@@ -1415,6 +1440,7 @@ const VALID_MOMENT_TOKENS = new Set([
           try {
             return this._formatDateForDisplay(date);
           } catch (error) {
+            this._logRecoveredError('pickerI18n.formatDate', error);
             return date ? date.toLocaleDateString() : '';
           }
         },
@@ -1440,6 +1466,7 @@ const VALID_MOMENT_TOKENS = new Set([
             };
           } catch (error) {
             // Return current date instead of hardcoded values
+            this._logRecoveredError('pickerI18n.parseDate', error);
             const fallbackDate = this._moment();
             return {
               day: fallbackDate.get('D'),
@@ -1584,7 +1611,8 @@ const VALID_MOMENT_TOKENS = new Set([
           month: 'long',
           day: 'numeric',
         }).format(date);
-      } catch (_) {
+      } catch (error) {
+        this._logRecoveredError('_formatAriaDate', error);
         return date && date.toDateString ? date.toDateString() : '';
       }
     }
@@ -1614,7 +1642,9 @@ const VALID_MOMENT_TOKENS = new Set([
         if (Number.isNaN(d.getTime())) return null;
         d.setHours(0, 0, 0, 0);
         return d;
-      } catch (_) {
+      } catch (error) {
+        // A value we cannot read is reported as "no date"; log why so the cause is diagnosable.
+        this._logRecoveredError('_parseDateOnly', error);
         return null;
       }
     }
@@ -1648,6 +1678,8 @@ const VALID_MOMENT_TOKENS = new Set([
 
         return date;
       } catch (error) {
+        // An ISO string we cannot read is reported as "no date"; log why.
+        this._logRecoveredError('_parseDateFromISO', error);
         return null;
       }
     }
@@ -2361,7 +2393,8 @@ const VALID_MOMENT_TOKENS = new Set([
         return new Intl.DateTimeFormat(locale, {
           month: 'long',
         }).format(date);
-      } catch (e) {
+      } catch (error) {
+        this._logRecoveredError('_getMonthName', error);
         // ⚠️ Fallback: Use i18n for English months
         const lang = locale.split('-')[0];
         const monthIndex = date.getMonth();
@@ -3532,7 +3565,9 @@ const VALID_MOMENT_TOKENS = new Set([
         }
 
         return null;
-      } catch (e) {
+      } catch (error) {
+        // Unparseable input is reported as "no date"; log why.
+        this._logRecoveredError('_parseWithFormat', error);
         return null;
       }
     }
@@ -3676,12 +3711,13 @@ const VALID_MOMENT_TOKENS = new Set([
           this.notifyPath('value');
         }
       } catch (error) {
-        // Error setting value safely - using fallback
-        // Last resort - try direct assignment
+        // Error setting value safely - last resort is direct assignment.
+        this._logRecoveredError('_safeSetValue', error);
         try {
           this.value = newValue;
-        } catch (fallbackError) {
-          // Failed to set value with fallback - silent error
+        } catch (_) {
+          // Direct assignment failed too. Nothing further can be done without breaking the
+          // field, and the cause was already logged above.
         }
       }
     }
@@ -3854,8 +3890,9 @@ const VALID_MOMENT_TOKENS = new Set([
           // Canonicalize locale (handles casing, region format, etc.)
           const [canonicalLocale] = Intl.getCanonicalLocales(normalizedLocale);
           normalizedLocale = canonicalLocale;
-        } catch (e) {
+        } catch (error) {
           // Fallback safely
+          this._logRecoveredError('_getDatePlaceholder (locale canonicalisation)', error);
           normalizedLocale = 'en-US';
         }
 
@@ -3895,8 +3932,9 @@ const VALID_MOMENT_TOKENS = new Set([
             return part.value; // keep separators like "/", "-", "."
           })
           .join('');
-      } catch (e) {
+      } catch (error) {
         // Safe fallback (still respects locale order)
+        this._logRecoveredError('_getDatePlaceholder', error);
         try {
           const locale = navigator.language;
 
@@ -3910,6 +3948,7 @@ const VALID_MOMENT_TOKENS = new Set([
             })
             .join('');
         } catch (error) {
+          this._logRecoveredError('_getDatePlaceholder (locale fallback)', error);
           return 'dd/mm/yyyy';
         }
       }
@@ -4125,6 +4164,7 @@ const VALID_MOMENT_TOKENS = new Set([
         // Reset the flag after all updates are done
         this._preventInputUpdate = false;
       } catch (error) {
+        this._logRecoveredError('_valueChanged', error);
         this._selectedDate = null;
         // Don't clear input if there are persistent errors - preserve user input
         if (!this._userIsTyping && !this._errorPersists) {
@@ -5023,6 +5063,7 @@ const VALID_MOMENT_TOKENS = new Set([
         return this._moment(date).format(format);
       } catch (error) {
         // Safe fallback using Intl.DateTimeFormat
+        this._logRecoveredError('_formatDateForDisplay', error);
         return new Intl.DateTimeFormat(navigator.language).format(date);
       }
     }
@@ -5151,6 +5192,8 @@ const VALID_MOMENT_TOKENS = new Set([
 
         return null;
       } catch (error) {
+        // Unparseable input is reported as "no date"; log why.
+        this._logRecoveredError('_parseUserInput', error);
         return null;
       }
     }

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -3715,9 +3715,9 @@ const VALID_MOMENT_TOKENS = new Set([
         this._logRecoveredError('_safeSetValue', error);
         try {
           this.value = newValue;
-        } catch (_) {
-          // Direct assignment failed too. Nothing further can be done without breaking the
-          // field, and the cause was already logged above.
+        } catch (fallbackError) {
+          // Direct assignment failed too — log separately so both root causes are visible.
+          this._logRecoveredError('_safeSetValue (direct assignment)', fallbackError);
         }
       }
     }

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -4270,15 +4270,12 @@ const VALID_MOMENT_TOKENS = new Set([
           left = Math.max(minLeft, Math.min(maxLeft, preferredLeft));
         }
 
-        // Additional adjustment for extreme edge cases
-        if (left === minLeft && rect.left < minLeft) {
-          // If we're at minimum left and trigger is also at edge, try to center
-          const centerLeft = (viewportW - popWidth) / 2;
-          if (centerLeft >= minLeft && centerLeft <= maxLeft) {
-            left = centerLeft;
-          }
-        } else if (left === maxLeft && rect.right > viewportW - minPadding) {
-          // If we're at maximum right and trigger is also at edge, try to center
+        // Additional adjustment for extreme edge cases: the popover was clamped to a
+        // viewport edge *and* the trigger itself sits at (or past) that same edge. Left and
+        // right both centre the popover, so the two cases share one branch.
+        const clampedAtLeftEdge = left === minLeft && rect.left < minLeft;
+        const clampedAtRightEdge = left === maxLeft && rect.right > viewportW - minPadding;
+        if (clampedAtLeftEdge || clampedAtRightEdge) {
           const centerLeft = (viewportW - popWidth) / 2;
           if (centerLeft >= minLeft && centerLeft <= maxLeft) {
             left = centerLeft;
@@ -4855,11 +4852,10 @@ const VALID_MOMENT_TOKENS = new Set([
     }
 
     _handleCalendarIconKeydown(e) {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        e.stopPropagation();
-        this._openCalendar(e, true); // Opened via keyboard
-      } else if (e.key === 'ArrowDown' || e.key === 'F4') {
+      // Enter / Space activate the icon; ArrowDown / F4 are the WAI-ARIA combobox
+      // shortcuts for opening the popup. All four open the calendar in keyboard mode.
+      const opensCalendar = e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown' || e.key === 'F4';
+      if (opensCalendar) {
         e.preventDefault();
         e.stopPropagation();
         this._openCalendar(e, true); // Opened via keyboard

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -32,6 +32,30 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 // collapsing the popover during month navigation.
 const FOCUS_SUPPRESSION_MS = 200;
 
+// Moment tokens accepted in the `format` property (extend if needed). A Set because it is
+// only ever used for membership tests; hoisted to module scope so it is built once.
+const VALID_MOMENT_TOKENS = new Set([
+  'D',
+  'DD',
+  'Do',
+  'M',
+  'MM',
+  'MMM',
+  'MMMM',
+  'YY',
+  'YYYY',
+  'H',
+  'HH',
+  'h',
+  'hh',
+  'm',
+  'mm',
+  's',
+  'ss',
+  'A',
+  'a',
+]);
+
 {
   class CustomDatePicker extends mixinBehaviors(
     [I18nBehavior, IronFormElementBehavior, IronValidatableBehavior],
@@ -1507,7 +1531,7 @@ const FOCUS_SUPPRESSION_MS = 200;
       // Replace placeholders
       Object.keys(placeholders).forEach((placeholder) => {
         const value = placeholders[placeholder];
-        text = text.replace(new RegExp(`\\{${placeholder}\\}`, 'g'), value);
+        text = text.replace(new RegExp(String.raw`\{${placeholder}\}`, 'g'), value);
       });
 
       return text;
@@ -1576,7 +1600,7 @@ const FOCUS_SUPPRESSION_MS = 200;
       if (!value) return null;
       try {
         if (typeof value === 'string') {
-          const m = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+          const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
           if (m) {
             const year = parseInt(m[1], 10);
             const month = parseInt(m[2], 10) - 1;
@@ -1601,7 +1625,7 @@ const FOCUS_SUPPRESSION_MS = 200;
 
       try {
         // Strict ISO format validation: YYYY-MM-DD
-        const match = isoString.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoString);
         if (!match) return null;
 
         const year = parseInt(match[1], 10);
@@ -2993,8 +3017,7 @@ const FOCUS_SUPPRESSION_MS = 200;
         }
       }
       if (popover) {
-        popover.classList.remove('open');
-        popover.classList.remove('open-up');
+        popover.classList.remove('open', 'open-up');
         popover.style.left = '';
         popover.style.right = '';
         popover.style.top = '';
@@ -4191,9 +4214,10 @@ const FOCUS_SUPPRESSION_MS = 200;
         const popHeight = popRect.height || 320;
         const popWidth = popRect.width || 280;
 
-        // Position using fixed positioning for modal-like behavior
-        let { left } = rect;
-        let top = rect.bottom + 4; // 4px margin
+        // Position using fixed positioning for modal-like behavior.
+        // Both coordinates are assigned on every branch below, so they start unset.
+        let left;
+        let top;
         const minVerticalPadding = 8; // Minimum padding from viewport edges
 
         // Smart vertical positioning with better edge handling
@@ -4771,34 +4795,11 @@ const FOCUS_SUPPRESSION_MS = 200;
     _isValidMomentFormat(format) {
       if (!format || typeof format !== 'string') return false;
 
-      // Allowed moment tokens (extend if needed)
-      const validTokens = [
-        'D',
-        'DD',
-        'Do',
-        'M',
-        'MM',
-        'MMM',
-        'MMMM',
-        'YY',
-        'YYYY',
-        'H',
-        'HH',
-        'h',
-        'hh',
-        'm',
-        'mm',
-        's',
-        'ss',
-        'A',
-        'a',
-      ];
-
       // Extract tokens from format string
       const tokens = format.match(/[A-Za-z]+/g) || [];
 
       // Check if every token is valid
-      return tokens.every((token) => validTokens.includes(token));
+      return tokens.every((token) => VALID_MOMENT_TOKENS.has(token));
     }
 
     _selectYear(e) {
@@ -5129,8 +5130,8 @@ const FOCUS_SUPPRESSION_MS = 200;
           'MM-DD',
         ];
 
-        for (let i = 0; i < commonFormats.length; i++) {
-          momentDate = this._moment(trimmedInput, commonFormats[i], true);
+        for (const commonFormat of commonFormats) {
+          momentDate = this._moment(trimmedInput, commonFormat, true);
           if (momentDate.isValid()) {
             const date = momentDate.toDate();
             date.setHours(0, 0, 0, 0);
@@ -5163,8 +5164,7 @@ const FOCUS_SUPPRESSION_MS = 200;
       // Try multiple sources for locale detection
       const sources = [navigator.languages && navigator.languages[0], navigator.language, this._locale, 'en-US'];
 
-      for (let i = 0; i < sources.length; i++) {
-        const locale = sources[i];
+      for (const locale of sources) {
         if (locale && typeof locale === 'string') {
           return locale;
         }
@@ -5209,8 +5209,7 @@ const FOCUS_SUPPRESSION_MS = 200;
           'YYYY.MM.DD',
         ];
 
-        for (let i = 0; i < commonFormats.length; i++) {
-          const format = commonFormats[i];
+        for (const format of commonFormats) {
           const testDate = this._moment(inputString, format, true);
           if (testDate.isValid()) {
             results.parsed = true;

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -32,6 +32,35 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 // collapsing the popover during month navigation.
 const FOCUS_SUPPRESSION_MS = 200;
 
+// Formats tried, in order, when the primary (property or locale) format does not match what the
+// user typed. Hoisted to module scope so the list is not rebuilt on every keystroke; the contents
+// and their order are unchanged from the array that lived inside _parseUserInput.
+const COMMON_INPUT_FORMATS = [
+  'DD/MM/YYYY',
+  'DD-MM-YYYY',
+  'DD.MM.YYYY',
+  'DD/MM/YY',
+  'DD-MM-YY',
+  'DD.MM.YY',
+  'MM/DD/YYYY',
+  'MM-DD-YYYY',
+  'MM.DD.YYYY',
+  'MM/DD/YY',
+  'MM-DD-YY',
+  'MM.DD.YY',
+  'YYYY-MM-DD',
+  'YYYY/MM/DD',
+  'YYYY.MM.DD',
+  'DD MMM YYYY',
+  'DD MMMM YYYY',
+  'MMM DD, YYYY',
+  'MMMM DD, YYYY',
+  'DD/MM',
+  'MM/DD',
+  'DD-MM',
+  'MM-DD',
+];
+
 // Moment tokens accepted in the `format` property (extend if needed). A Set because it is
 // only ever used for membership tests; hoisted to module scope so it is built once.
 const VALID_MOMENT_TOKENS = new Set([
@@ -5112,6 +5141,56 @@ const VALID_MOMENT_TOKENS = new Set([
         .replace(/m(?![a-zA-Z])/g, 'M');
     }
 
+    /**
+     * The format to try first for user input: the explicit `format` property when it is a usable
+     * moment pattern, otherwise the active locale's short date format.
+     *
+     * Extracted from _parseUserInput (SonarCloud S3776). The side effect of flagging an unusable
+     * `format` is kept here rather than lifted out, because the original set `invalid` and
+     * `errorMessage` while still falling back to the locale format, and both halves matter.
+     *
+     * @returns {string} A moment format string.
+     */
+    _resolvePrimaryInputFormat() {
+      const localeFormat = moment.localeData().longDateFormat('L');
+      // No format, or a mixed-case one we cannot trust: use the locale format as fallback.
+      if (!this.format || this._isMixedCaseFormat(this.format)) {
+        return localeFormat;
+      }
+      const normalizedFormat = this._normalizeFormat(this.format);
+      if (this._isValidMomentFormat(normalizedFormat)) {
+        return normalizedFormat;
+      }
+      this.invalid = true;
+      this.errorMessage = `Invalid date format "${this.format}"`;
+      return localeFormat;
+    }
+
+    /**
+     * Turns a moment parse result into a start-of-day `Date`, or null when it is unusable.
+     *
+     * Extracted from _parseUserInput (SonarCloud S3776), where this block appeared four times.
+     * `requirePlausibleYear` exists because the four copies were not identical: the strict
+     * primary-format path returned whatever moment produced, while the three recovery paths also
+     * required the year to fall inside 1900-2200.
+     *
+     * @param {Object} momentDate A moment instance.
+     * @param {boolean} requirePlausibleYear Apply the 1900-2200 sanity window.
+     * @returns {?Date}
+     */
+    _momentToStartOfDay(momentDate, requirePlausibleYear) {
+      if (!momentDate.isValid()) {
+        return null;
+      }
+      const date = momentDate.toDate();
+      date.setHours(0, 0, 0, 0);
+      // Verify it's a logical date
+      if (requirePlausibleYear && (date.getFullYear() < 1900 || date.getFullYear() > 2200)) {
+        return null;
+      }
+      return date;
+    }
+
     // Professional date parser for user input with comprehensive format support
     _parseUserInput(inputString) {
       if (!inputString || typeof inputString !== 'string') return null;
@@ -5121,95 +5200,33 @@ const VALID_MOMENT_TOKENS = new Set([
 
       try {
         // Get user's locale with better fallback
-        const userLocale = this._getUserLocale();
-        moment.locale(userLocale);
+        moment.locale(this._getUserLocale());
 
-        let primaryFormat = moment.localeData().longDateFormat('L');
+        const primaryFormat = this._resolvePrimaryInputFormat();
 
-        if (this.format) {
-          // Check for mixed case format and fallback to locale format if detected
-          if (this._isMixedCaseFormat(this.format)) {
-            // Mixed format detected, use locale format as fallback
-            primaryFormat = moment.localeData().longDateFormat('L');
-          } else {
-            const normalizedFormat = this._normalizeFormat(this.format);
-
-            if (this._isValidMomentFormat(normalizedFormat)) {
-              primaryFormat = normalizedFormat;
-            } else {
-              this.invalid = true;
-              this.errorMessage = `Invalid date format "${this.format}"`;
-            }
-          }
+        // Strict parsing with primary format. The input is already in the expected shape, so it is
+        // kept verbatim rather than reformatted, and the plausible-year window is deliberately not
+        // applied here - matching the original, which only checked the year on the recovery paths.
+        const exact = this._momentToStartOfDay(this._moment(trimmedInput, primaryFormat, true), false);
+        if (exact) {
+          return { date: exact, isExactFormat: true };
         }
 
-        // Strict parsing with primary format
-        let momentDate = this._moment(trimmedInput, primaryFormat, true);
-
-        if (momentDate.isValid()) {
-          const date = momentDate.toDate();
-          date.setHours(0, 0, 0, 0);
-          return { date, isExactFormat: true };
-        }
-
-        // Lenient parsing with primary format
-        momentDate = this._moment(trimmedInput, primaryFormat, false);
-
-        if (momentDate.isValid()) {
-          const date = momentDate.toDate();
-          date.setHours(0, 0, 0, 0);
-          // Verify it's a logical date
-          if (date.getFullYear() >= 1900 && date.getFullYear() <= 2200) {
-            return { date, isExactFormat: false };
-          }
-        }
-
-        // Fallback: Try common date formats if locale parsing fails
-        const commonFormats = [
-          'DD/MM/YYYY',
-          'DD-MM-YYYY',
-          'DD.MM.YYYY',
-          'DD/MM/YY',
-          'DD-MM-YY',
-          'DD.MM.YY',
-          'MM/DD/YYYY',
-          'MM-DD-YYYY',
-          'MM.DD.YYYY',
-          'MM/DD/YY',
-          'MM-DD-YY',
-          'MM.DD.YY',
-          'YYYY-MM-DD',
-          'YYYY/MM/DD',
-          'YYYY.MM.DD',
-          'DD MMM YYYY',
-          'DD MMMM YYYY',
-          'MMM DD, YYYY',
-          'MMMM DD, YYYY',
-          'DD/MM',
-          'MM/DD',
-          'DD-MM',
-          'MM-DD',
+        /*
+         * Everything below is a recovery attempt, in the original's order: lenient parsing with the
+         * primary format, then each common format strictly, then moment's own natural-language
+         * parsing. All of them get reformatted for display, so none counts as an exact-format
+         * match, and all apply the 1900-2200 plausible-year window.
+         */
+        const attempts = [
+          () => this._moment(trimmedInput, primaryFormat, false),
+          ...COMMON_INPUT_FORMATS.map((format) => () => this._moment(trimmedInput, format, true)),
+          () => this._moment(trimmedInput),
         ];
 
-        for (const commonFormat of commonFormats) {
-          momentDate = this._moment(trimmedInput, commonFormat, true);
-          if (momentDate.isValid()) {
-            const date = momentDate.toDate();
-            date.setHours(0, 0, 0, 0);
-
-            if (date.getFullYear() >= 1900 && date.getFullYear() <= 2200) {
-              return { date, isExactFormat: false };
-            }
-          }
-        }
-
-        // Last resort: Try moment's natural language parsing
-        momentDate = this._moment(trimmedInput);
-        if (momentDate.isValid()) {
-          const date = momentDate.toDate();
-          date.setHours(0, 0, 0, 0);
-          // Verify it's a logical date
-          if (date.getFullYear() >= 1900 && date.getFullYear() <= 2200) {
+        for (const attempt of attempts) {
+          const date = this._momentToStartOfDay(attempt(), true);
+          if (date) {
             return { date, isExactFormat: false };
           }
         }

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -4888,76 +4888,111 @@ const VALID_MOMENT_TOKENS = new Set([
       }
     }
 
+    /**
+     * Moves focus `delta` options within the open year list, clamped at both ends, keeping the
+     * roving tabindex in sync and scrolling the new option into view.
+     *
+     * Hoisted verbatim out of _handleYearDropdownKeydown, where it was a local closure and the
+     * single largest contributor to that function's cognitive complexity (SonarCloud S3776). It
+     * captured nothing but `this`, so the move is mechanical.
+     *
+     * @param {number} delta Options to move by; Home/End pass a value large enough to saturate
+     *   the clamp.
+     */
+    _moveYearOptionFocus(delta) {
+      const yearOptions = this.shadowRoot.querySelector('#yearOptions');
+      if (!yearOptions || !yearOptions.classList.contains('open')) return;
+      const buttons = Array.from(yearOptions.querySelectorAll('.year-option'));
+      if (!buttons.length) return;
+      let current = buttons.findIndex((b) => b.tabIndex === 0);
+      if (current < 0) current = 0;
+      let next = current + delta;
+      if (next < 0) next = 0;
+      if (next > buttons.length - 1) next = buttons.length - 1;
+      buttons.forEach((btn, idx) => {
+        btn.tabIndex = idx === next ? 0 : -1;
+      });
+      const btn = buttons[next];
+      btn.focus();
+      if (typeof btn.scrollIntoView === 'function') {
+        btn.scrollIntoView({ block: 'nearest' });
+      }
+    }
+
+    /**
+     * Enter / Space on the year trigger: open the list when it is closed, otherwise activate the
+     * option that currently holds focus, falling back to the one carrying the roving tabindex.
+     *
+     * Extracted from _handleYearDropdownKeydown (SonarCloud S3776) unchanged.
+     */
+    _activateFocusedYearOption() {
+      if (!this._isYearDropdownOpen) {
+        this._toggleYearDropdown();
+        return;
+      }
+      // Select currently focused option
+      const active = this.shadowRoot.activeElement;
+      const focused =
+        active && active.classList.contains('year-option')
+          ? active
+          : this.shadowRoot.querySelector('#yearOptions .year-option[tabindex="0"]');
+      if (focused) {
+        focused.click();
+      }
+    }
+
     _handleYearDropdownKeydown(e) {
-      const moveWithinOptions = (delta) => {
-        const yearOptions = this.shadowRoot.querySelector('#yearOptions');
-        if (!yearOptions || !yearOptions.classList.contains('open')) return;
-        const buttons = Array.from(yearOptions.querySelectorAll('.year-option'));
-        if (!buttons.length) return;
-        let current = buttons.findIndex((b) => b.tabIndex === 0);
-        if (current < 0) current = 0;
-        let next = current + delta;
-        if (next < 0) next = 0;
-        if (next > buttons.length - 1) next = buttons.length - 1;
-        buttons.forEach((btn, idx) => {
-          btn.tabIndex = idx === next ? 0 : -1;
-        });
-        const btn = buttons[next];
-        btn.focus();
-        if (typeof btn.scrollIntoView === 'function') {
-          btn.scrollIntoView({ block: 'nearest' });
+      /*
+       * The key handling below is a reordering of an eight-branch `else if` chain (SonarCloud
+       * S3776). Reordering is safe because the branches are mutually exclusive on `e.key`, and
+       * each branch keeps its own preventDefault/stopPropagation behaviour verbatim — including
+       * Escape's conditional one and Tab's deliberate absence.
+       *
+       * Maps rather than object literals so an unrelated `e.key` such as "toString" cannot match
+       * through Object.prototype, and without needing Object.hasOwn, which is ES2022 and above
+       * this repo's runtime floor (see S6653 on ELEMENTS-2077).
+       */
+
+      // Keys that jump within the options list. Home/End saturate the clamp in
+      // _moveYearOptionFocus; PageUp/PageDown move by ten.
+      const jumpDeltas = new Map([
+        ['Home', -9999],
+        ['End', 9999],
+        ['PageUp', -10],
+        ['PageDown', 10],
+      ]);
+      // Arrow keys step by one when the list is open, and otherwise open it.
+      const stepDeltas = new Map([
+        ['ArrowDown', 1],
+        ['ArrowUp', -1],
+      ]);
+
+      if (jumpDeltas.has(e.key)) {
+        e.preventDefault();
+        e.stopPropagation();
+        this._moveYearOptionFocus(jumpDeltas.get(e.key));
+        return;
+      }
+
+      if (stepDeltas.has(e.key)) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (this._isYearDropdownOpen) {
+          this._moveYearOptionFocus(stepDeltas.get(e.key));
+        } else {
+          this._toggleYearDropdown();
         }
-      };
+        return;
+      }
 
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         e.stopPropagation();
-        if (!this._isYearDropdownOpen) {
-          this._toggleYearDropdown();
-        } else {
-          // Select currently focused option
-          // max-len: break into multiple lines
-          const focused =
-            this.shadowRoot.activeElement && this.shadowRoot.activeElement.classList.contains('year-option')
-              ? this.shadowRoot.activeElement
-              : this.shadowRoot.querySelector('#yearOptions .year-option[tabindex="0"]');
-          if (focused) {
-            focused.click();
-          }
-        }
-      } else if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        e.stopPropagation();
-        if (this._isYearDropdownOpen) {
-          moveWithinOptions(+1);
-        } else {
-          this._toggleYearDropdown();
-        }
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        e.stopPropagation();
-        if (this._isYearDropdownOpen) {
-          moveWithinOptions(-1);
-        } else {
-          this._toggleYearDropdown();
-        }
-      } else if (e.key === 'Home') {
-        e.preventDefault();
-        e.stopPropagation();
-        moveWithinOptions(-9999);
-      } else if (e.key === 'End') {
-        e.preventDefault();
-        e.stopPropagation();
-        moveWithinOptions(9999);
-      } else if (e.key === 'PageUp') {
-        e.preventDefault();
-        e.stopPropagation();
-        moveWithinOptions(-10);
-      } else if (e.key === 'PageDown') {
-        e.preventDefault();
-        e.stopPropagation();
-        moveWithinOptions(10);
-      } else if (e.key === 'Escape') {
+        this._activateFocusedYearOption();
+        return;
+      }
+
+      if (e.key === 'Escape') {
         // Only consume Escape when the year-options panel is actually open so
         // it just collapses the dropdown. Otherwise let the event bubble up so
         // the popover/document Escape handlers can close the whole calendar
@@ -4967,12 +5002,15 @@ const VALID_MOMENT_TOKENS = new Set([
           e.stopPropagation();
           this._closeYearDropdown();
         }
-      } else if (e.key === 'Tab') {
-        // Close dropdown when user tabs away
-        this._closeYearDropdown();
-        // Don't prevent default - allow normal tab navigation
+        return;
       }
-      // Tab navigation is handled by central focus management
+
+      if (e.key === 'Tab') {
+        // Close dropdown when user tabs away.
+        // Don't prevent default - allow normal tab navigation.
+        this._closeYearDropdown();
+      }
+      // Any other key: Tab navigation is handled by central focus management
     }
 
     // Helper to get focusable element by name

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -5191,6 +5191,26 @@ const VALID_MOMENT_TOKENS = new Set([
       return date;
     }
 
+    /**
+     * Tries each format in COMMON_INPUT_FORMATS strictly, in order, and returns the first that
+     * yields a plausible start-of-day date.
+     *
+     * Extracted from _parseUserInput (SonarCloud S3776) to keep the recovery chain there flat.
+     * The order is the original's, and `return` on the first hit matches its early return.
+     *
+     * @param {string} trimmedInput
+     * @returns {?Date}
+     */
+    _parseWithCommonFormats(trimmedInput) {
+      for (const format of COMMON_INPUT_FORMATS) {
+        const date = this._momentToStartOfDay(this._moment(trimmedInput, format, true), true);
+        if (date) {
+          return date;
+        }
+      }
+      return null;
+    }
+
     // Professional date parser for user input with comprehensive format support
     _parseUserInput(inputString) {
       if (!inputString || typeof inputString !== 'string') return null;
@@ -5217,18 +5237,19 @@ const VALID_MOMENT_TOKENS = new Set([
          * primary format, then each common format strictly, then moment's own natural-language
          * parsing. All of them get reformatted for display, so none counts as an exact-format
          * match, and all apply the 1900-2200 plausible-year window.
+         *
+         * `||` short-circuits, so each stage runs only if the previous one produced nothing -
+         * exactly like the original's sequential `if (...) return` blocks. Written as a chain
+         * rather than an array of thunks so that this path, which runs on every keystroke,
+         * allocates nothing per call.
          */
-        const attempts = [
-          () => this._moment(trimmedInput, primaryFormat, false),
-          ...COMMON_INPUT_FORMATS.map((format) => () => this._moment(trimmedInput, format, true)),
-          () => this._moment(trimmedInput),
-        ];
+        const recovered =
+          this._momentToStartOfDay(this._moment(trimmedInput, primaryFormat, false), true) ||
+          this._parseWithCommonFormats(trimmedInput) ||
+          this._momentToStartOfDay(this._moment(trimmedInput), true);
 
-        for (const attempt of attempts) {
-          const date = this._momentToStartOfDay(attempt(), true);
-          if (date) {
-            return { date, isExactFormat: false };
-          }
+        if (recovered) {
+          return { date: recovered, isExactFormat: false };
         }
 
         return null;

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -3251,6 +3251,28 @@ const VALID_MOMENT_TOKENS = new Set([
       }
     }
 
+    // True when `date` falls inside the month currently rendered in the grid. Extracted from
+    // _handleGridKeydown (SonarCloud S3776), where this pair of comparisons appeared seven times.
+    _isInViewedMonth(date) {
+      return date.getMonth() === this._viewDate.getMonth() && date.getFullYear() === this._viewDate.getFullYear();
+    }
+
+    /**
+     * Applies a focus move that must not cross a month boundary: the move lands only when the
+     * target day is still inside the month on screen, otherwise nothing happens.
+     *
+     * Extracted from _handleGridKeydown (SonarCloud S3776), where the six arrow/Home/End cases
+     * repeated this block verbatim.
+     *
+     * @param {Date} targetDate
+     */
+    _focusDateWithinViewedMonth(targetDate) {
+      // Only navigate within current month - don't allow month transitions
+      if (this._isInViewedMonth(targetDate)) {
+        this._focusDate(targetDate, false);
+      }
+    }
+
     _handleGridKeydown(e) {
       const currentButton = e.target;
       if (!currentButton.classList.contains('calendar-day')) return;
@@ -3258,106 +3280,48 @@ const VALID_MOMENT_TOKENS = new Set([
       const currentDate = new Date(currentButton.dataset.date);
       const targetDate = new Date(currentDate);
 
+      /*
+       * Day offsets for the keys that move focus inside the month on screen. Replaces six
+       * switch cases that differed only by this number (SonarCloud S3776) — the offsets are
+       * exactly those the cases used, and every one of them ran the same
+       * "move, then focus if still in the viewed month" block that
+       * _focusDateWithinViewedMonth now holds.
+       *
+       * Home/End are relative to the focused day's weekday, so the table is rebuilt per event
+       * rather than hoisted. A Map (not an object literal) so an unrelated `e.key` such as
+       * "toString" cannot match through Object.prototype, and without needing Object.hasOwn,
+       * which is ES2022 and above this repo's runtime floor (see S6653 on ELEMENTS-2077).
+       */
+      const dayOffsets = new Map([
+        ['ArrowLeft', -1],
+        ['ArrowRight', 1],
+        ['ArrowUp', -7],
+        ['ArrowDown', 7],
+        ['Home', -currentDate.getDay()],
+        ['End', 6 - currentDate.getDay()],
+      ]);
+
       // Stop bubbling so parent lists (e.g. iron-list in nuxeo-data-table) do not handle
       // Arrow keys / Enter and steal focus while the calendar is open (WEBUI-1986 follow-up).
+      if (dayOffsets.has(e.key)) {
+        e.preventDefault();
+        e.stopPropagation();
+        targetDate.setDate(currentDate.getDate() + dayOffsets.get(e.key));
+        this._focusDateWithinViewedMonth(targetDate);
+        return;
+      }
+
       switch (e.key) {
         case 'Enter':
         case ' ':
           e.preventDefault();
           e.stopPropagation();
-          // Allow selection of any current month date, not just non-empty
-          if (!currentButton.disabled && currentButton.classList.contains('calendar-day')) {
-            // Check if it's a valid current month date
-            const isCurrentMonth =
-              currentDate.getMonth() === this._viewDate.getMonth() &&
-              currentDate.getFullYear() === this._viewDate.getFullYear();
-            if (isCurrentMonth) {
-              this._selectDate(currentDate);
-            }
+          // Allow selection of any current month date, not just non-empty.
+          // The classList re-check the original had here is guaranteed by the guard above.
+          if (!currentButton.disabled && this._isInViewedMonth(currentDate)) {
+            this._selectDate(currentDate);
           }
           break;
-
-        case 'ArrowLeft':
-          e.preventDefault();
-          e.stopPropagation();
-          targetDate.setDate(currentDate.getDate() - 1);
-          // Only navigate within current month - don't allow month transitions
-          if (
-            targetDate.getMonth() === this._viewDate.getMonth() &&
-            targetDate.getFullYear() === this._viewDate.getFullYear()
-          ) {
-            this._focusDate(targetDate, false);
-          }
-          break;
-
-        case 'ArrowRight':
-          e.preventDefault();
-          e.stopPropagation();
-          targetDate.setDate(currentDate.getDate() + 1);
-          // Only navigate within current month - don't allow month transitions
-          if (
-            targetDate.getMonth() === this._viewDate.getMonth() &&
-            targetDate.getFullYear() === this._viewDate.getFullYear()
-          ) {
-            this._focusDate(targetDate, false);
-          }
-          break;
-
-        case 'ArrowUp':
-          e.preventDefault();
-          e.stopPropagation();
-          targetDate.setDate(currentDate.getDate() - 7);
-          // Only navigate within current month - don't allow month transitions
-          if (
-            targetDate.getMonth() === this._viewDate.getMonth() &&
-            targetDate.getFullYear() === this._viewDate.getFullYear()
-          ) {
-            this._focusDate(targetDate, false);
-          }
-          break;
-
-        case 'ArrowDown':
-          e.preventDefault();
-          e.stopPropagation();
-          targetDate.setDate(currentDate.getDate() + 7);
-          // Only navigate within current month - don't allow month transitions
-          if (
-            targetDate.getMonth() === this._viewDate.getMonth() &&
-            targetDate.getFullYear() === this._viewDate.getFullYear()
-          ) {
-            this._focusDate(targetDate, false);
-          }
-          break;
-
-        case 'Home': {
-          e.preventDefault();
-          e.stopPropagation();
-          const dayOfWeek = currentDate.getDay();
-          targetDate.setDate(currentDate.getDate() - dayOfWeek);
-          // Only navigate within current month - don't allow month transitions
-          if (
-            targetDate.getMonth() === this._viewDate.getMonth() &&
-            targetDate.getFullYear() === this._viewDate.getFullYear()
-          ) {
-            this._focusDate(targetDate, false);
-          }
-          break;
-        }
-
-        case 'End': {
-          e.preventDefault();
-          e.stopPropagation();
-          const daysToEnd = 6 - currentDate.getDay();
-          targetDate.setDate(currentDate.getDate() + daysToEnd);
-          // Only navigate within current month - don't allow month transitions
-          if (
-            targetDate.getMonth() === this._viewDate.getMonth() &&
-            targetDate.getFullYear() === this._viewDate.getFullYear()
-          ) {
-            this._focusDate(targetDate, false);
-          }
-          break;
-        }
 
         case 'PageUp':
           e.preventDefault();

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -3402,89 +3402,60 @@ const VALID_MOMENT_TOKENS = new Set([
       }, 50);
     }
 
+    /**
+     * Focuses the day button for `date`, but only when the rendered month actually has a focusable
+     * button for it.
+     *
+     * Extracted from _findAndFocusNearestValidDate (SonarCloud S3776), which repeated this block
+     * five times. The inline `${year}-${padded month}-${padded day}` construction is replaced by
+     * the existing _dateToISO helper, which builds the identical string; for an invalid date it
+     * returns '' instead of "NaN-NaN-NaN", and neither selector matches anything.
+     *
+     * @param {?Date} date Candidate date; a falsy value simply fails the attempt.
+     * @returns {boolean} True when the button was found and focused.
+     */
+    _tryFocusDayButton(date) {
+      if (!date) {
+        return false;
+      }
+      const button = this.shadowRoot.querySelector(`[data-date="${this._dateToISO(date)}"]`);
+      if (!button || button.disabled || button.classList.contains('empty')) {
+        return false;
+      }
+      this._focusedDate = new Date(date);
+      button.focus();
+      return true;
+    }
+
     _findAndFocusNearestValidDate(targetDate) {
       // Find the first valid date in the current month
       const year = this._viewDate.getFullYear();
       const month = this._viewDate.getMonth();
+      const isInViewedMonth = (date) => !!date && date.getMonth() === month && date.getFullYear() === year;
 
-      // If targetDate is provided and it's in the current month, try to use it
-      if (targetDate && targetDate.getMonth() === month && targetDate.getFullYear() === year) {
-        const targetYear = targetDate.getFullYear();
-        const targetMonth = String(targetDate.getMonth() + 1).padStart(2, '0');
-        const targetDay = String(targetDate.getDate()).padStart(2, '0');
-        const dateISO = `${targetYear}-${targetMonth}-${targetDay}`;
-
-        const button = this.shadowRoot.querySelector(`[data-date="${dateISO}"]`);
-        if (button && !button.disabled && !button.classList.contains('empty')) {
-          this._focusedDate = new Date(targetDate);
-          button.focus();
-          return;
-        }
-      }
-
-      // Try the selected date first if it's in the current month
-      if (this._selectedDate && this._selectedDate.getMonth() === month && this._selectedDate.getFullYear() === year) {
-        // Use local date formatting to avoid timezone issues
-        const selYear = this._selectedDate.getFullYear();
-        const selMonth = String(this._selectedDate.getMonth() + 1).padStart(2, '0');
-        const selDay = String(this._selectedDate.getDate()).padStart(2, '0');
-        const dateISO = `${selYear}-${selMonth}-${selDay}`;
-
-        const button = this.shadowRoot.querySelector(`[data-date="${dateISO}"]`);
-        if (button && !button.disabled && !button.classList.contains('empty')) {
-          this._focusedDate = new Date(this._selectedDate);
-          button.focus();
-          return;
-        }
-      }
-
-      // Try today if it's in the current month
-      if (this._today.getMonth() === month && this._today.getFullYear() === year) {
-        // Use local date formatting to avoid timezone issues
-        const todayYear = this._today.getFullYear();
-        const todayMonth = String(this._today.getMonth() + 1).padStart(2, '0');
-        const todayDay = String(this._today.getDate()).padStart(2, '0');
-        const dateISO = `${todayYear}-${todayMonth}-${todayDay}`;
-
-        const button = this.shadowRoot.querySelector(`[data-date="${dateISO}"]`);
-        if (button && !button.disabled && !button.classList.contains('empty')) {
-          this._focusedDate = new Date(this._today);
-          button.focus();
-          return;
-        }
-      }
-
-      // Try the first day of the month
-      const firstValidDate = new Date(year, month, 1);
-      // Use local date formatting to avoid timezone issues
-      const firstYear = firstValidDate.getFullYear();
-      const firstMonth = String(firstValidDate.getMonth() + 1).padStart(2, '0');
-      const firstDay = String(firstValidDate.getDate()).padStart(2, '0');
-      let dateISO = `${firstYear}-${firstMonth}-${firstDay}`;
-
-      let button = this.shadowRoot.querySelector(`[data-date="${dateISO}"]`);
-
-      if (button && !button.disabled && !button.classList.contains('empty')) {
-        this._focusedDate = firstValidDate;
-        button.focus();
+      /*
+       * Preference order, unchanged from the five sequential blocks this replaces: the requested
+       * target, then the current selection, then today, then the 1st of the month. The first three
+       * are tried only when they fall inside the month on screen; `some` short-circuits on the
+       * first success exactly as the original's early returns did.
+       */
+      const preferred = [
+        isInViewedMonth(targetDate) ? targetDate : null,
+        isInViewedMonth(this._selectedDate) ? this._selectedDate : null,
+        isInViewedMonth(this._today) ? this._today : null,
+        new Date(year, month, 1),
+      ];
+      if (preferred.some((date) => this._tryFocusDayButton(date))) {
         return;
       }
 
-      // Otherwise, find any valid date in the current month
+      // Otherwise, find any valid date in the current month. The 1st is retried here, which is a
+      // no-op: it has just failed above.
       for (let day = 1; day <= 31; day++) {
-        const testDate = new Date(year, month, day);
-        if (testDate.getMonth() !== month) break; // Gone past the end of the month
+        const candidate = new Date(year, month, day);
+        if (candidate.getMonth() !== month) break; // Gone past the end of the month
 
-        // Use local date formatting to avoid timezone issues
-        const testYear = testDate.getFullYear();
-        const testMonth = String(testDate.getMonth() + 1).padStart(2, '0');
-        const testDay = String(testDate.getDate()).padStart(2, '0');
-        dateISO = `${testYear}-${testMonth}-${testDay}`;
-
-        button = this.shadowRoot.querySelector(`[data-date="${dateISO}"]`);
-        if (button && !button.disabled && !button.classList.contains('empty')) {
-          this._focusedDate = testDate;
-          button.focus();
+        if (this._tryFocusDayButton(candidate)) {
           return;
         }
       }

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -4514,55 +4514,66 @@ const VALID_MOMENT_TOKENS = new Set([
       return this._getLocalizedText('required');
     }
 
+    /**
+     * Which of the `min`/`max` bounds `currentDate` violates, or null when it is in range.
+     *
+     * Extracted from _getValidity (SonarCloud S3776). Both of the original's blocks set an
+     * identical errorReason and errorMessage, so the caller does not need to know which bound it
+     * was; the min check still runs first, and each bound is still only tested when set.
+     *
+     * @param {Object} currentDate A moment instance.
+     * @returns {?string} 'min', 'max' or null.
+     */
+    _getViolatedBound(currentDate) {
+      if (this.min && currentDate.isBefore(this._moment(this._parseDateOnly(this.min)), 'day')) {
+        return 'min';
+      }
+      if (this.max && currentDate.isAfter(this._moment(this._parseDateOnly(this.max)), 'day')) {
+        return 'max';
+      }
+      return null;
+    }
+
     _getValidity() {
+      const isEmpty = !this.value || this.value.trim() === '';
+
       // Check required field first
-      if (this.required && (!this.value || this.value.trim() === '')) {
+      if (this.required && isEmpty) {
         this.errorReason = 'required';
         // Generate dynamic error message using field label
         this.errorMessage = this._generateRequiredMessage();
         return false;
       }
 
-      // If field is not required and empty, it's valid
-      if (!this.required && (!this.value || this.value.trim() === '')) {
+      // If field is not required and empty, it's valid. Reaching here already rules out
+      // `required && isEmpty`, so isEmpty on its own implies the original's `!this.required`.
+      if (isEmpty) {
         this.errorReason = '';
         this.errorMessage = '';
         return true;
       }
 
-      // If we have a value, check if it's a valid date
-      if (this.value) {
-        const currentDate = this._moment(this.value);
+      // Past the guards above, this.value is necessarily a non-blank string, so the original's
+      // `if (this.value)` wrapper could never be false here and has been dropped.
+      const currentDate = this._moment(this.value);
 
-        // Check if the date itself is valid
-        if (!currentDate.isValid()) {
-          this.errorReason = 'invalidDate';
-          this.errorMessage = this._getLocalizedText('invalidDate');
-          return false;
-        }
+      // Check if the date itself is valid
+      if (!currentDate.isValid()) {
+        this.errorReason = 'invalidDate';
+        this.errorMessage = this._getLocalizedText('invalidDate');
+        return false;
+      }
 
-        // Get current locale format for error messages
-        const userLocale = navigator.languages !== undefined ? navigator.languages[0] : navigator.language;
-        moment.locale(userLocale);
-        // Check min constraint
-        if (this.min) {
-          const minDate = this._moment(this._parseDateOnly(this.min));
-          if (currentDate.isBefore(minDate, 'day')) {
-            this.errorReason = 'outOfRange';
-            this.errorMessage = this._buildOutOfRangeMessage(currentDate.toDate());
-            return false;
-          }
-        }
+      // Get current locale format for error messages. This must stay ahead of the bound check
+      // below: _buildOutOfRangeMessage formats against moment's active locale.
+      const userLocale = navigator.languages !== undefined ? navigator.languages[0] : navigator.language;
+      moment.locale(userLocale);
 
-        // Check max constraint
-        if (this.max) {
-          const maxDate = this._moment(this._parseDateOnly(this.max));
-          if (currentDate.isAfter(maxDate, 'day')) {
-            this.errorReason = 'outOfRange';
-            this.errorMessage = this._buildOutOfRangeMessage(currentDate.toDate());
-            return false;
-          }
-        }
+      // Check min/max constraints
+      if (this._getViolatedBound(currentDate)) {
+        this.errorReason = 'outOfRange';
+        this.errorMessage = this._buildOutOfRangeMessage(currentDate.toDate());
+        return false;
       }
 
       // If we reach here, the date is valid - clear any error state

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -1761,31 +1761,42 @@ const VALID_MOMENT_TOKENS = new Set([
     }
 
     /**
+     * A `min`/`max` bound as a Date, or null when it is absent or unparseable.
+     *
+     * Collapsing "unset" and "invalid" to null is what lets callers drop the Number.isNaN guards:
+     * the original ignored an unparseable bound (its NaN comparisons were false either way), and a
+     * null bound is ignored the same way.
+     *
+     * @param {?string} value
+     * @returns {?Date}
+     */
+    _parseBoundDate(value) {
+      if (!value) {
+        return null;
+      }
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    /**
      * The 1900-2099 year span, narrowed to whatever `min`/`max` allow.
      *
-     * Extracted from _generateMonthYearOptions (SonarCloud S3776). The body is moved verbatim: an
-     * unparseable `min`/`max` is still ignored via the Number.isNaN guard rather than collapsing
-     * the range to nothing.
+     * Extracted from _generateMonthYearOptions (SonarCloud S3776).
      *
+     * @param {?Date} minDate
+     * @param {?Date} maxDate
      * @returns {{startYear: number, endYear: number}}
      */
-    _getMonthYearRange() {
+    _getMonthYearRange(minDate, maxDate) {
       let startYear = 1900;
       let endYear = 2099;
 
       // Apply min/max constraints if specified
-      if (this.min) {
-        const minDate = new Date(this.min);
-        if (!Number.isNaN(minDate.getTime())) {
-          startYear = Math.max(startYear, minDate.getFullYear());
-        }
+      if (minDate) {
+        startYear = Math.max(startYear, minDate.getFullYear());
       }
-
-      if (this.max) {
-        const maxDate = new Date(this.max);
-        if (!Number.isNaN(maxDate.getTime())) {
-          endYear = Math.min(endYear, maxDate.getFullYear());
-        }
+      if (maxDate) {
+        endYear = Math.min(endYear, maxDate.getFullYear());
       }
 
       return { startYear, endYear };
@@ -1797,31 +1808,38 @@ const VALID_MOMENT_TOKENS = new Set([
      *
      * Extracted from _generateMonthYearOptions (SonarCloud S3776). Equivalent to the two inline
      * checks it replaces: the original's `this.max && isValidMonthYear` guard only short-circuited
-     * the max test once min had already failed, which the early return here does directly. An
-     * invalid `min`/`max` yields a NaN comparison, which is false either way, so such a bound is
-     * ignored exactly as before.
+     * the max test once min had already failed, which the early return here does directly.
+     *
+     * The bounds are passed in already parsed. This runs up to 2400 times per call, and building
+     * them here meant re-parsing `min` and `max` on every one of those iterations - which the
+     * original did too, so this is a straight saving rather than a behaviour change.
      *
      * @param {number} year
      * @param {number} month Zero-based, as Date uses.
+     * @param {?Date} minDate
+     * @param {?Date} maxDate
      * @returns {boolean}
      */
-    _isMonthYearInRange(year, month) {
+    _isMonthYearInRange(year, month, minDate, maxDate) {
       // Last day of the month, i.e. day 0 of the next one.
-      if (this.min && new Date(year, month + 1, 0) < new Date(this.min)) {
+      if (minDate && new Date(year, month + 1, 0) < minDate) {
         return false;
       }
-      return !(this.max && new Date(year, month, 1) > new Date(this.max));
+      return !(maxDate && new Date(year, month, 1) > maxDate);
     }
 
     _generateMonthYearOptions() {
-      // Use 1900-2099 range but respect min/max constraints
-      const { startYear, endYear } = this._getMonthYearRange();
+      // Use 1900-2099 range but respect min/max constraints. Both bounds are parsed once here
+      // rather than inside the loop below.
+      const minDate = this._parseBoundDate(this.min);
+      const maxDate = this._parseBoundDate(this.max);
+      const { startYear, endYear } = this._getMonthYearRange(minDate, maxDate);
 
       this._monthYearOptions = [];
       for (let year = startYear; year <= endYear; year++) {
         for (let month = 0; month < 12; month++) {
           // Check if this month-year combination is within min/max range
-          if (this._isMonthYearInRange(year, month)) {
+          if (this._isMonthYearInRange(year, month, minDate, maxDate)) {
             this._monthYearOptions.push({
               label: new Intl.DateTimeFormat(this._locale, {
                 month: 'long',
@@ -4443,9 +4461,6 @@ const VALID_MOMENT_TOKENS = new Set([
     }
 
     /**
-     * Update error display in DOM
-     */
-    /**
      * What #errorText should do for the given validity: show a message, clear itself, or be left
      * exactly as it is.
      *
@@ -4476,6 +4491,11 @@ const VALID_MOMENT_TOKENS = new Set([
       return { action: 'keep' };
     }
 
+    /**
+     * Update error display in DOM, applying whatever _getErrorDisplayAction decides.
+     *
+     * @param {boolean} isValid
+     */
     _updateErrorDisplay(isValid) {
       const errorEl = this.shadowRoot.querySelector('#errorText');
       // Both of the original's branches were guarded on errorEl, so a missing element did nothing.

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -4416,37 +4416,61 @@ const VALID_MOMENT_TOKENS = new Set([
     /**
      * Update error display in DOM
      */
+    /**
+     * What #errorText should do for the given validity: show a message, clear itself, or be left
+     * exactly as it is.
+     *
+     * Extracted from _updateErrorDisplay (SonarCloud S3776). Reaching past the first check means
+     * `!isValid && this._showErrors`, which is precisely the original's outer condition, so the
+     * two message branches below are unchanged and in the same order.
+     *
+     * The 'keep' case is not an oversight. A field that is invalid and showing errors but has
+     * neither a required-field violation nor an `errorMessage` fell through both inner branches
+     * and kept whatever was already on screen. That is behaviour, and it is preserved here.
+     *
+     * @param {boolean} isValid
+     * @returns {{action: string, message: (string|undefined)}} action is 'show', 'clear' or 'keep'.
+     */
+    _getErrorDisplayAction(isValid) {
+      // Clear errors when valid OR when _showErrors is false (i.e. before the first submit)
+      if (isValid || !this._showErrors) {
+        return { action: 'clear' };
+      }
+      if (this.required && (!this.value || this.value.trim() === '')) {
+        // Use dynamic error message for required fields
+        return { action: 'show', message: this._generateRequiredMessage() };
+      }
+      if (this.errorMessage) {
+        // Use the current error message for other validation errors
+        return { action: 'show', message: this.errorMessage };
+      }
+      return { action: 'keep' };
+    }
+
     _updateErrorDisplay(isValid) {
       const errorEl = this.shadowRoot.querySelector('#errorText');
+      // Both of the original's branches were guarded on errorEl, so a missing element did nothing.
+      if (!errorEl) {
+        return;
+      }
 
-      if (!isValid && this._showErrors && errorEl) {
-        // Show error message only if _showErrors is true (after form submit)
-        if (this.required && (!this.value || this.value.trim() === '')) {
-          // Use dynamic error message for required fields
-          errorEl.textContent = this._generateRequiredMessage();
-          errorEl.hidden = false;
+      const { action, message } = this._getErrorDisplayAction(isValid);
 
-          // Ensure invalid attribute is set on host
-          if (!this.hasAttribute('invalid')) {
-            this.setAttribute('invalid', '');
-          }
-        } else if (this.errorMessage) {
-          // Use the current error message for other validation errors
-          errorEl.textContent = this.errorMessage;
-          errorEl.hidden = false;
+      if (action === 'show') {
+        errorEl.textContent = message;
+        errorEl.hidden = false;
 
-          // Ensure invalid attribute is set on host
-          if (!this.hasAttribute('invalid')) {
-            this.setAttribute('invalid', '');
-          }
+        // Ensure invalid attribute is set on host
+        if (!this.hasAttribute('invalid')) {
+          this.setAttribute('invalid', '');
         }
-      } else if ((isValid || !this._showErrors) && errorEl) {
-        // Clear errors when valid OR when _showErrors is false
+      } else if (action === 'clear') {
         errorEl.hidden = true;
         if (this.hasAttribute('invalid')) {
           this.removeAttribute('invalid');
         }
       }
+      // action === 'keep': leave the element exactly as it is.
     }
 
     /**

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -2444,62 +2444,62 @@ const VALID_MOMENT_TOKENS = new Set([
       return date.getFullYear();
     }
 
+    /**
+     * True when a document-level click originated inside this element: on the popover, the input
+     * wrapper or the field wrapper (or any descendant), anywhere along the event's composed path,
+     * or anywhere inside the shadow root.
+     *
+     * Extracted from _handleDocumentClick (SonarCloud S3776). The five checks and their order are
+     * unchanged; the sequential `if (!isInsideComponent && ...)` chain is just expressed as
+     * short-circuiting returns, which is equivalent because none of the checks has a side effect.
+     * The composed-path walk switches from `forEach` to `some` for the same reason.
+     *
+     * @param {Event} e
+     * @returns {boolean}
+     */
+    _isClickInsideComponent(e) {
+      const { target } = e;
+
+      // Elements this component owns and that a click may legitimately land on.
+      const owned = [
+        this.shadowRoot.querySelector('#calendarPopover'),
+        this.shadowRoot.querySelector('.input-wrapper'),
+        this.shadowRoot.querySelector('.field-wrapper'),
+      ];
+
+      // First to third check: the popover, the input wrapper, the field wrapper.
+      if (owned.some((node) => node && (target === node || node.contains(target)))) {
+        return true;
+      }
+
+      // Fourth check: walk the composed path, which sees through shadow boundaries that the
+      // target alone does not.
+      const path = e.composedPath ? e.composedPath() : [target];
+      if (
+        path.some((element) => element === this || (element.host && element.host === this) || owned.includes(element))
+      ) {
+        return true;
+      }
+
+      // Fifth check: anywhere inside our shadow root.
+      return !!this.shadowRoot && this.shadowRoot.contains(target);
+    }
+
     _handleDocumentClick(e) {
       if (!this._isCalendarOpen) return;
 
-      // Check if click target is within this element's shadow DOM or calendar popover
-      const { target } = e;
-      let isInsideComponent = false;
-
-      // Get all relevant elements
-      const calendarPopover = this.shadowRoot.querySelector('#calendarPopover');
-      const inputWrapper = this.shadowRoot.querySelector('.input-wrapper');
-      const fieldWrapper = this.shadowRoot.querySelector('.field-wrapper');
-
-      // First check: Is it within the calendar popover specifically?
-      if (calendarPopover && (target === calendarPopover || calendarPopover.contains(target))) {
-        isInsideComponent = true;
-      }
-
-      // Second check: Is it within the input wrapper area?
-      if (!isInsideComponent && inputWrapper && (target === inputWrapper || inputWrapper.contains(target))) {
-        isInsideComponent = true;
-      }
-
-      // Third check: Is it within the field wrapper?
-      if (!isInsideComponent && fieldWrapper && (target === fieldWrapper || fieldWrapper.contains(target))) {
-        isInsideComponent = true;
-      }
-
-      // Fourth check: Walk up the composed path to check for our component
-      if (!isInsideComponent) {
-        const path = e.composedPath ? e.composedPath() : [target];
-        path.forEach((element) => {
-          if (element === this || (element.host && element.host === this)) {
-            isInsideComponent = true;
-          }
-          // Also check specific elements
-          if (element === calendarPopover || element === inputWrapper || element === fieldWrapper) {
-            isInsideComponent = true;
-          }
-        });
-      }
-
-      // Fifth check: Is it within our shadow root?
-      if (!isInsideComponent && this.shadowRoot && this.shadowRoot.contains(target)) {
-        isInsideComponent = true;
-      }
-
       // Only close if we're absolutely sure it's outside and not during active interaction
-      if (!isInsideComponent && !this._interactingWithCalendar) {
-        this._closeCalendar();
+      if (this._isClickInsideComponent(e) || this._interactingWithCalendar) {
+        return;
+      }
 
-        // Also close year dropdown if open
-        const yearOptions = this.shadowRoot.querySelector('#yearOptions');
-        if (yearOptions) {
-          yearOptions.classList.remove('open');
-          this._isYearDropdownOpen = false;
-        }
+      this._closeCalendar();
+
+      // Also close year dropdown if open
+      const yearOptions = this.shadowRoot.querySelector('#yearOptions');
+      if (yearOptions) {
+        yearOptions.classList.remove('open');
+        this._isYearDropdownOpen = false;
       }
     }
 

--- a/ui/widgets/custom-date-picker.js
+++ b/ui/widgets/custom-date-picker.js
@@ -1731,8 +1731,16 @@ const VALID_MOMENT_TOKENS = new Set([
       }
     }
 
-    _generateMonthYearOptions() {
-      // Use 1900-2099 range but respect min/max constraints
+    /**
+     * The 1900-2099 year span, narrowed to whatever `min`/`max` allow.
+     *
+     * Extracted from _generateMonthYearOptions (SonarCloud S3776). The body is moved verbatim: an
+     * unparseable `min`/`max` is still ignored via the Number.isNaN guard rather than collapsing
+     * the range to nothing.
+     *
+     * @returns {{startYear: number, endYear: number}}
+     */
+    _getMonthYearRange() {
       let startYear = 1900;
       let endYear = 2099;
 
@@ -1751,37 +1759,45 @@ const VALID_MOMENT_TOKENS = new Set([
         }
       }
 
+      return { startYear, endYear };
+    }
+
+    /**
+     * True when any day of `year`/`month` is still selectable: the month's last day is on or after
+     * `min`, and its first day is on or before `max`.
+     *
+     * Extracted from _generateMonthYearOptions (SonarCloud S3776). Equivalent to the two inline
+     * checks it replaces: the original's `this.max && isValidMonthYear` guard only short-circuited
+     * the max test once min had already failed, which the early return here does directly. An
+     * invalid `min`/`max` yields a NaN comparison, which is false either way, so such a bound is
+     * ignored exactly as before.
+     *
+     * @param {number} year
+     * @param {number} month Zero-based, as Date uses.
+     * @returns {boolean}
+     */
+    _isMonthYearInRange(year, month) {
+      // Last day of the month, i.e. day 0 of the next one.
+      if (this.min && new Date(year, month + 1, 0) < new Date(this.min)) {
+        return false;
+      }
+      return !(this.max && new Date(year, month, 1) > new Date(this.max));
+    }
+
+    _generateMonthYearOptions() {
+      // Use 1900-2099 range but respect min/max constraints
+      const { startYear, endYear } = this._getMonthYearRange();
+
       this._monthYearOptions = [];
       for (let year = startYear; year <= endYear; year++) {
         for (let month = 0; month < 12; month++) {
-          const date = new Date(year, month, 1);
-
           // Check if this month-year combination is within min/max range
-          let isValidMonthYear = true;
-
-          if (this.min) {
-            const minDate = new Date(this.min);
-            const endOfMonth = new Date(year, month + 1, 0); // Last day of the month
-            if (endOfMonth < minDate) {
-              isValidMonthYear = false;
-            }
-          }
-
-          if (this.max && isValidMonthYear) {
-            const maxDate = new Date(this.max);
-            if (date > maxDate) {
-              isValidMonthYear = false;
-            }
-          }
-
-          if (isValidMonthYear) {
-            const label = new Intl.DateTimeFormat(this._locale, {
-              month: 'long',
-              year: 'numeric',
-            }).format(date);
-
+          if (this._isMonthYearInRange(year, month)) {
             this._monthYearOptions.push({
-              label,
+              label: new Intl.DateTimeFormat(this._locale, {
+                month: 'long',
+                year: 'numeric',
+              }).format(new Date(year, month, 1)),
               value: `${year}-${month}`,
               year,
               month,


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR grew after it was first approved.** It originally carried 23 provably-equivalent findings, and that set was approved. Eight cognitive-complexity **refactors** have since been added on top (section 4 below), which is a different kind of change from what the original review covered. GitHub dismissed the stale approval automatically. Please re-review from `995893b9`/`d289bc95` onward — the first seven commits are unchanged from the approved set.
>
> This was a deliberate call: keeping one changeset per LTS line, rather than a second pair of PRs, so QA runs one pass over the shared widget instead of two. The trade is a larger review.

## What

Clears **31 of the 36** SonarCloud findings in `ui/widgets/custom-date-picker.js` that [ELEMENTS-2077](https://hyland.atlassian.net/browse/ELEMENTS-2077) covers, in two groups:

1. **23 findings that cannot alter behaviour** — mechanical built-in swaps, two provably identical branch merges, and "handle the exception instead of discarding it". Sections 1-3.
2. **8 of the 11 `S3776` cognitive-complexity findings** — extractions of blocks that were repeated verbatim, or of self-contained computations. Section 4. Each one is argued for equivalence in its commit message and in a comment on the extracted helper.

The remaining **4 findings** (`S3776` x3, `S2004` x1) are **not** in this PR and are being marked *Won't Fix* on SonarCloud — see [Deferred](#deferred).

| Rule | Findings | Risk |
| --- | --- | --- |
| `S2486` Exception ignored | 11 (of 11) | Logging only; no fallback changed |
| `S4138` Prefer `for-of` | 3 (of 3) | Mechanical |
| `S6594` Prefer `RegExp.exec()` | 2 (of 2) | Spec-identical for non-global regexes |
| `S1854` Useless assignment | 2 (of 2) | Dead stores |
| `S1871` Duplicate branch body | 2 (of 2) | Bodies were byte-identical |
| `S7776` Array -> `Set` | 1 (of 1) | Read-only lookup table |
| `S7778` Repeated `classList.remove()` | 1 (of 1) | Mechanical |
| `S7780` Prefer `String.raw` | 1 (of 1) | Identical regex source |
| `S3776` Cognitive complexity | 8 (of 11) | Restructuring — see section 4 |
| `S2004` Nesting > 5 levels | 0 (of 1) | Deferred |
| **Total** | **31** | |

## The fix, commit by commit

### 1. Low-risk sweep — `S1854` / `S4138` / `S6594` / `S7776` / `S7778` / `S7780` (10 findings)

- **`S1854` x2, `_positionPopover`** — `let { left } = rect;` and `let top = rect.bottom + 4;` were overwritten on every path before being read. Verified by inspection: all four vertical branches assign `top`, and both the RTL and LTR branches assign `left`. Now `let left; let top;`.
- **`S4138` x3** — `_parseUserInput`, `_getUserLocale` and `_testDateParsing` iterated arrays with an index counter; now `for...of`.
- **`S6594` x2** — `_parseDateOnly` and `_parseDateFromISO` used `str.match(re)`; now `re.exec(str)`. Both regexes are non-global, for which the spec defines the two as the same operation: the same match array or `null`, and no `lastIndex` state carried between calls. The regex literals stay inline, so nothing is shared across instances.
- **`S7776`, `_isValidMomentFormat`** — the 20-entry `validTokens` array was rebuilt on every call and only ever used for `.includes()`. Now a module-scope `VALID_MOMENT_TOKENS` `Set`, built once, queried with `.has()`.
- **`S7778`, `_closeCalendar`** — two `classList.remove()` calls collapsed into `remove('open', 'open-up')`.
- **`S7780`, `_getLocalizedText`** — `` `\\{${placeholder}\\}` `` -> `` String.raw`\{${placeholder}\}` ``. Produces the identical regex source string.

### 2. `S1871` — the two duplicate branch bodies (2 findings)

Both flagged pairs were byte-identical, so `if (a) { X } else if (b) { X }` collapses to `if (a || b) { X }` with no behaviour change:

- **`_positionPopover`** — the "clamped to the left viewport edge" and "clamped to the right viewport edge" cases both centred the popover. Now one condition over two named predicates, `clampedAtLeftEdge || clampedAtRightEdge`.
- **`_handleCalendarIconKeydown`** — the `Enter`/`Space` branch and the `ArrowDown`/`F4` branch both ran `preventDefault()`, `stopPropagation()`, `_openCalendar(e, true)`. Now a single `opensCalendar` condition.

Both are user-facing paths (one keyboard-accessibility, one geometry), so both got real tests rather than being swept — see [Tests](#tests).

### 3. `S2486` — stop discarding caught errors (11 findings)

Every `catch` in this element recovers rather than rethrows, and that is deliberate: a malformed value, an unsupported format string or an unexpected locale must degrade to a sensible default instead of breaking the field. The problem was that **none of them inspected the error**, so a malformed date, an unsupported format and an unexpected locale were all indistinguishable from "no value" at runtime with nothing logged — which made a field report of *"the date picker just clears my input"* undiagnosable.

Adds `_logRecoveredError(context, error)`: one `console.warn` labelled with the call site, **de-duplicated per element instance and per site** so a persistently broken locale cannot flood the console from a path that runs once per rendered day cell. `console.warn` is the established convention in this repo (`nuxeo-i18n-behavior`, `nuxeo-uploader-behavior`, `nuxeo-user-avatar`, `nuxeo-user-group-permissions-table`) and is explicitly allowed by the `no-console` rule in `eslint.config.mjs`.

**No fallback behaviour was changed — only the logging was added.** The 14 sites:

| Site | Recovery (unchanged) |
| --- | --- |
| `_parseDateOnly` | `null` |
| `_parseDateFromISO` | `null` |
| `_parseWithFormat` | `null` |
| `_parseUserInput` | `null` |
| `pickerI18n.formatDate` | `date.toLocaleDateString()` |
| `pickerI18n.parseDate` | the current date |
| `_formatAriaDate` | `date.toDateString()` |
| `_getMonthName` | i18n month names (en) / `''` |
| `_safeSetValue` | direct assignment |
| `_getDatePlaceholder` (x3) | `en-US` / navigator locale / `'dd/mm/yyyy'` |
| `_valueChanged` | cleared selection |
| `_formatDateForDisplay` | `Intl.DateTimeFormat(navigator.language)` |

That is **14 sites for 11 findings**. The ticket listed 11; `pickerI18n.formatDate`, `_formatAriaDate` and `_getMonthName` are structurally identical siblings of listed sites, so they are fixed too rather than leaving the file with two different policies for the same situation.

One other edit in this commit: `_safeSetValue`'s unused inner `catch (fallbackError)` is renamed to `catch (_)`, the convention this repo's `no-unused-vars` config already encodes (`caughtErrorsIgnorePattern: '^_'`), so the block reads as deliberately ignored.

The comment-only `catch` blocks (`_announce`, `_setupEventListeners`, `_openCalendar`, `_closeCalendar`, `_positionPopover`, `disconnectedCallback`, `_buildOutOfRangeMessage`) are already in the form Sonar accepts and are untouched.

### 4. `S3776` — eight cognitive-complexity refactors (8 findings)

One commit per function, so a bisect lands on a single function even though they share a PR.

> [!NOTE]
> **Two corrections since this PR was first extended,** both found by re-auditing rather than by a test failure:
> 1. An earlier version of this description claimed the `_generateMonthYearOptions` split "stops rebuilding `new Date(this.min)` inside a 2400-iteration double loop". **That was wrong** — `_isMonthYearInRange` still constructs those Dates per iteration, exactly as the original did inside the same loop. The extraction is behaviour-neutral, not a performance win. The claim also appears in commit `d289bc95`/`995893b9`'s message; treat this description as the correction.
> 2. The first version of the `_parseUserInput` refactor built the recovery attempts as an **array of 25 closures per call** — a small allocation regression on a per-keystroke path, against an original that built one array of string literals. Fixed in a follow-up commit with a short-circuiting `||` chain plus `_parseWithCommonFormats`. Same order, same early-exit, no per-call allocation.

**Note on the numbers:** the complexities below are taken from SonarCloud's own branch analysis (with the line each finding is raised on, in the pre-merge file, for traceability). ELEMENTS-2077's original table listed the right *multiset* of complexities but paired several of them to the wrong function; these are the actual per-function values. **No test file is touched by any of these eight commits** — the only file that changes is the widget, which is what makes the unchanged test counts below meaningful as a regression signal rather than a tautology.

| Function | Complexity | Sonar line | Extracted | Why it is equivalent |
| --- | --- | --- | --- | --- |
| `_generateMonthYearOptions` | 27 | 1678 | `_getMonthYearRange`, `_isMonthYearInRange` | The original's `this.max && isValidMonthYear` guard only short-circuited the max test once min had failed, which the early return does directly. An invalid bound still yields a NaN comparison — false either way — so it is still ignored. |
| `_handleGridKeydown` | 27 | 3182 | `_isInViewedMonth`, `_focusDateWithinViewedMonth` | Six switch cases differed **only by a day offset** and otherwise repeated the same "move, then focus if still in month" block. Offsets move to a per-event table; `Home`/`End` are computed from the focused weekday, as before. The `classList` re-check in `Enter`/`Space` is dropped because the guard at the top of the function already makes it unconditionally true. |
| `_handleYearDropdownKeydown` | 27 | 4868 | `_moveYearOptionFocus`, `_activateFocusedYearOption` | The `moveWithinOptions` closure captured nothing but `this`, so hoisting it is mechanical. The eight-branch chain becomes two delta tables; reordering is safe because the branches are mutually exclusive on `e.key`, and each keeps its own `preventDefault`/`stopPropagation` verbatim — including `Escape`'s conditional one and `Tab`'s deliberate absence. |
| `_parseUserInput` | 27 | 5054 | `_resolvePrimaryInputFormat`, `_momentToStartOfDay` | `requirePlausibleYear` exists because the four copies of the start-of-day block were **not** identical: the strict path returned whatever moment produced, the three recovery paths also required 1900-2200. Recovery order unchanged. The 23-entry format list moves to module scope, and the recovery chain short-circuits with `||` rather than building an array of thunks, so this per-keystroke path allocates nothing per call. |
| `_findAndFocusNearestValidDate` | 23 | 3369 | `_tryFocusDayButton` | The "build ISO id, look up button, check focusable, focus" block appeared **five times verbatim**. Fallback order (target -> selection -> today -> 1st -> any) is unchanged; `some()` short-circuits exactly as the early returns did. Inline ISO construction replaced by the existing `_dateToISO`, which builds the identical string. |
| `_getValidity` | 19 | 4481 | `_getViolatedBound` | Both bounds produced an identical `errorReason`/`errorMessage`, so the caller need not know which. `moment.locale()` deliberately **stays in the caller**, ahead of the bound check, because `_buildOutOfRangeMessage` formats against moment's active locale. |
| `_handleDocumentClick` | 16 | 2374 | `_isClickInsideComponent` | Five containment checks, **none with a side effect**, so the sequential `if (!isInsideComponent && ...)` chain becomes short-circuiting returns in the same order. |
| `_updateErrorDisplay` | 16 | 4407 | `_getErrorDisplayAction` | Returns `show`/`clear`/`keep`. **The `keep` case is behaviour, not an oversight**: a field that is invalid and showing errors but has neither a required violation nor an `errorMessage` fell through both inner branches and kept whatever was on screen. Preserved explicitly. |

Two redundancies were removed along the way, both provably unreachable rather than judgement calls:

- `_getValidity`'s second guard tested `!this.required && isEmpty`; reaching it already rules out `required && isEmpty`, so `isEmpty` alone is equivalent.
- `_getValidity`'s `if (this.value)` wrapper could never be false at that point, because a blank value has already returned above.

**On `Object.hasOwn`:** the key-dispatch tables in `_handleGridKeydown` and `_handleYearDropdownKeydown` are `Map`s, not object literals. This keeps an unrelated `e.key` such as `"toString"` from matching through `Object.prototype` **without** reaching for `Object.hasOwn`, which is ES2022 and above this repo's runtime floor — the same reason `S6653` stays deferred below. Using it here would have contradicted that decision.

## Tests

**49 new characterisation tests, proven equivalent across the refactor.**

The eight refactor commits touch no test file, so the suite was byte-identical before and after them (**3915** on `lts-2025`, **3916** on `maintenance-3.1.x`). That is a clean signal, but it was also a weak one: several of the refactored branches had **no test exercising them at all** — most starkly the year-dropdown focus movement, where only **2 of 15 lines** ran.

A final commit adds 49 tests to close that gap. Every one drives a **pre-existing entry point** (`_handleGridKeydown`, `_handleYearDropdownKeydown`, `_updateErrorDisplay`, `_parseUserInput`, `_handleDocumentClick`) rather than a newly extracted helper, so the file runs unchanged against both this branch and the commit before the refactor. **Verified green on both: 3964 either way** — which makes them equivalence evidence, not just a snapshot of current behaviour.

Coverage of the extracted helpers, before and after those tests:

| Helper | Before | After |
| --- | --- | --- |
| `_moveYearOptionFocus` | 2/15 | **15/15** |
| `_activateFocusedYearOption` | 3/7 | **7/7** |
| `_resolvePrimaryInputFormat` | 6/9 | **9/9** |
| `_momentToStartOfDay` | 6/7 | **7/7** |
| `_getErrorDisplayAction` | 6/7 | **7/7** |
| `_isClickInsideComponent` | 8/9 | **9/9** |
| `_focusDateWithinViewedMonth` | 1/2 | **2/2** |

File branch coverage **77.5% → 80.8%** across the whole change (the ticket asks only for no drop).

**Writing them against the unrefactored code first caught three wrong expectations — all about the ORIGINAL, none a refactor bug:**

1. An empty required field does **not** un-hide the error row unless `errorMessage` is already set: `setAttribute('invalid')` fires `_invalidChanged`, which recomputes `hidden` from `errorMessage`. The real flow sets it in `_getValidity` first.
2. With a non-numeric primary format, moment's lenient pass turns `'1850-12-04'` into **2050-01-17**, so it never reaches the year window at all. (Pre-existing, unchanged by this PR, but arguably worth its own ticket.)
3. With `format="YYYY-MM-DD"` the strict path accepts 1850 and 2500 outright — confirming the asymmetry that `_momentToStartOfDay`'s `requirePlausibleYear` parameter encodes.

Each of the eight intermediate commits was also syntax-checked independently, so `git bisect` over this range will not land on a broken tree.

For the 23 findings in sections 1-3: **736 -> 769 (+33), all passing.** No test was changed or removed.

- **16 recovery-path tests** — one per changed `S2486` site: force the throw, assert the documented fallback is still exactly what comes out, and assert the cause is surfaced with its call-site label. Plus the dedupe behaviour (once per site; again on a fresh element).
- **1 log-noise guard** — the flip side of adding logging: an ordinary interaction (set value -> open -> select -> close -> retype -> validate) must log **nothing**. This is what stops the new `console.warn` calls turning into noise on every keystroke.
- **10 `_handleCalendarIconKeydown` a11y tests** — each of `Enter` / `Space` / `ArrowDown` / `F4` still opens the calendar *and* swallows the event (so the keystroke cannot also scroll the page or reach a parent `iron-list` / dialog handler), and `Escape` / `Tab` / `ArrowUp` / `ArrowLeft` / `F2` / `a` still leave both the calendar and the event untouched.
- **5 `_positionPopover` geometry tests** with stubbed trigger/popover rects, pinning the computed `left`/`top`: trigger inside the viewport, clamped-and-centred at the left edge, clamped-and-centred at the right edge, RTL right-alignment, and flip-above-the-trigger. The centring tests assert the centred value is actually reachable in the runner viewport *first*, so a narrow viewport fails loudly instead of making them vacuous.

These `catch` arms were the file's least-covered branches, which is exactly what made branch coverage (75.9%) the weak spot the ticket flags.

## Verification

Run locally on both branches — the diff is byte-identical on `maintenance-3.1.x` and `lts-2025`:

| Check | Result |
| --- | --- |
| `ui` suite, `lts-2025` (before -> after refactor) | **3915 -> 3915 passed, 0 failed** |
| New tests on pre-refactor vs refactored code | **3964 -> 3964 passed, 0 failed** (identical) |
| `ui` suite with new tests, `maintenance-3.1.x` | **3965 passed, 0 failed** |
| File branch coverage | **77.5% -> 80.8%** |
| `ui/test/custom-date-picker.test.js` (sections 1-3) | **769 passed, 0 failed** |
| `npm run lint` | **exit 0** (0 errors, 20 pre-existing warnings elsewhere) |
| `npx eslint .` | clean |
| `npx prettier "**/*.{js,html}" --list-different` | clean |
| `npx polymer lint -i ui/widgets/custom-date-picker.js` | clean |

Note `ui/widgets/custom-date-picker.js` is in the global `ignores` of `eslint.config.mjs`, so ESLint is not a safety net on this file; Prettier and `polymer lint` do cover it. (Whether that exclusion should be lifted now that the file has real coverage is worth a follow-up — the file is first-party, added by ELEMENTS-1831, not vendored.)

## Deferred

Three items are deliberately **out** of this PR:

1. **`S3776` x3 + `S2004` x1 (4 findings) — being marked *Won't Fix* on SonarCloud**, tracked on [ELEMENTS-2081](https://hyland.atlassian.net/browse/ELEMENTS-2081). These are the three functions where no extraction is provably equivalent, each for a specific reason:

   - **`_positionPopover` (26)** — the tempting move is to collapse the RTL and LTR clamping into one `clamp()` helper. **It is not equivalent.** When the viewport is narrower than the popover plus padding, `maxLeft < minLeft`, and for `preferredLeft > maxLeft` the current RTL branch yields `maxLeft` while `Math.max(minLeft, Math.min(maxLeft, preferredLeft))` yields `minLeft`. A single clamp silently changes RTL placement on narrow viewports.
   - **`_openCalendar` (23) and its `S2004`** — 165 lines of *ordered* side effects: DOM class toggles, `showPopover()`, four window listeners, a 200 ms flag clear, and a 150 ms deferral wrapping a three-deep `requestAnimationFrame` chain that swaps `tabindex` on five elements and restores them in the innermost callback. The rAF nesting *is* the `S2004`. Focus timing and tabindex-restore ordering are precisely what unit tests do not catch.
   - **`_valueChanged` (22)** — a Polymer observer guarded by the `_preventInputUpdate` re-entrancy flag, which is set near the top and must be cleared on *every* exit path including the `catch`. Any extraction risks changing when it clears, which surfaces as "the input clears itself while typing" — the exact class of bug the `_userIsTyping`/`_errorPersists` flags exist to prevent.
2. **`S6653` (1 finding) — `Object.hasOwn` in `_safeSetValue`.** `Object.hasOwn` is ES2022 (Chrome/Edge 93+, Firefox 92+, Safari 15.4+). This repo declares no `browserslist` and has no Babel or core-js configuration, and nuxeo-web-ui ships untranspiled ES2020 syntax (optional chaining, nullish coalescing), which puts the actual runtime floor at roughly Chrome 80 / Safari 13.4 — below what `Object.hasOwn` requires. Left open pending a decision on the supported browser matrix, which the ticket explicitly allows.

## Note for the reviewer

[#1635](https://github.com/nuxeo/nuxeo-elements/pull/1635) / [#1636](https://github.com/nuxeo/nuxeo-elements/pull/1636) (ELEMENTS-2050) also touch this file and are still open. This PR is based on the release branch rather than on them, so it can land independently. Expect a small conflict in exactly two places if 2050 lands first, both trivial:

- `_parseDateOnly` — 2050 changes the `parseInt` calls on the lines below; this PR changes the `.match()` -> `.exec()` line above them.
- `_parseDateFromISO` — same shape.

Nothing else overlaps.

---

Companion PR for `maintenance-3.1.x`: #1664 (byte-identical diff).

