### PR TITLE
ELEMENTS-2100: Clear stale column sort direction and drop dead TODOs [maintenance-3.1.x]

### DIFF
--- a/ui/nuxeo-data-table/data-table-cell.js
+++ b/ui/nuxeo-data-table/data-table-cell.js
@@ -388,8 +388,6 @@ const RESIZE_ZONE = 8;
       }
       // sometimes instance isn't ready to be notified yet and throws an error.
       microTask.run(() => {
-        // TODO: hack to avoid: https://github.com/Polymer/polymer/issues/3307
-        this._parentProps = this._parentProps || {};
         instance.notifyPath(column.path, column.value);
       });
     }

--- a/ui/nuxeo-data-table/data-table-column-sort.js
+++ b/ui/nuxeo-data-table/data-table-column-sort.js
@@ -81,7 +81,7 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
         },
         path: String,
         order: {
-          type: Number,
+          type: String,
           computed: '_order(path, sortOrder, sortOrder.length)',
         },
         sortOrder: Array,
@@ -93,26 +93,26 @@ import { I18nBehavior } from '../nuxeo-i18n-behavior.js';
     }
 
     _order(path, sortOrder, length) {
-      if (length <= 1) {
+      // `sortOrder` is still unset during the initial property flush, and the sequence badge is
+      // only meaningful while several columns are sorted at once.
+      if (!sortOrder || length <= 1) {
         return '';
       }
 
-      for (let i = 0; i < length; i++) {
-        if (sortOrder[i].path === path) {
-          return i + 1;
-        }
-      }
+      const index = sortOrder.findIndex((entry) => entry.path === path);
+      return index === -1 ? '' : `${index + 1}`;
     }
 
     _sortOrderChanged(sortOrder) {
-      // TODO: if sortOrder for this column has been removed from outside, direction is not updated.
-      if (sortOrder.base) {
-        sortOrder.base.forEach((sort) => {
-          if (sort.path === this.path) {
-            this.direction = sort.direction;
-          }
-        });
+      if (!sortOrder.base) {
+        return;
       }
+
+      // `sortOrder` may be replaced from outside the element, for instance when a saved content
+      // view is restored, so the direction has to be cleared when this column is no longer part
+      // of it. Leaving it stale would keep both the arrow and the aria-label out of sync.
+      const sort = sortOrder.base.find((entry) => entry.path === this.path);
+      this.direction = sort ? sort.direction : null;
     }
 
     _sort() {

--- a/ui/nuxeo-data-table/data-table-templatizer-behavior.js
+++ b/ui/nuxeo-data-table/data-table-templatizer-behavior.js
@@ -103,9 +103,6 @@ saulis.DataTableTemplatizerBehaviorImpl = {
   },
 
   _itemPathChanged(instance, item) {
-    // TODO: hack to avoid: https://github.com/Polymer/polymer/issues/3307
-    this._parentProps = this._parentProps || {};
-
     if (instance) {
       instance.notifyPath(item.path, item.value);
     }

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -901,12 +901,10 @@ function hasRowDetailTemplate(node) {
         // notifyResize() doesn't do anything on iOS if the viewport size hasn't changed
         // so calling updateSizeForItem(item) is more reliable.
 
-        // TODO: However, since we're reusing the same items array in most cases,
-        // the _collection item map inside <iron-list> gets out of sync and
-        // that breaks things like selection and updateSizeForItem.
-        // To mitigate the issue, we'll update height of every row element.
-        // Can be optimized later if needed to update only the row that has
-        // expanded or collapsed.
+        // However, since we're reusing the same items array in most cases, the _collection
+        // item map inside <iron-list> gets out of sync and that breaks things like selection
+        // and updateSizeForItem. Every row element is therefore re-measured, rather than only
+        // the row that has expanded or collapsed.
         const itemSet = [];
         for (let i = 0; i < this.$.list._physicalItems.length; i++) {
           itemSet.push(i);

--- a/ui/test/data-table-column-sort.test.js
+++ b/ui/test/data-table-column-sort.test.js
@@ -1,0 +1,121 @@
+/**
+@license
+©2026 Hyland Software, Inc. and its affiliates. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+import { fixture, flush, html } from '@nuxeo/testing-helpers';
+import '../nuxeo-data-table/data-table-column-sort.js';
+
+suite('nuxeo-data-table-column-sort', () => {
+  let el;
+
+  setup(async () => {
+    el = await fixture(
+      html`
+        <nuxeo-data-table-column-sort path="dc:title"></nuxeo-data-table-column-sort>
+      `,
+    );
+  });
+
+  const sortIcon = () => el.shadowRoot.getElementById('sortIcon');
+
+  suite('_sortOrderChanged', () => {
+    test('picks up the direction when this column is part of the sort order', () => {
+      el.sortOrder = [{ path: 'dc:title', direction: 'asc' }];
+      expect(el.direction).to.equal('asc');
+    });
+
+    test('follows the direction when it changes for this column', () => {
+      el.sortOrder = [{ path: 'dc:title', direction: 'asc' }];
+      el.sortOrder = [{ path: 'dc:title', direction: 'desc' }];
+      expect(el.direction).to.equal('desc');
+    });
+
+    test('ignores directions belonging to other columns', () => {
+      el.sortOrder = [{ path: 'dc:modified', direction: 'asc' }];
+      expect(el.direction).to.be.null;
+    });
+
+    // ELEMENTS-2100
+    test('clears the direction when this column is dropped from a replaced sort order', () => {
+      el.sortOrder = [{ path: 'dc:title', direction: 'asc' }];
+      expect(el.direction).to.equal('asc');
+
+      // a saved content view being restored replaces sortOrder wholesale
+      el.sortOrder = [{ path: 'dc:modified', direction: 'desc' }];
+      expect(el.direction).to.be.null;
+    });
+
+    test('clears the direction when the sort order is emptied', () => {
+      el.sortOrder = [{ path: 'dc:title', direction: 'desc' }];
+      el.sortOrder = [];
+      expect(el.direction).to.be.null;
+    });
+
+    test('clears the direction when this column is spliced out of the sort order', () => {
+      el.sortOrder = [
+        { path: 'dc:modified', direction: 'asc' },
+        { path: 'dc:title', direction: 'asc' },
+      ];
+      expect(el.direction).to.equal('asc');
+
+      el.splice('sortOrder', 1, 1);
+      expect(el.direction).to.be.null;
+    });
+
+    test('keeps the direction when another column is spliced out', () => {
+      el.sortOrder = [
+        { path: 'dc:title', direction: 'desc' },
+        { path: 'dc:modified', direction: 'asc' },
+      ];
+      el.splice('sortOrder', 1, 1);
+      expect(el.direction).to.equal('desc');
+    });
+
+    test('does nothing when the change record carries no array', () => {
+      el.direction = 'asc';
+      el._sortOrderChanged({});
+      expect(el.direction).to.equal('asc');
+    });
+  });
+
+  suite('aria-label', () => {
+    test('is dropped again once the direction is cleared', async () => {
+      el.sortOrder = [{ path: 'dc:title', direction: 'asc' }];
+      await flush();
+      expect(sortIcon().getAttribute('aria-label')).to.equal('command.sort.ascend');
+
+      el.sortOrder = [];
+      await flush();
+      expect(sortIcon().getAttribute('aria-label')).to.be.null;
+    });
+  });
+
+  suite('_order', () => {
+    test('is empty while a single column is sorted', () => {
+      el.sortOrder = [{ path: 'dc:title', direction: 'asc' }];
+      expect(el.order).to.equal('');
+    });
+
+    test('is the 1-based position while several columns are sorted', () => {
+      el.sortOrder = [
+        { path: 'dc:modified', direction: 'asc' },
+        { path: 'dc:title', direction: 'desc' },
+      ];
+      expect(el.order).to.equal('2');
+    });
+
+    test('is empty when this column is not part of a multi-column sort', () => {
+      el.sortOrder = [
+        { path: 'dc:modified', direction: 'asc' },
+        { path: 'dc:created', direction: 'desc' },
+      ];
+      expect(el.order).to.equal('');
+    });
+  });
+});

--- a/ui/test/data-table-templatizer.test.js
+++ b/ui/test/data-table-templatizer.test.js
@@ -79,21 +79,12 @@ suite('DataTableTemplatizerBehavior extras', () => {
   suite('_itemPathChanged', () => {
     test('calls notifyPath on instance', () => {
       const instance = { notifyPath: sinon.spy() };
-      const ctx = { _parentProps: null };
-      impl._itemPathChanged.call(ctx, instance, { path: 'item.name', value: 'x' });
+      impl._itemPathChanged(instance, { path: 'item.name', value: 'x' });
       expect(instance.notifyPath).to.have.been.calledWith('item.name', 'x');
     });
 
-    test('initializes _parentProps if undefined', () => {
-      const instance = { notifyPath: sinon.spy() };
-      const ctx = {};
-      impl._itemPathChanged.call(ctx, instance, { path: 'item.x', value: 1 });
-      expect(ctx._parentProps).to.be.an('object');
-    });
-
     test('does nothing when instance is null', () => {
-      const ctx = {};
-      impl._itemPathChanged.call(ctx, null, { path: 'item.x', value: 1 });
+      impl._itemPathChanged(null, { path: 'item.x', value: 1 });
     });
   });
 


### PR DESCRIPTION
> **Companion PR:** same change on `lts-2025` — #1695

## Problem

`nuxeo-data-table-column-sort` never clears its `direction`, so a column that is dropped from `sortOrder` **from outside the element** keeps its sort arrow — and keeps announcing a sort state that is no longer true.

The element's own 2019 TODO reported this and was never acted on:

```js
// TODO: if sortOrder for this column has been removed from outside, direction is not updated.
```

Jira: [ELEMENTS-2100](https://hyland.atlassian.net/browse/ELEMENTS-2100) (split from [ELEMENTS-2093](https://hyland.atlassian.net/browse/ELEMENTS-2093), which had this queued for blanket acceptance as an informational `S1135` note).

**Why it matters now.** `_sortOrderChanged` only ever *assigned* `direction`, and only on a path match — there was no branch that cleared it. Clicking a column was always fine, because `_sort()` sets `direction` locally before dispatching. The gap is only reachable when `sortOrder` is replaced wholesale, which is exactly what the 2026 table-personalisation work introduced:

- [ELEMENTS-1918](https://hyland.atlassian.net/browse/ELEMENTS-1918) — preserve the user's column customization (3.1.29 / 2025.14.0)
- [ELEMENTS-1966](https://hyland.atlassian.net/browse/ELEMENTS-1966) — automatically save filters **and sort** on a content view (3.1.32 / 2025.17.0)

Restoring saved settings assigns `sortOrder` in one go (`el.settings = { sortOrder: [...] }`). So a saved view that no longer sorts a previously-sorted column restores with a stale arrow on that column. A TODO that was theoretical for seven years became a live defect this year.

**Accessibility.** `direction` is not only visual — it also drives the accessible name:

```html
<paper-icon-button id="sortIcon" direction$="[[direction]]"
  aria-label$="[[_computeAriaLabel(direction, i18n)]]">
```

A stale `direction` therefore announces `Sort in ascending order` on a column that is not sorted, which makes this a WCAG concern rather than a cosmetic one.

## Changes

**`ui/nuxeo-data-table/data-table-column-sort.js`**

| Method | Change |
| --- | --- |
| `_sortOrderChanged` | Finds this column in the incoming `sortOrder` once and assigns `sort.direction` or `null`, so the direction is cleared when the column is absent. TODO removed. |
| `_order` | Always returns a string (SonarCloud `javascript:S3800`), and guards the initial property flush. |
| `order` property | `type: Number` → `type: String`, matching what `_order` now returns. |

**Dead code removed** — the two `_parentProps` hacks, plus the one test that only asserted the hack had run:

- `ui/nuxeo-data-table/data-table-cell.js`
- `ui/nuxeo-data-table/data-table-templatizer-behavior.js`
- `ui/test/data-table-templatizer.test.js`

**Comment reworded** — `ui/nuxeo-data-table/iron-data-table.js`, the `_collection` note in `_updateSizeForItem`. No code change.

**New tests** — `ui/test/data-table-column-sort.test.js`, 13 tests for the element, which had no dedicated test file.

## Notes

**Clearing `direction` is safe in every flow.** This is the main thing worth reviewing, so the reasoning in full:

1. **It cannot feed back into the table.** The header template binds `sort-order="[[sortOrder]]"` one-way *in*, and does not bind `direction` at all. `notify: true` on `direction` has no consumer in `iron-data-table`.
2. **`null` is already a supported value.** `_sort()` cycles `asc → desc → null`, so the unsorted rendering and the absent `aria-label` are pre-existing, tested states.
3. **The table's handler is additive.** `_sortDirectionChanged` (`nuxeo-page-provider-display-behavior.js`) updates the matching entry, removes it when the direction is falsy, and pushes when absent — it never drops *other* columns. So after a click the clicked path is always present in `sortOrder`, and the observer re-affirms the same direction.
4. **Tables without a page provider are unaffected.** That handler is guarded by `if (this._hasPageProvider())`, so `sortOrder` does not change on click and the observer does not re-fire.
5. **The user/group management tables benefit too.** They drive the same element through `SortBehavior._applySortDirectionChanged`, which returns a *new* array each time — so those tables had the same stale arrow and are fixed by the same change.

**`_order` needed an explicit `!sortOrder` guard, and this is the trap.** The original relied on an accident: with `sortOrder` unset, `length <= 1` was `undefined <= 1` → `false`, so it fell through to `for (let i = 0; i < undefined; i++)`, which never ran, and the function returned `undefined`. In other words the third return type that `S3800` complains about was load-bearing for the initial property flush. Replacing the loop with `findIndex` without a guard threw `Cannot read properties of undefined` during `ready()` — the local suite caught it as 12 failures across unrelated table fixtures. Returning `''` there renders identically, since Polymer text bindings map both `undefined` and `''` to empty text.

**The `_parentProps` lines were provably dead.** All three points check out:

- `Polymer/polymer#3307` was filed against **Polymer 1.2.3**, is labelled `1.x`, and was **closed on 2018-02-06** — a year *before* these lines were written into the Polymer 3 port.
- `_parentProps` appears **nowhere** in the installed `@polymer/polymer@3.5.2`, including `lib/legacy/templatizer-behavior.js`, which is the templatizer these files import. Nothing reads it. (`_forwardedParentProps` in the same behavior is a different, real property and is untouched.)
- The only reader was `initializes _parentProps if undefined`, a test whose sole assertion was that the hack had run.

**`iron-data-table.js` was documentation, not a task.** The comment explains why every physical row is re-measured — the `<iron-list>` `_collection` map drifts when the items array is reused, breaking selection. Since `S1135` keys off the literal word "TODO", rewording clears the finding with no behavioural change. The optimisation it floated is deliberately **not** done here: this file is a vendored fork and narrowing the re-measure risks the row-height and selection bugs the mitigation exists to prevent.

## Test plan

- `npm run lint` — 0 errors.
- `npm test` — all three packages pass: **core 164**, **ui 3895 / 2 skipped**, **dataviz 29**.
- **The new tests genuinely reproduce the defect.** Reverting only `_sortOrderChanged` while keeping the tests fails 5 of them, including `aria-label > is dropped again once the direction is cleared` with `expected 'command.sort.ascend' to be null` — the accessibility impact, demonstrated rather than asserted.
- Existing coverage that constrains this change still passes unchanged: the `Accessibility > select all clear after sorting` test in `nuxeo-data-table.test.js` (which pins `aria-label` as absent → ascend → descend), the `settings` / `sortOrder` suites in `iron-data-table.test.js`, and the `_sortDirectionChanged` suite in `nuxeo-page-provider-display-behavior.test.js`.
- Regression checks for prior fixes in this area — multi-column sort ([ELEMENTS-1390](https://hyland.atlassian.net/browse/ELEMENTS-1390)), sorting by hidden columns ([ELEMENTS-987](https://hyland.atlassian.net/browse/ELEMENTS-987)) and arrow/badge overlap ([ELEMENTS-1776](https://hyland.atlassian.net/browse/ELEMENTS-1776)) — are covered by the suites above and stay green.

**Manual QA** (worth a QA sub-task, since this is the customer-visible part): sort a column in a content view, save the view, change the sort, then reload the saved view — the previously-sorted column must show no arrow, and a screen reader must not announce a sort order for it.

### SonarCloud effect

| Rule | Before | After |
| --- | --- | --- |
| `javascript:S1135` (TODO) | 9 | 5 — the 4 handled here close as *Fixed* |
| `javascript:S3800` (inconsistent return type) | 1 | 0 |

The remaining 5 `S1135` findings are the genuinely informational ones; ELEMENTS-2100 records the per-site rationale for accepting them, and ELEMENTS-2093 has been corrected so it no longer proposes accepting all nine.
