### PR TITLE
ELEMENTS-2092: Remove redundant thisArg from Array.forEach [maintenance-3.1.x]

### DIFF
--- a/core/nuxeo-task-page-provider.js
+++ b/core/nuxeo-task-page-provider.js
@@ -267,7 +267,7 @@ import './nuxeo-resource.js';
             params[key] = value['entity-type'] ? value.uid || value.id : JSON.stringify(value);
           }
         }
-      }, this);
+      });
 
       return params;
     }

--- a/dataviz/nuxeo-aggregate-data-behavior.js
+++ b/dataviz/nuxeo-aggregate-data-behavior.js
@@ -401,7 +401,7 @@ Nuxeo.AggregateDataBehavior = {
         const term = {};
         term[key] = this.where[key];
         terms.push({ term });
-      }, this);
+      });
     }
     return { bool: { must: terms } };
   },

--- a/ui/nuxeo-slots.js
+++ b/ui/nuxeo-slots.js
@@ -305,7 +305,7 @@ window.nuxeo.slots.setSharedModel = (model) => {
       }
       this._instances.forEach((instance) => {
         instance.set(prop, value);
-      }, this);
+      });
     }
   }
 


### PR DESCRIPTION
> **Companion PR:** same change on `lts-2025` — #1690


## Problem

SonarCloud reports 3 `javascript:S7729` findings — a redundant `thisArg` passed as the second argument to `Array#forEach()`.

Jira: [ELEMENTS-2092](https://hyland.atlassian.net/browse/ELEMENTS-2092)

## Changes

Dropped the trailing `, this` at three call sites:

| File | Call site |
| --- | --- |
| `core/nuxeo-task-page-provider.js` | `_params` — building the request parameter map |
| `dataviz/nuxeo-aggregate-data-behavior.js` | `_buildTerms` — the object branch that turns `where` keys into term clauses |
| `ui/nuxeo-slots.js` | `_forwardHostProp` — propagating a host property change to each instance |

Nothing else changed; each edit is confined to the closing line of the `forEach` call.

## Notes

**The argument was dead code.** All three callbacks are arrow functions, and an arrow function has no `this` binding of its own — `this` resolves lexically from the enclosing scope, and the `thisArg` handed to `forEach` is ignored outright. Removing it cannot change what `this` is.

That matters because **two of the three callbacks do use `this`**: `_params` reads `this.params` and `_buildTerms` reads `this.where`. In both cases `this` still resolves to the enclosing method's receiver exactly as before, because it always did — it was never coming from the `forEach` argument. The third callback does not reference `this` at all.

The repository has other `}, this)` occurrences that are correctly **not** in scope: they pass `function` callbacks, where the argument really does bind `this` and removing it would break them.

## Test plan

- CI green — `lint`, `test`, `storybook`, `Build and analyze`, CodeQL, `license/cla` and the downstream `web-ui` integration job all pass.
- SonarCloud quality gate passed, 0 new issues. `javascript:S7729` goes 3 → 0.
- `npm test` — 4076 passed / 2 skipped, matching the `maintenance-3.1.x` baseline. No test file is touched.

**All three call sites are executed by the unit suite:**

- `core/nuxeo-task-page-provider.js` — 100% line and branch coverage.
- `ui/nuxeo-slots.js` — `_forwardHostProp` is covered.
- `dataviz/nuxeo-aggregate-data-behavior.js` — the object branch of `_buildTerms` that this change touches is covered. (The sibling array branch is not, but it is untouched here.)

SonarCloud reports 0.0% coverage on new code because the only changed lines are the closing `});` of three calls, which carry no coverable statement of their own. There is nothing for the metric to measure — it is not a coverage gap.

No manual QA sub-task was raised; the reasoning is recorded on the Jira ticket.
