### PR TITLE
ELEMENTS-2089: Hoist nested functions to outer scope [lts-2025]

### DIFF
--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -52,6 +52,19 @@ import { PageProviderDisplayBehavior } from '../nuxeo-page-provider-display-beha
 import { DraggableListBehavior } from '../nuxeo-draggable-list-behavior.js';
 import '../nuxeo-button-styles.js';
 
+function hasDataTableColumn(node) {
+  return node.nodeType === Node.ELEMENT_NODE && node instanceof Nuxeo.DataTableColumn;
+}
+
+function hasRowDetailTemplate(node) {
+  return (
+    node.nodeType === Node.ELEMENT_NODE &&
+    node.tagName === 'TEMPLATE' &&
+    node.hasAttribute('is') &&
+    node.getAttribute('is') === 'row-detail'
+  );
+}
+
 {
   /**
    * An element to display a page provider result within a table with infinite scrolling.
@@ -585,30 +598,20 @@ import '../nuxeo-button-styles.js';
       this._fieldTypeStats = null;
       this._fieldTypeHints = null;
       this._observer = dom(this).observeNodes((info) => {
-        const hasColumns = function(node) {
-          return node.nodeType === Node.ELEMENT_NODE && node instanceof Nuxeo.DataTableColumn;
-        };
-
-        const hasDetails = function(node) {
-          return (
-            node.nodeType === Node.ELEMENT_NODE &&
-            node.tagName === 'TEMPLATE' &&
-            node.hasAttribute('is') &&
-            node.getAttribute('is') === 'row-detail'
-          );
-        };
-
         if (this._reorderingColumns) {
           return;
         }
 
-        if (info.addedNodes.filter(hasColumns).length > 0 || info.removedNodes.filter(hasColumns).length > 0) {
-          this.set('columns', this.$.columns.assignedNodes().filter(hasColumns));
+        if (
+          info.addedNodes.filter(hasDataTableColumn).length > 0 ||
+          info.removedNodes.filter(hasDataTableColumn).length > 0
+        ) {
+          this.set('columns', this.$.columns.assignedNodes().filter(hasDataTableColumn));
           this._backupColumnsState();
           this.notifyResize();
         }
 
-        if (info.addedNodes.filter(hasDetails).length > 0) {
+        if (info.addedNodes.filter(hasRowDetailTemplate).length > 0) {
           this.set('rowDetail', this.getContentChildren('[select="template[is=row-detail]"]')[0]);
 
           // assuming parent element is always a Polymer element.

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -602,16 +602,13 @@ function hasRowDetailTemplate(node) {
           return;
         }
 
-        if (
-          info.addedNodes.filter(hasDataTableColumn).length > 0 ||
-          info.removedNodes.filter(hasDataTableColumn).length > 0
-        ) {
+        if (info.addedNodes.some(hasDataTableColumn) || info.removedNodes.some(hasDataTableColumn)) {
           this.set('columns', this.$.columns.assignedNodes().filter(hasDataTableColumn));
           this._backupColumnsState();
           this.notifyResize();
         }
 
-        if (info.addedNodes.filter(hasRowDetailTemplate).length > 0) {
+        if (info.addedNodes.some(hasRowDetailTemplate)) {
           this.set('rowDetail', this.getContentChildren('[select="template[is=row-detail]"]')[0]);
 
           // assuming parent element is always a Polymer element.


### PR DESCRIPTION
> **Companion PR:** same change on `maintenance-3.1.x` — #1683

Cherry-pick of #1683; the diff is identical.

## Problem

SonarCloud reports 5 maintainability findings in `ui/nuxeo-data-table/iron-data-table.js`, all inside the `dom(this).observeNodes()` callback that keeps the table's columns and row-detail template in sync with its light DOM:

- **`javascript:S7721` ×2** — the `hasColumns` and `hasDetails` predicates were declared inside the callback, so a fresh pair of closures was allocated on every light-DOM mutation.
- **`javascript:S7754` ×3** — three `.filter(…).length > 0` checks used as booleans.

Jira: [ELEMENTS-2089](https://hyland.atlassian.net/browse/ELEMENTS-2089)

## Changes

All in `ui/nuxeo-data-table/iron-data-table.js`:

- Hoist both predicates to module scope, renamed for clarity now that they are no longer local: `hasColumns` → `hasDataTableColumn`, `hasDetails` → `hasRowDetailTemplate`. Their bodies are unchanged.
- Convert the three boolean checks to `.some(…)`: the added-node and removed-node column checks, and the row-detail check.

The `.filter(hasDataTableColumn)` call that populates `columns` is deliberately left as `.filter(…)` — its result is the array itself, not a boolean.

## Notes

Hoisting is safe here because neither predicate captures anything: both read only their `node` argument plus the `Node` and `Nuxeo` globals, and neither touches `this`. `Nuxeo.DataTableColumn` is dereferenced inside the function body, so it still resolves at call time and module evaluation order is unaffected.

`.some(p)` is equivalent to `.filter(p).length > 0` whenever `p` is free of side effects; the only difference is short-circuiting. Both predicates are pure DOM reads (`nodeType`, `instanceof`, `tagName`, `hasAttribute`, `getAttribute`), so nothing observable depends on the tail of the list being visited.

## Test plan

- CI green — `lint`, `test`, `storybook`, `Build and analyze`, CodeQL, `license/cla` and the downstream `web-ui` integration job all pass.
- SonarCloud quality gate passed, 0 new issues. `S7721` 2 → 0 and `S7754` 3 → 0 in this file.
- `npm test` — 4075 passed / 2 skipped, matching the `lts-2025` baseline. No test file is touched.

**Every changed line is executed by the unit suite.** Coverage on new code reads 83.3% because SonarCloud counts branch conditions alongside lines, and two branches on the row-detail predicate are never driven true:

- Column detection — fully covered, including **both** sides of the `||` on the added/removed check and the `.filter(…)` that rebuilds `columns`. This is the path the product actually relies on.
- Row-detail detection — the `if` executes, but always evaluates false, so the predicate's `&&` chain is only partly exercised and the body beneath it never runs. That gap is pre-existing: the tests that cover row-detail behaviour assign `rowDetail` directly rather than declaring a `<template is="row-detail">`.

No manual QA sub-task was raised; the reasoning is recorded on the Jira ticket.
