### PR TITLE
ELEMENTS-2086: Batch consecutive Array.push calls [maintenance-3.1.x]

### DIFF
--- a/core/nuxeo-document.js
+++ b/core/nuxeo-document.js
@@ -261,8 +261,7 @@ import './nuxeo-resource.js';
       if (this.documentData) {
         if (this.documentData.contextParameters) {
           const documentContextParams = this.documentData.contextParameters;
-          documentProps.push(documentContextParams.preview);
-          documentProps.push(documentContextParams.renditions);
+          documentProps.push(documentContextParams.preview, documentContextParams.renditions);
         }
 
         if (this.documentData.properties) {

--- a/ui/dataviz/nuxeo-document-distribution-chart.js
+++ b/ui/dataviz/nuxeo-document-distribution-chart.js
@@ -783,12 +783,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
 
     // Generate a string that describes the points of a breadcrumb polygon.
     _breadcrumbPoints(d, i) {
-      const points = [];
-      points.push('0,0');
-      points.push(`${b.w},0`);
-      points.push(`${b.w + b.t},${b.h / 2}`);
-      points.push(`${b.w},${b.h}`);
-      points.push(`0,${b.h}`);
+      const points = ['0,0', `${b.w},0`, `${b.w + b.t},${b.h / 2}`, `${b.w},${b.h}`, `0,${b.h}`];
       if (i > 0) {
         // Leftmost breadcrumb; don't include 6th vertex.
         points.push(`${b.t},${b.h / 2}`);


### PR DESCRIPTION
> **Companion PR:** same change on `lts-2025` — #1678


## Problem

SonarCloud reports 5 `javascript:S7778` findings — consecutive `Array#push()` calls that should be combined into one. (A sixth S7778 finding, in `custom-date-picker.js`, is owned by a separate ticket and is not touched here.)

Jira: [ELEMENTS-2086](https://hyland.atlassian.net/browse/ELEMENTS-2086)

## Changes

| File | Site | Findings |
| --- | --- | --- |
| `core/nuxeo-document.js` | `setDocumentViewDownloadProp()` — two pushes merged into one call | 1 |
| `ui/dataviz/nuxeo-document-distribution-chart.js` | `_breadcrumbPoints()` — five sequential pushes replaced by an array literal | 4 |

The conditional sixth vertex in `_breadcrumbPoints()` stays a separate `push()`; it is guarded by `if (i > 0)` and so is not consecutive with the others.

## Notes

`push(a, b)` appends the same elements in the same order as `push(a); push(b);`, and the array literal preserves the vertex order exactly. Only the call shape changes — no control flow, no receiver, no ordering.

## Test plan

- CI green on both PRs — `lint`, `test`, `storybook`, `Build and analyze`, CodeQL and the downstream `web-ui` integration job all pass.
- SonarCloud quality gate passed — 0 new issues, 0.0% duplication, `javascript:S7778` 5 → 0 for the in-scope files.
- No test file is touched, so the suite composition is unchanged.

Coverage on new code is 50%: of the two changed lines, one is executed by the unit suite and one is not.

- `core/nuxeo-document.js` — **covered and asserted.** The file is at 100% line and branch coverage, and `core/test/nuxeo-document.test.js` asserts that both pushed elements are processed downstream, checking that `contextParameters.preview` and `contextParameters.renditions[0]` each come back stamped with `viewUrl`/`downloadUrl`. Dropping or reordering either element would fail those assertions.
- `ui/dataviz/nuxeo-document-distribution-chart.js` — **not executed.** The file sits at 3.1% line and 0% branch coverage, and its test file has no assertion touching `_breadcrumbPoints()` or the breadcrumb trail.

Manual QA is scoped to that one unexercised site and tracked in [ELEMENTS-2097](https://hyland.atlassian.net/browse/ELEMENTS-2097).
