### PR TITLE
task: Document avoiding optional chaining for Polymer analyzer [lts-2025]

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,7 @@ test/                → Shared test setup
 - **ESLint**: Flat config (`eslint.config.mjs`), `eslint-plugin-html` for `.html` files
 - **Max line length**: 120 characters
 - **`Nuxeo` global**: Declared as `writable` in ESLint
+- **No optional chaining (`?.`)** in `core/`, `ui/`, or `dataviz/` source — Polymer lint/analyze cannot parse it and elements go missing from `analysis.json`. Use `(obj && obj.prop)` or similar explicit guards instead.
 - Always run `npm run format` before committing
 
 ### Naming

--- a/.github/instructions/core.instructions.md
+++ b/.github/instructions/core.instructions.md
@@ -40,6 +40,10 @@ Do NOT use the legacy `Polymer({…})` factory for core elements.
 - Elements: `nuxeo-<name>` (kebab-case)
 - All elements register on the `Nuxeo` global namespace
 
+## Style
+
+- Do not use optional chaining (`?.`) — Polymer lint/analyze predates it and drops elements from `analysis.json`. Use explicit `&&` guards instead.
+
 ## Testing
 
 - Test files: `core/test/nuxeo-<element-name>.test.js`

--- a/.github/instructions/dataviz.instructions.md
+++ b/.github/instructions/dataviz.instructions.md
@@ -21,6 +21,10 @@ Dataviz elements use the `AggregateDataBehavior` for shared query logic:
 - Depends on `@nuxeo/nuxeo-elements` (core) for server communication
 - Uses `@nuxeo/moment` for date handling
 
+## Style
+
+- Do not use optional chaining (`?.`) — Polymer lint/analyze predates it and drops elements from `analysis.json`. Use explicit `&&` guards instead.
+
 ## Testing
 
 - Test files: `dataviz/test/nuxeo-<element-name>.test.js`

--- a/.github/instructions/ui.instructions.md
+++ b/.github/instructions/ui.instructions.md
@@ -37,6 +37,7 @@ Shared logic uses Polymer behaviors (not mixins):
 
 - Prettier: 120 chars, `arrowParens: 'always'`
 - `Nuxeo` is a writable global
+- Do not use optional chaining (`?.`) — Polymer lint/analyze predates it and drops elements from `analysis.json`. Use explicit `&&` guards instead.
 
 ## Vendored Code
 

--- a/.github/skills/write-unit-test/SKILL.md
+++ b/.github/skills/write-unit-test/SKILL.md
@@ -18,6 +18,10 @@ Generate unit test files for Nuxeo Elements Polymer components using @web/test-r
 3. Generate the test file following the patterns below
 4. Run `npm test` to verify (or `npm run test:core`, `npm run test:ui`, `npm run test:dataviz`)
 
+## Coding constraint (element source, not tests)
+
+When fixing or extending element source under `core/`, `ui/`, or `dataviz/`, **do not use optional chaining (`?.`)**. Polymer lint/analyze cannot parse it and elements disappear from `analysis.json`. Prefer explicit guards — e.g. `(obj && obj.prop)` or `(template && template._templateInfo) || {}`.
+
 > The test runner loads one generated barrel per package (`<package>/test/load-all-tests.js`).
 > After creating a new test file, run `npm run update-test-load-all` (or `npm test`, which
 > regenerates it automatically) so the new suite is picked up.

--- a/.github/skills/write-unit-test/SKILL.md
+++ b/.github/skills/write-unit-test/SKILL.md
@@ -20,7 +20,9 @@ Generate unit test files for Nuxeo Elements Polymer components using @web/test-r
 
 ## Coding constraint (element source, not tests)
 
