### PR TITLE
ELEMENTS-2084: Prefer childNode.remove() over removeChild [maintenance-3.1.x]

### DIFF
--- a/ui/dataviz/nuxeo-document-distribution-chart.js
+++ b/ui/dataviz/nuxeo-document-distribution-chart.js
@@ -569,7 +569,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
       const svg = this.$.chart.querySelector('svg');
       const textContainer = this.$.chart.querySelector('#ex');
       if (svg) {
-        svg.parentNode.removeChild(svg);
+        svg.remove();
       }
 
       vis = select(this.$.chart)
@@ -762,7 +762,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 
     _initializeBreadcrumbTrail() {
       while (this.$.sequence.firstChild) {
-        this.$.sequence.removeChild(this.$.sequence.firstChild);
+        this.$.sequence.firstChild.remove();
       }
 
       // Add the svg area.

--- a/ui/import-href.js
+++ b/ui/import-href.js
@@ -74,7 +74,7 @@ export const importHref = function(href, onload, onerror, optAsync) {
     // will be automatically created again the next time `importHref` is
     // called.
     if (link.parentNode) {
-      link.parentNode.removeChild(link);
+      link.remove();
     }
     if (onerror) {
       whenImportsReady(() => {

--- a/ui/nuxeo-document-preview.js
+++ b/ui/nuxeo-document-preview.js
@@ -261,7 +261,7 @@ import './marked-element.js';
     _updatePreview() {
       // clear current previewer
       while (this.$.preview.firstChild) {
-        this.$.preview.removeChild(this.$.preview.firstChild);
+        this.$.preview.firstChild.remove();
       }
 
       // lookup the preview according to the blob's mimetype

--- a/ui/nuxeo-draggable-list-behavior.js
+++ b/ui/nuxeo-draggable-list-behavior.js
@@ -140,7 +140,7 @@ export const DraggableListBehavior = {
       this.style.pointerEvents = '';
       bodyEl.style.cursor = '';
       if (proxy) {
-        bodyEl.removeChild(proxy);
+        proxy.remove();
         proxy = null;
       }
       // cleanup listeners

--- a/ui/nuxeo-filter.js
+++ b/ui/nuxeo-filter.js
@@ -297,11 +297,8 @@ import Interpreter from './js-interpreter/interpreter.js';
       if (this._instance) {
         const c$ = this._instance.children;
         if (c$ && c$.length) {
-          // use first child parent, for case when dom-if may have been detached
-          const parent = dom(dom(c$[0]).parentNode);
-
           for (let i = 0, n; i < c$.length && (n = c$[i]); i++) {
-            parent.removeChild(n);
+            n.remove();
           }
         }
         this._instance = null;

--- a/ui/nuxeo-slots.js
+++ b/ui/nuxeo-slots.js
@@ -196,11 +196,8 @@ window.nuxeo.slots.setSharedModel = (model) => {
       this._instances.forEach((instance) => {
         const c$ = instance.children;
         if (c$ && c$.length) {
-          // use first child parent, for case when dom-if may have been detached
-          const p = dom(dom(c$[0]).parentNode);
-
           for (let i = 0, n; i < c$.length && (n = c$[i]); i++) {
-            p.removeChild(n);
+            n.remove();
           }
         }
       });

--- a/ui/nuxeo-tree/nuxeo-tree-node.js
+++ b/ui/nuxeo-tree/nuxeo-tree-node.js
@@ -221,7 +221,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
           // clear <iron-collapse> content in case we are re-rendering
           const children = dom(this).querySelector('#children');
           while (children.lastChild) {
-            children.removeChild(children.lastChild);
+            children.lastChild.remove();
           }
 
           const items = this._children || [];
@@ -305,9 +305,8 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
     _teardownInstance() {
       const { children } = this._instance;
       if (children && children.length) {
-        const parent = dom(dom(children[0]).parentNode);
         for (let i = 0; i < children.length; i++) {
-          parent.removeChild(children[i]);
+          children[i].remove();
         }
       }
       this._instance = null;

--- a/ui/nuxeo-tree/nuxeo-tree.js
+++ b/ui/nuxeo-tree/nuxeo-tree.js
@@ -151,7 +151,7 @@ import './nuxeo-tree-node.js';
       if (this.data && this.controller) {
         const template = dom(this).querySelector('template');
         if (this._root) {
-          dom(this).removeChild(this._root);
+          this._root.remove();
         }
         this._root = document.createElement('nuxeo-tree-node');
         this._root.id = 'root';

--- a/ui/widgets/nuxeo-dialog.js
+++ b/ui/widgets/nuxeo-dialog.js
@@ -457,11 +457,8 @@ IronOverlayManager._overlayWithBackdrop = function() {
       if (this._instance) {
         const c$ = this._instance.children;
         if (c$ && c$.length) {
-          // use first child parent, for case when dom-if may have been detached
-          const parent = dom(dom(c$[0]).parentNode);
-
           for (let i = 0, n; i < c$.length && (n = c$[i]); i++) {
-            parent.removeChild(n);
+            n.remove();
           }
         }
         this._instance = null;

--- a/ui/widgets/nuxeo-operation-button.js
+++ b/ui/widgets/nuxeo-operation-button.js
@@ -361,7 +361,7 @@ import '../actions/nuxeo-action-button-styles.js';
       a.href = url;
       document.body.appendChild(a);
       a.click();
-      document.body.removeChild(a);
+      a.remove();
     }
 
     _computeTooltip(tooltip, label) {


### PR DESCRIPTION
> **Companion PR:** same change on `lts-2025` — #1674

## Problem

SonarCloud reports 12 `javascript:S7762` findings: `parentNode.removeChild(childNode)` should be `childNode.remove()`.

Jira: [ELEMENTS-2084](https://hyland.atlassian.net/browse/ELEMENTS-2084)

## Changes

All 12 sites rewritten to `remove()`, across 10 files:

| File | Sonar finding lines |
| --- | --- |
| `ui/dataviz/nuxeo-document-distribution-chart.js` | 572, 765 |
| `ui/import-href.js` | 77 |
| `ui/nuxeo-document-preview.js` | 264 |
| `ui/nuxeo-draggable-list-behavior.js` | 143 |
| `ui/nuxeo-filter.js` | 304 |
| `ui/nuxeo-slots.js` | 203 |
| `ui/nuxeo-tree/nuxeo-tree-node.js` | 224, 310 |
| `ui/nuxeo-tree/nuxeo-tree.js` | 154 |
| `ui/widgets/nuxeo-dialog.js` | 464 |
| `ui/widgets/nuxeo-operation-button.js` | 364 |

Four teardown loops (`nuxeo-filter`, `nuxeo-slots`, `nuxeo-dialog`, `nuxeo-tree-node`) also drop the `const parent = dom(dom(c$[0]).parentNode)` they used only as the removal receiver; `nuxeo-tree` drops a `dom(this)` wrapper for the same reason.

## Notes

`Element#remove()` is behaviour-equivalent to `parentNode.removeChild()` when the node has a parent. The dropped `dom()` wrappers are no-ops — ShadyDOM is not used in this repo, so `dom(x).removeChild` already resolved to the native call.

One intentional difference in the four teardown loops: the old code removed every node from a *precomputed* parent and threw `NotFoundError` if a node had since been reparented, whereas `remove()` acts on each node's own current parent and no-ops if it has none. Teardown is strictly more robust as a result.

## Test plan

- `npm run lint` — exit 0
- `npm test` — 4076 passed, 2 skipped; identical to the pre-change baseline, so no existing assertion changed behaviour
- SonarCloud quality gate passed — 0 new issues, 0.0% duplication, `javascript:S7762` 12 → 0

Coverage on new code is 63.6%. Mapping each rewritten line against the PR coverage report, **7 of the 12 sites are executed** by the unit suite — the teardown loops in `nuxeo-filter`, `nuxeo-slots` and `nuxeo-dialog`, the children clear in `nuxeo-tree-node`, the root swap in `nuxeo-tree`, the drag-proxy cleanup in `nuxeo-draggable-list-behavior`, and the download-link cleanup in `nuxeo-operation-button`. The other 5 are not: both chart-teardown sites in `nuxeo-document-distribution-chart`, the previewer clear in `nuxeo-document-preview`, `nuxeo-tree-node._teardownInstance()`, and the failed-import cleanup in `import-href` (a file no test imports, so it is not instrumented at all).

Manual QA is scoped to exactly those 5 unexercised sites and tracked in [ELEMENTS-2096](https://hyland.atlassian.net/browse/ELEMENTS-2096).

