### PR TITLE
ELEMENTS-2087: Use String.raw for escaped literals [lts-2025]

### DIFF
--- a/ui/nuxeo-format-behavior.js
+++ b/ui/nuxeo-format-behavior.js
@@ -216,10 +216,12 @@ export const FormatBehavior = [
      * @param {string} text the NXQL string literal to be escaped
      */
     escapeNxqlStringLiteral(text) {
+      // These values are the escape sequences themselves, so String.raw (S7780) must not be
+      // applied here: String.raw`'` drops the backslash and yields an unescaped quote.
       const replaceMap = {
-        "'": String.raw`'`,
-        '\\': String.raw`\\`,
-        '"': String.raw`"`,
+        "'": "\\'",
+        '\\': '\\\\',
+        '"': '\\"',
       };
 
       return text && text.replace(/["'\\]/g, (match) => replaceMap[match]);

--- a/ui/nuxeo-format-behavior.js
+++ b/ui/nuxeo-format-behavior.js
@@ -206,7 +206,7 @@ export const FormatBehavior = [
      * @param {string} text the RegExp to be escaped
      */
     escapeRegExp(text) {
-      return text && text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+      return text && text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, String.raw`\$&`);
     },
 
     /**
@@ -217,9 +217,9 @@ export const FormatBehavior = [
      */
     escapeNxqlStringLiteral(text) {
       const replaceMap = {
-        "'": "\\'",
-        '\\': '\\\\',
-        '"': '\\"',
+        "'": String.raw`'`,
+        '\\': String.raw`\\`,
+        '"': String.raw`"`,
       };
 
       return text && text.replace(/["'\\]/g, (match) => replaceMap[match]);

--- a/ui/nuxeo-path-suggestion/nuxeo-path-suggestion.js
+++ b/ui/nuxeo-path-suggestion/nuxeo-path-suggestion.js
@@ -189,7 +189,7 @@ import { FormatBehavior } from '../nuxeo-format-behavior.js';
 
         allowedPattern: {
           type: String,
-          value: '[^()\\+*%]',
+          value: String.raw`[^()\+*%]`,
         },
 
         disabled: {


### PR DESCRIPTION
> **Companion PR:** same change on `maintenance-3.1.x` — #1679

Cherry-pick of #1679. The diff is identical to the `maintenance-3.1.x` PR.

## Problem

SonarCloud reports `javascript:S7780` — string literals that escape backslashes should use `String.raw`. Two findings are in scope here; the `custom-date-picker.js` site belongs to a separate ticket.

Jira: [ELEMENTS-2087](https://hyland.atlassian.net/browse/ELEMENTS-2087)

## Changes

| File | Site |
| --- | --- |
| `ui/nuxeo-format-behavior.js` | `escapeRegExp()` replacement literal |
| `ui/nuxeo-path-suggestion/nuxeo-path-suggestion.js` | `allowedPattern` property default |

`escapeNxqlStringLiteral()` in the same file is deliberately **not** converted, and this PR adds a comment there saying so. Its `replaceMap` values *are* the escape sequences, so `String.raw` would strip the backslash and return an unescaped quote — the opposite of what the function exists to do. The comment is there to stop a future S7780 sweep re-applying the rule at that site.

## Notes

Both conversions were verified byte-identical rather than eyeballed:

```js
'\\$&'       === String.raw`\$&`       // both are the 3-char string  \$&
'[^()\\+*%]' === String.raw`[^()\+*%]` // both are the 9-char string  [^()\+*%]
```

The `escapeRegExp` output was also compared across a sample of inputs containing every metacharacter in its character class, and the two forms produce identical results.

## Test plan

- CI green on both PRs — `lint`, `test`, `storybook`, `Build and analyze`, CodeQL, `license/cla` and the downstream `web-ui` integration job all pass.
- SonarCloud quality gate passed — 0 new issues, **100% coverage on new code**, `javascript:S7780` 2 → 0 for the in-scope sites.

Both changed values are executed *and* asserted at exact-value level, which is the strongest form of coverage for a literal rewrite:

- `escapeRegExp` — `ui/test/nuxeo-format-behavior.test.js` asserts exact escaped output for several inputs, plus the empty and null/undefined cases.
- `allowedPattern` — `ui/test/nuxeo-path-suggestion.test.js` asserts `properties.allowedPattern.value` equals the exact expected string, so any drift in the literal fails the test directly.
- `escapeNxqlStringLiteral` — unchanged, and its quote/backslash escaping assertions guard the site left deliberately unconverted.

No manual QA sub-task was raised; the reasoning is recorded on the Jira ticket.
