### PR TITLE
ELEMENTS-2090: Log ignored catch blocks [maintenance-3.1.x]

### DIFF
--- a/core/nuxeo-resource.js
+++ b/core/nuxeo-resource.js
@@ -357,7 +357,8 @@ import './nuxeo-connection.js';
                   this.error = JSON.parse(text);
                   this.error.status = error.response.status;
                   console.warn(`Resource request failed: ${this.error.message}`);
-                } catch (_e) {
+                } catch (parseError) {
+                  console.warn('nuxeo-resource: failed to parse error response JSON', parseError);
                   this.error = { message: 'Invalid json', status: error.response.status };
                 }
               } else {

--- a/ui/test/nuxeo-image-viewer.test.js
+++ b/ui/test/nuxeo-image-viewer.test.js
@@ -857,5 +857,44 @@ suite('nuxeo-image-viewer extras', () => {
       Object.defineProperty(el.$.image, 'naturalWidth', { value: 0, configurable: true });
       expect(el._getToolbarBackgroundLuminance()).to.be.null;
     });
+
+    // The catch is only reachable once every geometry guard above it has passed, so the toolbar
+    // lookup, the image dimensions and both bounding rectangles describe a toolbar that fully
+    // overlaps the canvas. getImageData then throws the way it does once the canvas has been
+    // tainted by a cross-origin image, which is the repeating failure the warn-once guard exists
+    // for: the method runs from a requestAnimationFrame loop, so it must stay quiet after the
+    // first warning.
+    test('returns null and warns only once when reading the canvas throws', () => {
+      const warn = sandbox.stub(console, 'warn');
+      const querySelector = sandbox.stub(el.shadowRoot, 'querySelector');
+      querySelector.callThrough();
+      querySelector.withArgs('#toolbar').returns({
+        getBoundingClientRect: () => {
+          return { left: 0, top: 0, width: 100, height: 100 };
+        },
+      });
+      Object.defineProperty(el.$.image, 'naturalWidth', { value: 100, configurable: true });
+      Object.defineProperty(el.$.image, 'naturalHeight', { value: 100, configurable: true });
+      sandbox.stub(el.$.canvas, 'getBoundingClientRect').returns({ left: 0, top: 0, width: 100, height: 100 });
+      el._el = {
+        getCanvasData: () => {
+          return { left: 0, top: 0, width: 100, height: 100 };
+        },
+      };
+      const context = {
+        clearRect: sandbox.spy(),
+        drawImage: sandbox.spy(),
+        getImageData: sandbox.stub().throws(new Error('SecurityError: the canvas has been tainted')),
+      };
+      el.__contrastCanvas = document.createElement('canvas');
+      sandbox.stub(el.__contrastCanvas, 'getContext').returns(context);
+
+      expect(el._getToolbarBackgroundLuminance()).to.be.null;
+      expect(el._getToolbarBackgroundLuminance()).to.be.null;
+
+      expect(context.getImageData).to.have.been.calledTwice;
+      expect(warn).to.have.been.calledOnce;
+      expect(warn.firstCall.args[0]).to.contain('failed to compute average toolbar luminance');
+    });
   });
 });

--- a/ui/viewers/nuxeo-image-viewer.js
+++ b/ui/viewers/nuxeo-image-viewer.js
@@ -441,7 +441,8 @@ import '../nuxeo-icons.js';
           total += this._relativeLuminanceFromRgb(imageData[index], imageData[index + 1], imageData[index + 2]);
         }
         return pixels > 0 ? total / pixels : null;
-      } catch (_) {
+      } catch (error) {
+        console.warn('nuxeo-image-viewer: failed to compute average toolbar luminance', error);
         return null;
       }
     }

--- a/ui/viewers/nuxeo-image-viewer.js
+++ b/ui/viewers/nuxeo-image-viewer.js
@@ -442,7 +442,12 @@ import '../nuxeo-icons.js';
         }
         return pixels > 0 ? total / pixels : null;
       } catch (error) {
-        console.warn('nuxeo-image-viewer: failed to compute average toolbar luminance', error);
+        // Reached from a requestAnimationFrame loop, so warn only once per instance: getImageData
+        // throws on every call once the canvas is tainted by a cross-origin image.
+        if (!this.__toolbarLuminanceWarned) {
+          this.__toolbarLuminanceWarned = true;
+          console.warn('nuxeo-image-viewer: failed to compute average toolbar luminance', error);
+        }
         return null;
       }
     }


### PR DESCRIPTION
> **Companion PR:** same change on `lts-2025` — #1686


## Problem

Two `javascript:S2486` findings — `catch` blocks that swallowed the caught error without handling or documenting it, so a real failure left no trace. The remaining `S2486` sites in the repo sit in `custom-date-picker.js` and are tracked separately.

| File | Catch |
| --- | --- |
| `core/nuxeo-resource.js` | parsing a failed request's error body as JSON |
| `ui/viewers/nuxeo-image-viewer.js` | computing average toolbar luminance off a canvas |

Jira: [ELEMENTS-2090](https://hyland.atlassian.net/browse/ELEMENTS-2090)

## Changes

- **`core/nuxeo-resource.js`** — name the binding (`_e` → `parseError`) and log it. The `{ message: 'Invalid json', status }` fallback is untouched.
- **`ui/viewers/nuxeo-image-viewer.js`** — name the binding (`_` → `error`) and log it behind a once-per-instance guard, with a comment explaining why the guard is there. Still returns `null` on every failure.
- **`ui/test/nuxeo-image-viewer.test.js`** — new test covering the catch, added because it had no coverage before.

## Notes

**Neither catch changes control flow.** Both still produce exactly the value they did before; the only addition is a log line.

**The image-viewer warning is guarded because it sits under a `requestAnimationFrame` loop.** `_scheduleToolbarContrastUpdate()` re-arms a frame on `ready`, `cropend`, `zoom` and `_resize`, so during a pan, zoom or window resize this method runs roughly once per frame. `getImageData()` on a canvas tainted by a cross-origin image throws on *every* call rather than intermittently — the normal case for a blob served from S3 or a CDN without CORS headers — so an unguarded warn could emit around 60 lines a second for as long as the user keeps interacting. Copilot raised the same concern on review; the guard is the response, and the thread is resolved.

The flag deliberately never resets, so a later unrelated failure on the same element stays silent. The first failure is still logged with the full `error` object, which is what a diagnostic needs.

**`nuxeo-resource` logs exactly once either way.** If `JSON.parse` succeeds, the existing warn on the line above reports the failed request; if it throws, that line is skipped and the new warn fires instead. No path logs twice.

## Test plan

- CI green — `lint`, `test`, `storybook`, `Build and analyze`, CodeQL, `license/cla` and the downstream `web-ui` integration job all pass.
- SonarCloud quality gate passed, 0 new issues, **100% coverage on new code**. `S2486` 2 → 0 for these two files.
- `npm test` — 4076 passed / 2 skipped on the `maintenance-3.1.x` baseline, plus the new case.

Both catch bodies are now exercised, and the assertions check behaviour rather than just executing the lines:

- The new image-viewer test drives `getImageData` to throw, calls the method twice, and asserts `null` both times, that the failure genuinely recurred (`getImageData` called twice), and that `console.warn` fired exactly once with the expected message. That pins the warn-once contract directly.
- The `nuxeo-resource` catch is covered by the existing "falls back to Invalid json when the error body is not json" test, which asserts the rejected error's `message`. The file reads 100% line coverage on this PR.

No manual QA sub-task was raised; the reasoning is recorded on the Jira ticket.
