### PR TITLE
ELEMENTS-2085: Use object spread instead of Object.assign [lts-2025]

### DIFF
--- a/ui/actions/nuxeo-export-button.js
+++ b/ui/actions/nuxeo-export-button.js
@@ -150,7 +150,9 @@ import '../nuxeo-button-styles.js';
           .filter(
             (rendition) => rendition.kind !== 'nuxeo:video:conversion' && rendition.kind !== 'nuxeo:picture:conversion',
           )
-          .map((item) => Object.assign({ label: this.formatRendition(item.name) }, item));
+          .map((item) => {
+            return { label: this.formatRendition(item.name), ...item };
+          });
       }
       return [];
     }

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -1038,7 +1038,9 @@ import '../nuxeo-button-styles.js';
 
     get settings() {
       const sortOrder = Array.isArray(this.sortOrder)
-        ? this.sortOrder.map((entry) => Object.assign({}, entry))
+        ? this.sortOrder.map((entry) => {
+            return { ...entry };
+          })
         : this.sortOrder || null;
 
       const tableSettings = {

--- a/ui/nuxeo-justified-grid/nuxeo-justified-grid.js
+++ b/ui/nuxeo-justified-grid/nuxeo-justified-grid.js
@@ -433,7 +433,7 @@ import { RoutingBehavior } from '../nuxeo-routing-behavior.js';
       items
         .filter((item) => Object.keys(item).length !== 0)
         .forEach((item, idx) => {
-          const clone = Object.assign({}, item);
+          const clone = { ...item };
           // fallback to square dimensions if the item doesn't have a size object in it's model
           clone.size = clone.properties['picture:info'] || { width: 1, height: 1 };
           clone.size.width = clone.size.width || 1;

--- a/ui/widgets/nuxeo-directory-suggestion.js
+++ b/ui/widgets/nuxeo-directory-suggestion.js
@@ -258,17 +258,14 @@ import { escapeHTML } from './nuxeo-selectivity.js';
     }
 
     _computeParams() {
-      return Object.assign(
-        {},
-        {
-          directoryName: this.directoryName,
-          dbl10n: this.dbl10n,
-          canSelectParent: this.canSelectParent,
-          localize: true,
-          lang: window.nuxeo.I18n.language ? window.nuxeo.I18n.language.split('-')[0] : 'en',
-        },
-        this.params,
-      );
+      return {
+        directoryName: this.directoryName,
+        dbl10n: this.dbl10n,
+        canSelectParent: this.canSelectParent,
+        localize: true,
+        lang: window.nuxeo.I18n.language ? window.nuxeo.I18n.language.split('-')[0] : 'en',
+        ...this.params,
+      };
     }
 
     _getItemKey(item) {

--- a/ui/widgets/nuxeo-document-suggestion.js
+++ b/ui/widgets/nuxeo-document-suggestion.js
@@ -288,18 +288,15 @@ import { escapeHTML } from './nuxeo-selectivity.js';
     }
 
     _computeParams() {
-      return Object.assign(
-        {},
-        {
-          documentSchemas: this.schemas,
-          repository: this.repository,
-          providerName: this.pageProvider,
-          pageProviderName: this.pageProvider,
-          page: 0,
-          pageSize: 20,
-        },
-        this.params,
-      );
+      return {
+        documentSchemas: this.schemas,
+        repository: this.repository,
+        providerName: this.pageProvider,
+        pageProviderName: this.pageProvider,
+        page: 0,
+        pageSize: 20,
+        ...this.params,
+      };
     }
 
     _selectionFormatter(doc) {

--- a/ui/widgets/nuxeo-user-suggestion.js
+++ b/ui/widgets/nuxeo-user-suggestion.js
@@ -241,14 +241,11 @@ import './nuxeo-user-group-formatter.js';
     }
 
     _computeParams() {
-      return Object.assign(
-        {},
-        {
-          searchType: this.searchType,
-          groupRestriction: this.groupRestriction,
-        },
-        this.params,
-      );
+      return {
+        searchType: this.searchType,
+        groupRestriction: this.groupRestriction,
+        ...this.params,
+      };
     }
 
     _selectionFormatter(item) {


### PR DESCRIPTION
> **Companion PR:** same change on `maintenance-3.1.x` — #1675

Cherry-pick of #1675. The diff is identical to the `maintenance-3.1.x` PR.

## Problem

SonarCloud reports 6 `javascript:S6661` findings: `Object.assign()` should be object spread syntax.

Jira: [ELEMENTS-2085](https://hyland.atlassian.net/browse/ELEMENTS-2085)

## Changes

All 6 sites rewritten to spread:

| File | Sonar finding line | Site |
| --- | --- | --- |
| `ui/nuxeo-data-table/iron-data-table.js` | 1041 | `get settings()` — clone each `sortOrder` entry |
| `ui/actions/nuxeo-export-button.js` | 153 | rendition list — merge a computed `label` into each item |
| `ui/widgets/nuxeo-directory-suggestion.js` | 261 | `_computeParams()` — defaults + `this.params` |
| `ui/widgets/nuxeo-document-suggestion.js` | 291 | `_computeParams()` — defaults + `this.params` |
| `ui/widgets/nuxeo-user-suggestion.js` | 244 | `_computeParams()` — defaults + `this.params` |
| `ui/nuxeo-justified-grid/nuxeo-justified-grid.js` | 436 | shallow clone before computing tile size |

## Notes

Every site merges plain objects into a fresh object literal, so `{ ...a, ...b }` is equivalent to `Object.assign({}, a, b)`. Override order is preserved — `this.params` still wins over the defaults in the three `_computeParams()` sites, and an item's own `label` still wins over the computed one in `nuxeo-export-button` — and a `null`/`undefined` source is ignored by both forms. The cases where the two forms genuinely differ (a target carrying setters, or a source with an own `__proto__` key) do not arise: every target here is a fresh literal.

The `nuxeo-justified-grid` clone stays shallow, so the pre-existing aliasing of `clone.properties` is unchanged by this PR.

## Test plan

- `npm run lint` — exit 0
- `npm test` — 4075 passed, 2 skipped — the `lts-2025` baseline, unchanged (this PR touches no test file, and `lts-2025` runs one fewer test than `maintenance-3.1.x`)
- SonarCloud quality gate passed — 0 new issues, 0.0% duplication, **100% coverage on new code**, `javascript:S6661` 6 → 0

All six rewritten lines are executed by the unit suite, and each is covered by a test that asserts the specific merge semantics at risk:

- `nuxeo-directory-suggestion`, `nuxeo-document-suggestion` and `nuxeo-user-suggestion` each have a `_computeParams` suite asserting both the defaults and that custom params override them.
- `iron-data-table` — the `get settings` suite deep-equals the cloned `sortOrder`, including the `null`, empty and non-array cases.
- `nuxeo-export-button` — "adds label from formatRendition" asserts the merged item carries `label`.
- `nuxeo-justified-grid` — the layout test asserts `size` computed from the clone.

No manual QA sub-task was raised for this change; the reasoning is recorded on the Jira ticket.
