### PR TITLE
ELEMENTS-2088: Prefer Date.now() over new Date().getTime() [lts-2025]

### DIFF
--- a/ui/nuxeo-document-permissions/nuxeo-document-permissions.js
+++ b/ui/nuxeo-document-permissions/nuxeo-document-permissions.js
@@ -248,7 +248,7 @@ import '../nuxeo-button-styles.js';
           value: {
             'fetch-acls': 'username,creator,extended',
             depth: 'children',
-            time: new Date().getTime(),
+            time: Date.now(),
           },
         },
         visible: {
@@ -289,7 +289,7 @@ import '../nuxeo-button-styles.js';
     refresh() {
       if (this.visible) {
         this.doc = null;
-        this.params.time = new Date().getTime();
+        this.params.time = Date.now();
         this.$.doc.get().then(() => {
           this.dispatchEvent(
             new CustomEvent('iron-resize', {

--- a/ui/nuxeo-draggable-list-behavior.js
+++ b/ui/nuxeo-draggable-list-behavior.js
@@ -91,7 +91,7 @@ export const DraggableListBehavior = {
     // mouse move handler
     const moveFn = (e) => {
       // ELEMENTS-723: prevent dragging from beginning too early, which can interfere with other mouse events
-      if (new Date().getTime() - this._mouseDownStarted <= 150) {
+      if (Date.now() - this._mouseDownStarted <= 150) {
         return;
       }
       // block list pointer events while dragging and apply grabbing cursor
@@ -160,7 +160,7 @@ export const DraggableListBehavior = {
       if (this.draggable && e.target && this.draggableFilter(e.target)) {
         // prevent default behavior to make sure cursors are applied across all browsers
         e.preventDefault();
-        this._mouseDownStarted = this._mouseDownStarted || new Date().getTime();
+        this._mouseDownStarted = this._mouseDownStarted || Date.now();
         // setup listeners when drag starts
         document.addEventListener('mousemove', moveFn);
         document.addEventListener('mouseup', upFn);


### PR DESCRIPTION
> **Companion PR:** same change on `maintenance-3.1.x` — #1681

Cherry-pick of #1681. The diff is identical to the `maintenance-3.1.x` PR.

## Problem

SonarCloud reports 4 `javascript:S7759` findings — `new Date().getTime()` should be `Date.now()`.

Jira: [ELEMENTS-2088](https://hyland.atlassian.net/browse/ELEMENTS-2088)

## Changes

| File | Site |
| --- | --- |
| `ui/nuxeo-document-permissions/nuxeo-document-permissions.js` | `params.time` default, and its reset in `refresh()` — a cache-busting value on the ACL fetch |
| `ui/nuxeo-draggable-list-behavior.js` | the 150 ms drag-start guard, and the `_mouseDownStarted` stamp that feeds it |

## Notes

`Date.now()` and `new Date().getTime()` both return the same ECMAScript time value — milliseconds since the epoch, read from the same clock. The only difference is that the old form allocated a `Date` object first, so the change is value-identical and marginally cheaper.

The one way the two forms could diverge is a test that fakes the `Date` constructor without faking `Date.now`. Nothing in the suite does: the only `sinon.useFakeTimers()` call is in an unrelated test file, and it fakes both APIs together in any case.

## Test plan

- CI green on both PRs — `lint`, `test`, `storybook`, `Build and analyze`, CodeQL, `license/cla` and the downstream `web-ui` integration job all pass.
- SonarCloud quality gate passed — 0 new issues, `javascript:S7759` 4 → 0.
- No test file is touched, so the suite composition is unchanged.

**All four changed lines are executed by the unit suite.** Coverage on new code reads 85.7% rather than 100% because SonarCloud's coverage metric counts branch conditions alongside lines, not because a changed line is unexercised:

- `nuxeo-document-permissions.js` — 100% line coverage; both changed lines covered.
- `nuxeo-draggable-list-behavior.js` — both changed lines covered. The drag guard on the first of them is a half-covered branch: the suite never takes the "released too early" path, so its `return` is not executed.

That half-covered branch is pre-existing and untouched here. The change alters only how the timestamp is obtained, not which branch is taken, so it cannot flip that outcome.

No manual QA sub-task was raised; the reasoning is recorded on the Jira ticket.
