### PR TITLE
ELEMENTS-2078: use for-of instead of indexed for loops over iterables [lts-2025]

### DIFF
--- a/core/nuxeo-page-provider.js
+++ b/core/nuxeo-page-provider.js
@@ -453,9 +453,9 @@ import config from './config.js';
       // Append quick filters if any
       if (this.quickFilters) {
         const retainedFilters = [];
-        for (let i = 0; i < this.quickFilters.length; i++) {
-          if (this.quickFilters[i].active === true) {
-            retainedFilters.push(this.quickFilters[i].name);
+        for (const quickFilter of this.quickFilters) {
+          if (quickFilter.active === true) {
+            retainedFilters.push(quickFilter.name);
           }
         }
         params.quickFilters = retainedFilters.join(',');

--- a/ui/actions/nuxeo-move-documents-down-button.js
+++ b/ui/actions/nuxeo-move-documents-down-button.js
@@ -117,9 +117,9 @@ import '../nuxeo-button-styles.js';
       this.$.moveDownOp
         .execute()
         .then(() => {
-          for (let i = 0; i < this._sortedDocuments.length; i++) {
-            this.documents.splice(this.documents.indexOf(this._sortedDocuments[i]), 1);
-            this.documents.splice(this._focusIndex, 0, this._sortedDocuments[i]);
+          for (const sortedDocument of this._sortedDocuments) {
+            this.documents.splice(this.documents.indexOf(sortedDocument), 1);
+            this.documents.splice(this._focusIndex, 0, sortedDocument);
           }
           this._sortedDocuments = [];
           this.dispatchEvent(

--- a/ui/dataviz/nuxeo-document-distribution-chart.js
+++ b/ui/dataviz/nuxeo-document-distribution-chart.js
@@ -533,8 +533,8 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
         if (bucket.children.length === 0) {
           return;
         }
-        for (let j = 0; j < bucket.children.length; j++) {
-          this._transformSubBuckets(bucket.children[j]);
+        for (const child of bucket.children) {
+          this._transformSubBuckets(child);
         }
       }
     }
@@ -547,8 +547,8 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
       delete aggregations.buckets;
       delete aggregations.doc_count_error_upper_bound;
       delete aggregations.sum_other_doc_count;
-      for (let i = 0; i < aggregations.children.length; i++) {
-        this._transformSubBuckets(aggregations.children[i]);
+      for (const child of aggregations.children) {
+        this._transformSubBuckets(child);
       }
 
       this._chartData = aggregations;

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1732,8 +1732,7 @@ import '../nuxeo-button-styles.js';
       const { column } = this._resizing;
 
       const cells = this._getHeaderCells();
-      for (let i = 0; i < cells.length; i++) {
-        const cell = cells[i];
+      for (const cell of cells) {
         if (cell.column === column) {
           cell.classList.remove('resizing');
           cell.style.cursor = '';
@@ -1961,8 +1960,8 @@ import '../nuxeo-button-styles.js';
 
     _clearDropIndicators() {
       const cells = this._getHeaderCells();
-      for (let i = 0; i < cells.length; i++) {
-        cells[i].classList.remove('drop-left', 'drop-right');
+      for (const cell of cells) {
+        cell.classList.remove('drop-left', 'drop-right');
       }
     }
 
@@ -1978,9 +1977,9 @@ import '../nuxeo-button-styles.js';
       this._clearDropIndicators();
 
       const cells = this._getHeaderCells();
-      for (let i = 0; i < cells.length; i++) {
-        if (cells[i].column === column) {
-          cells[i].classList.add('drop-right');
+      for (const cell of cells) {
+        if (cell.column === column) {
+          cell.classList.add('drop-right');
           break;
         }
       }

--- a/ui/nuxeo-document-preview.js
+++ b/ui/nuxeo-document-preview.js
@@ -274,8 +274,7 @@ import './marked-element.js';
         return;
       }
 
-      for (let i = 0; i < previewers.length; i++) {
-        const previewer = previewers[i];
+      for (const previewer of previewers) {
         const mimetype = previewer.getAttribute('mime-pattern');
         const hasMimetype =
           mimetype &&

--- a/ui/nuxeo-filter.js
+++ b/ui/nuxeo-filter.js
@@ -227,8 +227,8 @@ import Interpreter from './js-interpreter/interpreter.js';
 
           // pass if any check returns true, basically Array.some()
           let pass = false;
-          for (let i = 0; i < values.length; i++) {
-            pass = fn.apply(this, args.concat(values[i]));
+          for (const value of values) {
+            pass = fn.apply(this, args.concat(value));
             if (pass) {
               break;
             }

--- a/ui/nuxeo-layout.js
+++ b/ui/nuxeo-layout.js
@@ -139,8 +139,7 @@ import './nuxeo-error.js';
     _getValidatableElements(parent) {
       const nodes = dom(parent).querySelectorAll('*');
       const submittable = [];
-      for (let i = 0; i < nodes.length; i++) {
-        const node = nodes[i];
+      for (const node of nodes) {
         if (!node.disabled && this._isVisible(node)) {
           if (node.validate || node.checkValidity) {
             submittable.push(node);

--- a/ui/nuxeo-tree/nuxeo-tree-node.js
+++ b/ui/nuxeo-tree/nuxeo-tree-node.js
@@ -225,13 +225,13 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
           }
 
           const items = this._children || [];
-          for (let i = 0; i < items.length; i++) {
+          for (const item of items) {
             const el = document.createElement('nuxeo-tree-node');
             el.controller = this.controller;
             el.template = this.template;
             el.nodeKey = this.nodeKey;
             el.dataHost = this._instance._rootDataHost;
-            el.data = items[i];
+            el.data = item;
             children.appendChild(el);
           }
           if (this.isNextAvailable) {
@@ -282,14 +282,14 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
       const selectElts = dom(this)
         .querySelector('#content')
         .querySelectorAll('[select]');
-      for (let i = 0; i < selectElts.length; i++) {
-        this.listen(selectElts[i], 'click', '_selectNode');
+      for (const selectElt of selectElts) {
+        this.listen(selectElt, 'click', '_selectNode');
       }
       const toggleEls = dom(this)
         .querySelector('#content')
         .querySelectorAll('[toggle]');
-      for (let i = 0; i < toggleEls.length; i++) {
-        this.listen(toggleEls[i], 'click', 'toggle');
+      for (const toggleEl of toggleEls) {
+        this.listen(toggleEl, 'click', 'toggle');
       }
     }
 
@@ -306,8 +306,8 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
       const { children } = this._instance;
       if (children && children.length) {
         const parent = dom(dom(children[0]).parentNode);
-        for (let i = 0; i < children.length; i++) {
-          parent.removeChild(children[i]);
+        for (const child of children) {
+          parent.removeChild(child);
         }
       }
       this._instance = null;

--- a/ui/nuxeo-user-group-management/nuxeo-create-group.js
+++ b/ui/nuxeo-user-group-management/nuxeo-create-group.js
@@ -316,8 +316,8 @@ import '../nuxeo-button-styles.js';
     }
 
     _resultsFilter(entry) {
-      for (let i = 0; i < this.selectedUsers.length; i++) {
-        if (entry.id === this.selectedUsers[i].id) {
+      for (const selectedUser of this.selectedUsers) {
+        if (entry.id === selectedUser.id) {
           return false;
         }
       }

--- a/ui/nuxeo-user-group-management/nuxeo-user-group-latest.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-group-latest.js
@@ -384,8 +384,7 @@ import '../nuxeo-sort-styles.js';
         return;
       }
       this._sortedLatest = entries.slice().sort((a, b) => {
-        for (let i = 0; i < cols.length; i++) {
-          const { path, direction } = cols[i];
+        for (const { path, direction } of cols) {
           const valA = this._getLatestSortValue(a, path);
           const valB = this._getLatestSortValue(b, path);
           const cmp = valA.localeCompare(valB, undefined, { sensitivity: 'base' });

--- a/ui/nuxeo-user-group-management/nuxeo-user-management.js
+++ b/ui/nuxeo-user-group-management/nuxeo-user-management.js
@@ -755,8 +755,8 @@ import '../nuxeo-button-styles.js';
     }
 
     _resultsFilter(entry) {
-      for (let i = 0; i < this.groups.length; i++) {
-        if (entry.id === this.groups[i].name) {
+      for (const group of this.groups) {
+        if (entry.id === group.name) {
           return false;
         }
       }

--- a/ui/test/nuxeo-document-distribution-chart.test.js
+++ b/ui/test/nuxeo-document-distribution-chart.test.js
@@ -192,11 +192,9 @@ suite.skip('nuxeo-document-distribution-chart', () => {
 suite('nuxeo-document-distribution-chart data transformation', () => {
   let chart;
 
-  setup(async () => {
-    chart = await fixture(html`
-      <nuxeo-document-distribution-chart index="nuxeo" path="/default-domain" chart-hue="blue" chart-luminosity="light">
-      </nuxeo-document-distribution-chart>
-    `);
+  setup(() => {
+    // Instantiate without fixture so ready() -> execute() does not fire a real request.
+    chart = document.createElement('nuxeo-document-distribution-chart');
   });
 
   test('_transformSubBuckets renames key to name and doc_count to size in count mode', () => {

--- a/ui/test/nuxeo-document-distribution-chart.test.js
+++ b/ui/test/nuxeo-document-distribution-chart.test.js
@@ -185,3 +185,83 @@ suite.skip('nuxeo-document-distribution-chart', () => {
     assert.equal(5, dom(distribution.root).querySelectorAll('path').length);
   });
 });
+
+// The suite above has been skipped since ELEMENTS-908 (the move to karma/open-wc) because its
+// assertions depend on a full d3 render. `_transformSubBuckets` is a pure data transform, so it can
+// be covered directly without rendering the sunburst or standing up a server.
+suite('nuxeo-document-distribution-chart data transformation', () => {
+  let chart;
+
+  setup(async () => {
+    chart = await fixture(html`
+      <nuxeo-document-distribution-chart index="nuxeo" path="/default-domain" chart-hue="blue" chart-luminosity="light">
+      </nuxeo-document-distribution-chart>
+    `);
+  });
+
+  test('_transformSubBuckets renames key to name and doc_count to size in count mode', () => {
+    chart.mode = 'count';
+    const bucket = { key: 'workspaces', doc_count: 62, size: { value: 28650901 } };
+
+    chart._transformSubBuckets(bucket);
+
+    expect(bucket.name).to.equal('workspaces');
+    expect(bucket.size).to.equal(62);
+    expect(bucket).to.not.have.property('key');
+    expect(bucket).to.not.have.property('doc_count');
+  });
+
+  test('_transformSubBuckets uses the size value in size mode', () => {
+    chart.mode = 'size';
+    const bucket = { key: 'workspaces', doc_count: 62, size: { value: 28650901 } };
+
+    chart._transformSubBuckets(bucket);
+
+    expect(bucket.size).to.equal(28650901);
+  });
+
+  test('_transformSubBuckets recurses into subLevel buckets, transforming every descendant', () => {
+    chart.mode = 'count';
+    const bucket = {
+      key: 'workspaces',
+      doc_count: 62,
+      subLevel: {
+        buckets: [
+          { key: 'Media', doc_count: 35 },
+          {
+            key: 'Deep',
+            doc_count: 19,
+            subLevel: { buckets: [{ key: 'Nested', doc_count: 4 }] },
+          },
+        ],
+      },
+    };
+
+    chart._transformSubBuckets(bucket);
+
+    // subLevel is promoted to children at every level
+    expect(bucket).to.not.have.property('subLevel');
+    expect(bucket.children).to.have.lengthOf(2);
+
+    // each child was transformed by the recursive call
+    expect(bucket.children[0].name).to.equal('Media');
+    expect(bucket.children[0].size).to.equal(35);
+    expect(bucket.children[1].name).to.equal('Deep');
+    expect(bucket.children[1].size).to.equal(19);
+
+    // and the recursion reaches grandchildren
+    expect(bucket.children[1].children).to.have.lengthOf(1);
+    expect(bucket.children[1].children[0].name).to.equal('Nested');
+    expect(bucket.children[1].children[0].size).to.equal(4);
+  });
+
+  test('_transformSubBuckets stops at an empty subLevel without adding children entries', () => {
+    chart.mode = 'count';
+    const bucket = { key: 'sections', doc_count: 1, subLevel: { buckets: [] } };
+
+    chart._transformSubBuckets(bucket);
+
+    expect(bucket.children).to.deep.equal([]);
+    expect(bucket.name).to.equal('sections');
+  });
+});

--- a/ui/test/nuxeo-tree-node.test.js
+++ b/ui/test/nuxeo-tree-node.test.js
@@ -131,5 +131,70 @@ suite('nuxeo-tree-node', () => {
       const result = await node.open();
       expect(result).to.be.undefined;
     });
+
+    test('changing data tears down every node the previous template instance stamped', async () => {
+      const firstInstance = node._instance;
+      expect(firstInstance).to.not.be.undefined;
+
+      // `_instance.children` is a plain static array built by Polymer's TemplateInstanceBase (it is
+      // only cast to NodeList for the type checker), so snapshotting it here is safe -- removing
+      // the nodes from the DOM does not shrink it.
+      const stamped = Array.from(firstInstance.children);
+      expect(stamped.length, 'the template should have stamped at least one node').to.be.above(0);
+      const stampedParent = stamped[0].parentNode;
+      expect(stampedParent).to.not.be.null;
+
+      // The `_renderNodeContent(data)` observer calls `_teardownInstance()` when an instance
+      // already exists, which removes every stamped node from its parent before re-stamping.
+      node.data = { id: 'root', title: 'Root renamed' };
+      await flush();
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(node._instance, 'a fresh instance should have replaced the old one').to.not.equal(firstInstance);
+      stamped.forEach((child) => {
+        expect(stampedParent.contains(child), 'every stamped node should have been removed').to.be.false;
+      });
+    });
+  });
+
+  suite('with a toggle element in the template', () => {
+    let tree;
+    let node;
+
+    setup(async () => {
+      tree = await fixture(html`
+        <nuxeo-tree>
+          <template>
+            <span select>[[item.title]]</span>
+            <span toggle class="toggle">+</span>
+          </template>
+        </nuxeo-tree>
+      `);
+      tree.controller = {
+        getChildren: sinon.stub().callsFake((data) => {
+          if (data.id === 'root') {
+            return Promise.resolve([{ id: 'a', title: 'A' }]);
+          }
+          return Promise.resolve([]);
+        }),
+        isLeaf: (data) => data.id !== 'root',
+      };
+      tree.data = { id: 'root', title: 'Root' };
+      await flush();
+      node = tree.querySelector('nuxeo-tree-node');
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    test('clicking a [toggle] element in the stamped template toggles the node', async () => {
+      const toggle = node.querySelector('[toggle]');
+      expect(toggle, 'the template should have stamped a [toggle] element').to.not.be.null;
+
+      const before = node.opened;
+      toggle.click();
+      await flush();
+
+      // proves `_setupToggleListener` bound the click handler to the [toggle] element
+      expect(node.opened).to.equal(!before);
+    });
   });
 });

--- a/ui/test/nuxeo-uploader-behavior.test.js
+++ b/ui/test/nuxeo-uploader-behavior.test.js
@@ -283,6 +283,29 @@ suite('Nuxeo.UploaderBehavior – DefaultUploadProvider', () => {
     expect(cb).to.have.been.calledWith(sinon.match({ type: 'uploadStarted' }));
   });
 
+  // Same array-like contract as `accepts()` further down this file: `upload(files, cb)` takes the
+  // same deliberately polymorphic argument, so its indexed loop must not be narrowed to iterables
+  // either. See ELEMENTS-2078 for why the S4138 finding here is accepted rather than fixed.
+  test('upload tolerates an array-like files argument that is not iterable', async () => {
+    const cb = sinon.spy();
+    const uploader = {
+      _batchId: 'b',
+      upload: sinon.stub().resolves({ batch: { _batchId: 'b' }, blob: { fileIdx: 0 } }),
+      done: sinon.stub().resolves({ batch: { _batchId: 'b' } }),
+    };
+    connection.batchUpload.resolves(uploader);
+    const arrayLike = { 0: fakeFile(), length: 1 };
+    expect(arrayLike[Symbol.iterator], 'the fixture must not be iterable for this test to mean anything').to.be
+      .undefined;
+
+    provider.upload(arrayLike, cb);
+    await flushAll();
+    await flushAll();
+
+    expect(cb).to.have.been.calledWith(sinon.match({ type: 'uploadStarted' }));
+    expect(uploader.upload).to.have.been.calledOnce;
+  });
+
   test('upload skips uploadStarted callback when callback is not a function', async () => {
     const uploader = {
       _batchId: 'b',
@@ -490,6 +513,32 @@ suite('Nuxeo.UploaderBehavior – host integration', () => {
   test('accepts returns false when no provider instance is available', () => {
     const isolated = { _instance: null, accepts: UploaderBehavior.accepts };
     expect(isolated.accepts({ length: 0 })).to.be.false;
+  });
+
+  // `accepts()` is public surface -- the amazon-s3-online-storage addon re-exports it via
+  // `get accepts()` -- and its documented contract is `@param {Object[]} files`, discriminated
+  // from a single File by `files.length`. That makes it tolerant of anything *array-like*, not
+  // just of iterables. These two tests pin that contract down, and they are why the SonarCloud
+  // S4138 findings on this method and on `upload()` are accepted rather than fixed: rewriting
+  // either indexed loop as a bare `for-of` would throw `TypeError: files is not iterable` on the
+  // inputs below. See ELEMENTS-2078.
+  test('accepts tolerates an array-like files argument that is not iterable', async () => {
+    const el = await fixture(html`
+      <nuxeo-file></nuxeo-file>
+    `);
+    const arrayLike = { 0: fakeFile(), length: 1 };
+    expect(arrayLike[Symbol.iterator], 'the fixture must not be iterable for this test to mean anything').to.be
+      .undefined;
+    expect(el.accepts(arrayLike)).to.be.true;
+  });
+
+  test('accepts rejects a non-matching file given in an array-like argument', async () => {
+    const el = await fixture(html`
+      <nuxeo-file accept="image/"></nuxeo-file>
+    `);
+    const arrayLike = { 0: fakeFile('a.txt', 'text/plain'), length: 1 };
+    expect(arrayLike[Symbol.iterator]).to.be.undefined;
+    expect(el.accepts(arrayLike)).to.be.false;
   });
 
   test('_uploadStarted pushes a file with progress=0 / error=false / complete=false', async () => {

--- a/ui/widgets/nuxeo-directory-checkbox.js
+++ b/ui/widgets/nuxeo-directory-checkbox.js
@@ -144,8 +144,8 @@ import { DirectoryWidgetBehavior } from './nuxeo-directory-widget-behavior.js';
       if (this._entries && e.detail && e.detail.value) {
         const tmp = [];
         const tmpIds = [];
-        for (let i = 0; i < e.detail.value.length; i++) {
-          const item = this._entries[e.detail.value[i].dataIndex];
+        for (const selected of e.detail.value) {
+          const item = this._entries[selected.dataIndex];
           tmp.push(item);
           tmpIds.push(this.idFunction(item));
         }

--- a/ui/widgets/nuxeo-uploader-behavior.js
+++ b/ui/widgets/nuxeo-uploader-behavior.js
@@ -68,8 +68,10 @@ DefaultUploadProvider.prototype.upload = function(files, callback) {
       const currentUploader = this.uploader;
       const isActive = () => this.uploader === currentUploader;
       const uploadPromises = [];
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i];
+      // Normalize first: `files` is documented as `Object[]` but callers may pass anything
+      // array-like (a raw `FileList`, or `{ 0: file, length: 1 }`). Bare `for-of` would require a
+      // true iterable and silently narrow that contract.
+      for (const file of Array.from(files)) {
         const blob = new Nuxeo.Blob({ content: file });
         cb({ type: 'uploadStarted', file });
         const p = currentUploader
@@ -464,8 +466,11 @@ export const UploaderBehavior = {
       return false;
     }
     if (files.length) {
-      for (let i = 0; i < files.length; i++) {
-        if (!this._accepts(files[i])) {
+      // Normalize first, as in `upload()` above. `accepts()` is public surface -- the
+      // amazon-s3-online-storage addon re-exports it -- so keep it tolerant of any array-like
+      // input rather than narrowing it to iterables only.
+      for (const file of Array.from(files)) {
+        if (!this._accepts(file)) {
           return false;
         }
       }

--- a/ui/widgets/nuxeo-uploader-behavior.js
+++ b/ui/widgets/nuxeo-uploader-behavior.js
@@ -68,10 +68,8 @@ DefaultUploadProvider.prototype.upload = function(files, callback) {
       const currentUploader = this.uploader;
       const isActive = () => this.uploader === currentUploader;
       const uploadPromises = [];
-      // Normalize first: `files` is documented as `Object[]` but callers may pass anything
-      // array-like (a raw `FileList`, or `{ 0: file, length: 1 }`). Bare `for-of` would require a
-      // true iterable and silently narrow that contract.
-      for (const file of Array.from(files)) {
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i];
         const blob = new Nuxeo.Blob({ content: file });
         cb({ type: 'uploadStarted', file });
         const p = currentUploader
@@ -466,11 +464,8 @@ export const UploaderBehavior = {
       return false;
     }
     if (files.length) {
-      // Normalize first, as in `upload()` above. `accepts()` is public surface -- the
-      // amazon-s3-online-storage addon re-exports it -- so keep it tolerant of any array-like
-      // input rather than narrowing it to iterables only.
-      for (const file of Array.from(files)) {
-        if (!this._accepts(file)) {
+      for (let i = 0; i < files.length; i++) {
+        if (!this._accepts(files[i])) {
           return false;
         }
       }


### PR DESCRIPTION
> **Companion PR:** the same change on `maintenance-3.1.x` — #1671. The finding set is identical on both LTS lines, and the diff content is identical on the two branches.

## ELEMENTS-2078 — SonarCloud `javascript:S4138`

[ELEMENTS-2078](https://hyland.atlassian.net/browse/ELEMENTS-2078) · rule: [`for of` should be used with Iterables](https://sonarcloud.io/project/issues?id=nuxeo_nuxeo-elements&issueStatuses=OPEN%2CCONFIRMED&rules=javascript%3AS4138)

**18 of the 21 in-scope indexed `for` loops converted to `for-of`**, across 12 source files. Every one used its index for nothing but `x[i]`. The remaining 3 are deliberately left alone and accepted in SonarCloud — see below.

### Please read this first — it is deliberately `for-of` only

No loop is rewritten as `.forEach()` / `.some()` / `.find()` / `.filter()`. **Nine of these loops carry a `break` or a `return` that exits the enclosing function**, and `for-of` preserves both while a callback-based rewrite would not. `for-of` also yields `undefined` for array holes exactly as `arr[i]` does, where `.forEach()` would silently skip them. Some sites are morally `.some()` or `.find()` — `nuxeo-filter.js:230` even has the comment *"basically Array.some()"* — but that is a different change with a different risk profile.

> ⚠️ `for-of` was almost absent from production source before this (only the lint-ignored `nuxeo-selectivity.js`), so this PR introduces the idiom broadly. That is the intent of the rule, but please read it as a deliberate convention change.

### Receivers verified — S4138's only real hazard

`for-of` needs an **iterable**, whereas an indexed `for` works on anything merely **array-like**. Every receiver was checked against its source.

**Plain arrays (10):** `this.quickFilters`; `this._children || []`; `bucket.children` and `aggregations.children`; `previewers` (built with `Array.from()`); `values` (from `String#split()`); `this.selectedUsers`; `this.groups`; `cols` (destructures, so `for (const { path, direction } of cols)`); `e.detail.value` (the `selectedItems` array from `iron-selector`).

**Static NodeLists (6):** `nuxeo-tree-node.js` ×2, `iron-data-table.js` ×3, `nuxeo-layout.js` ×1 — all from `dom(...).querySelectorAll()`, which Polymer forwards straight to the native method, so all are **static** `NodeList`s. `NodeList` implements `Symbol.iterator`, so snapshot semantics are unchanged. Two of the `iron-data-table` loops `break` on a match — fine under `for-of`.

**No site mutates the collection it iterates.** On the two chart sites the body recurses via `_transformSubBuckets()`, which reassigns **the child's own** `children`; the iterated array is never structurally modified. On `nuxeo-filter.js`, `let pass` stays declared *outside* the loop — assigned every pass, breaks on the first truthy result, read after the loop.

### Two sites look unsafe on a first read and are not

**`nuxeo-tree-node.js:309`** removes nodes while iterating `children`, which normally means a live-collection bug. It is fine here: Polymer's `TemplateInstanceBase` builds `children` as a **plain static array** (`let children = []; this.children = children;`, then pushes the stamped root nodes — see `@polymer/polymer/lib/utils/templatize.js`); it is only *cast* to `NodeList` for the type checker. Removing from the DOM does not shrink it, so every node is still visited. **This is now covered by a test** rather than only asserted here.

**`nuxeo-move-documents-down-button.js:120`** calls `splice()` twice on `this.documents` while iterating `this._sortedDocuments`. Two different arrays, so the iterated one is never mutated.

### Not converted — 3 findings accepted in SonarCloud

**`nuxeo-uploader-behavior.js:71` and `:467`** — left byte-for-byte unchanged. `files` is a deliberately polymorphic argument: `accepts(files)` uses `if (files.length)` to discriminate "a list of files" from "a single `File`", and `upload(files, cb)` takes the same input, so both are contractually tolerant of any **array-like** value, not only iterables. `accepts()` is public surface — the `amazon-s3-online-storage` addon re-exports it via `get accepts()` — so a caller passing `{ 0: file, length: 1 }` works today and would throw `TypeError: files is not iterable` after a bare `for-of`.

Normalising with `Array.from(files)` first was implemented, then reverted. It was correct — `Array.from` accepts a strict superset of what an indexed loop accepts — but it was the wrong trade here: the gain is purely stylistic, this is the least-testable path in the widget set, and the snapshot is only equivalent to the live read because the loop body happens to be synchronous today. Accepting the finding is the zero-risk option, and the rule is flagging the exact property the API intends.

**`nuxeo-dialog.js:32`** — a monkey-patch of `IronOverlayManager._overlayWithBackdrop` added for ELEMENTS-884, kept byte-for-byte identical to the upstream implementation it restores so the revert of `PolymerElements/iron-overlay-behavior@ac1cb` stays diffable against upstream.

Also untouched: the **3 findings in `ui/widgets/custom-date-picker.js`**, which is in the `ignores` list of `eslint.config.mjs` and pending a separate vendored-file scope decision.

### Tests added (+9)

Sonar's new-code coverage gate flagged 7 touched lines that were *already* untested — the refactor removed no coverage (overall stayed at 80.3%, absolute uncovered lines fell 2187 → 2184), but converting a loop reclassifies its lines as "new code". Six tests cover 5 of them:

- **`nuxeo-tree-node.js:292`** — the existing fixture template has only a `[select]` element, so `toggleEls` was always empty and the loop body never ran. New suite stamps a `[toggle]` element and asserts clicking it toggles the node.
- **`nuxeo-tree-node.js:309-310`** — asserts every node the previous template instance stamped is removed when `data` changes, pinning down the static-array behaviour described above.
- **`nuxeo-document-distribution-chart.js:536-537`** — new non-skipped suite for `_transformSubBuckets`, covering the recursive descent and the empty-`children` early return. Pure data transform, so no server and no d3 render.

Three more lock down the uploader contract that justifies accepting those findings. They pass **against the original indexed loops** and **fail if either loop is ever converted** to a bare `for-of`, so the Sonar rationale is enforced by tests rather than only recorded in a comment:

- `accepts tolerates an array-like files argument that is not iterable`
- `accepts rejects a non-matching file given in an array-like argument`
- `upload tolerates an array-like files argument that is not iterable`

Each asserts `arrayLike[Symbol.iterator] === undefined` first, so the fixture cannot silently become iterable and make the test vacuous.

`_buildSunBurst:550-551` remains uncovered — it needs the full d3 render path. Separately worth noting: the pre-existing `suite('nuxeo-document-distribution-chart')` has been `suite.skip`-ped since ELEMENTS-908 and is the **only skipped suite in the repo**. Un-skipped locally as an experiment, both its tests pass under the current runner and they cover 550-551. Re-enabling it is out of scope here — flagged on the ticket as a follow-up.

### No blockers, no config change

- **ESLint permits `for-of`.** Worth stating because the historic `eslint-config-airbnb-base` banned `ForOfStatement` via `no-restricted-syntax`. The current flat config sets no such rule.
- **No browser-baseline decision needed** — `for-of` is ES2015, well inside the declared `ecmaVersion: 2020`.
- **No transpiler concern** — no Babel in the build or test pipeline, so no regenerator-runtime cost.

### Gates

| Gate | Result |
| --- | --- |
| `npm run lint` | ✅ 0 errors (20 pre-existing `wc/*` warnings, none in changed files) |
| `npm test` | ✅ all pass |
| Test count vs base | ✅ **+9**, no drop — measured on the base commit and on this branch |

### Suggested manual verification

Expand/collapse a document tree and check node selection; resize and reorder data-table columns; open the document preview for a PDF and an image; load the document-distribution chart; use a directory checkbox widget; validate a form layout with an invalid field. The upload and dialog paths are unchanged in this PR.

### Merge-order note

`iron-data-table.js`, `nuxeo-document-distribution-chart.js`, `nuxeo-create-group.js` and `nuxeo-user-management.js` also carry findings from ELEMENTS-2071 (`S7765`) and the other modern-built-ins rules, on **different lines** — coordinate merge order.

### Cross-repo follow-up

Merging here auto-publishes a `SNAPSHOT` of the workspace packages; the change reaches Web UI users only once **nuxeo-web-ui bumps its `@nuxeo/nuxeo-elements` / `@nuxeo/nuxeo-ui-elements` / `@nuxeo/nuxeo-dataviz-elements` versions**. No companion `WEBUI-` ticket needed — internal-only refactor, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