-When fixing or extending element source under `core/`, `ui/`, or `dataviz/`, **do not use optional chaining (`?.`)**. Polymer lint/analyze cannot parse it and elements disappear from `analysis.json`. Prefer explicit guards — e.g. `(obj && obj.prop)` or `(template && template._templateInfo) || {}`.
+When fixing or extending element source under `core/`, `ui/`, or `dataviz/`, **do not use optional
+chaining (`?.`)**. Polymer lint/analyze cannot parse it and elements disappear from `analysis.json`.
+Prefer explicit guards — e.g. `(obj && obj.prop)` or `(template && template._templateInfo) || {}`.
 
 > The test runner loads one generated barrel per package (`<package>/test/load-all-tests.js`).
 > After creating a new test file, run `npm run update-test-load-all` (or `npm test`, which

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ Always use Nuxeo Elements for API calls, never `fetch()`:
 - ESLint: flat config in `eslint.config.mjs`
 - Max line length: 120 characters
 - `Nuxeo` global is `writable`
+- **Do not use optional chaining (`?.`)** in `core/`, `ui/`, or `dataviz/` source files. The Polymer linter/analyzer (`polymer lint`, `polymer analyze`) uses a parser that predates `?.`; it fails to parse the file or drops elements from `analysis.json` (consumed by Storybook and other tooling). Use explicit guards instead — e.g. `(obj && obj.prop)` or `(template && template._templateInfo) || {}`. Vendored code (`ui/viewers/pdfjs/`, `ui/js-interpreter/`) is exempt — do not modify it.
 
 ## Testing
 
@@ -134,6 +135,7 @@ PRs run lint and test workflows automatically.
 ## Common Pitfalls
 
 - This is a **library** repo — there is no bundler or dev server. Components are consumed via npm by `nuxeo-web-ui`.
+- **Do not use optional chaining (`?.`)** in element source — see Style Rules above. Polymer analyze feeds `analysis.json`; `?.` causes elements to go missing from that output.
 - Always commit `package-lock.json` changes when dependencies change. CI relies on it for `npm ci`.
 - `@nuxeo` npm packages come from `https://packages.nuxeo.com/repository/npm-public/`, not npmjs.org.
 - The `ui/` package has its own `eslint.config.mjs` in addition to the root config.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,11 @@ Always use Nuxeo Elements for API calls, never `fetch()`:
 - ESLint: flat config in `eslint.config.mjs`
 - Max line length: 120 characters
 - `Nuxeo` global is `writable`
-- **Do not use optional chaining (`?.`)** in `core/`, `ui/`, or `dataviz/` source files. The Polymer linter/analyzer (`polymer lint`, `polymer analyze`) uses a parser that predates `?.`; it fails to parse the file or drops elements from `analysis.json` (consumed by Storybook and other tooling). Use explicit guards instead — e.g. `(obj && obj.prop)` or `(template && template._templateInfo) || {}`. Vendored code (`ui/viewers/pdfjs/`, `ui/js-interpreter/`) is exempt — do not modify it.
+- **Do not use optional chaining (`?.`)** in `core/`, `ui/`, or `dataviz/` source files. The Polymer
+  linter/analyzer (`polymer lint`, `polymer analyze`) uses a parser that predates `?.`; it fails to
+  parse the file or drops elements from `analysis.json` (consumed by Storybook and other tooling). Use
+  explicit guards instead — e.g. `(obj && obj.prop)` or `(template && template._templateInfo) || {}`.
+  Vendored code (`ui/viewers/pdfjs/`, `ui/js-interpreter/`) is exempt — do not modify it.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Document that optional chaining (`?.`) must not be used in `core/`, `ui/`, or `dataviz/` source because Polymer lint/analyze predates it and drops elements from `analysis.json`.
- Update `AGENTS.md`, Copilot instructions, scoped package instructions (`core`, `ui`, `dataviz`), and the `write-unit-test` skill to steer AI assistants toward explicit `&&` guards instead.

## Test plan
- [x] Documentation-only change — no runtime code modified
- [ ] Review updated guidance in `AGENTS.md` and `.github/copilot-instructions.md`

Made with [Cursor](https://cursor.com)