### PR TITLE
ELEMENTS-2079: Accessibility: Empty table announces incorrect row count (reports 2 rows instead of 1 header row)[LTS-2025]

### DIFF
--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -290,10 +290,8 @@ import '../nuxeo-button-styles.js';
 
             <dom-if if="[[_isEmpty]]">
               <template>
-                <div class="emptyResult" role="rowgroup">
-                  <div role="row">
-                    <div role="cell" aria-live="polite">[[_computedEmptyLabel]]</div>
-                  </div>
+                <div class="emptyResult" role="presentation">
+                  <div role="presentation" aria-live="polite">[[_computedEmptyLabel]]</div>
                 </div>
               </template>
             </dom-if>

--- a/ui/test/nuxeo-data-table.test.js
+++ b/ui/test/nuxeo-data-table.test.js
@@ -1011,8 +1011,9 @@ suite('nuxeo-data-table', () => {
       expect(list.getAttribute('role')).to.equal('presentation');
       expect(table.shadowRoot.querySelector('#header').getAttribute('role')).to.equal('rowgroup');
       const emptyResult = table.shadowRoot.querySelector('.emptyResult');
-      expect(emptyResult.getAttribute('role')).to.equal('rowgroup');
-      expect(emptyResult.querySelector('[role="row"] [role="cell"]')).to.not.be.null;
+      expect(emptyResult.getAttribute('role')).to.equal('presentation');
+      expect(emptyResult.querySelector('[role="row"]')).to.be.null;
+      expect(emptyResult.querySelector('[aria-live="polite"]')).to.not.be.null;
     });
 
     // ELEMENTS-2005: the list wrapper lives in `iron-list`'s shadow root, so it may not be reachable yet.


### PR DESCRIPTION
https://hyland.atlassian.net/browse/ELEMENTS-2079