### PR TITLE
ELEMENTS-2089: Exclude vendored randomColor.js from Sonar analysis [maintenance-3.1.x]

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,6 +17,12 @@ sonar.inclusions=**/*.js,**/*.html,**/*.json,**/*.css,**/*.yaml,**/*.yml
 # Exclude build output, node_modules, generated files, vendor and coverage, plus
 # development-only pages that are not part of the shipped product (ELEMENTS-2056).
 #
+#  - ui/dataviz/randomColor.js — vendored randomColor by David Merfield (CC0), not our code.
+#    Its file header names the upstream project (github.com/davidmerfield/randomColor) and it is
+#    already treated as vendored by the rest of the toolchain: .prettierignore and the ESLint
+#    `ignores` block in eslint.config.mjs both list it next to ui/viewers/pdfjs/** and
+#    ui/js-interpreter/**. Sonar was the only tool still analysing it, so maintainability rules
+#    (S7721 on ELEMENTS-2089) were raised against third-party source we should not fork.
 #  - **/demo/** — legacy `polymer serve` demo pages (69 pages under ui/, core/, dataviz/).
 #    Not imported by any module, not built, not run in CI, and not deployed; the public
 #    documentation at nuxeo.github.io/nuxeo-elements is published from storybook/ by
@@ -50,6 +56,7 @@ sonar.exclusions=\
   storybook/**,\
   ui/viewers/pdfjs/**,\
   ui/js-interpreter/**,\
+  ui/dataviz/randomColor.js,\
   ui/i18n/**/*.json,\
   **/demo/**,\
   core/index.html,\


### PR DESCRIPTION
> **Companion PR:** same change on `lts-2025` — #1692


## Problem

A `javascript:S7721` finding was raised against `ui/dataviz/randomColor.js`. That file is randomColor by David Merfield under the CC0 license — third-party code vendored into `ui/dataviz`, as its own file header states. Patching it means forking upstream source for no functional gain, and the finding would return on every future sweep.

Jira: [ELEMENTS-2089](https://hyland.atlassian.net/browse/ELEMENTS-2089)

## Root cause

The file is already treated as vendored by every tool in the toolchain except Sonar:

| Tool | Config | Listed? |
|---|---|---|
| Prettier | `.prettierignore` | yes, next to `ui/viewers/pdfjs` |
| ESLint | `ignores` in `eslint.config.mjs` | yes, next to `ui/viewers/pdfjs/**` and `ui/js-interpreter/**` |
| Sonar | `sonar.exclusions` | **no** — the gap |

`sonar.exclusions` already covers both trees `AGENTS.md` names as vendored, but omits `randomColor.js`. That omission is the sole reason the rule fired on CC0 third-party code.

## Changes

`sonar-project.properties` — add `ui/dataviz/randomColor.js` to `sonar.exclusions`, positioned with the other vendored entries, with the rationale documented as a bullet in the existing comment block, matching the style of its neighbours. ELEMENTS-2056 established this pattern.

Deliberately not changed: `sonar.coverage.exclusions` (redundant, since `sonar.exclusions` drops the file from analysis entirely) and `ui/js-interpreter/**` (checked — already present).

## Test plan

Config-only; no runtime code is touched, so the unit suite is unaffected by construction.

- CI green — `lint`, `test`, `storybook`, `Build and analyze`, CodeQL, `license/cla` and the downstream `web-ui` integration job all pass.
- SonarCloud quality gate passed, 0 new issues.
- `npm run format` produced no changes; `npm test` — 4076 passed / 2 skipped, matching the `maintenance-3.1.x` baseline.

The 0.0% coverage-on-new-code figure is expected: the only changed file is a properties file, which has no coverable lines.
