### PR TITLE
NXENG-741: Add CodeQL Advanced workflow [maintenance-3.1.x]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,101 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]", "maintenance-2.2.x", "maintenance-2.4.x", "maintenance-3.0.x", "master" ]
+  pull_request:
+    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]", "maintenance-2.2.x", "maintenance-2.4.x", "maintenance-3.0.x", "master" ]
+  schedule:
+    - cron: '34 22 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: javascript-typescript
+          build-mode: none
+        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]", "maintenance-2.2.x", "maintenance-2.4.x", "maintenance-3.0.x", "master" ]
+    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]" ]
   pull_request:
-    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]", "maintenance-2.2.x", "maintenance-2.4.x", "maintenance-3.0.x", "master" ]
+    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]" ]
   schedule:
     - cron: '34 22 * * 4'
 


### PR DESCRIPTION
## Problem

Nuxeo Engineering enabled organization-level **Code scanning** default setup with CodeQL for repositories tagged `nuxeo-engineering`. Repositories need an explicit **CodeQL Advanced** GitHub Actions workflow so analysis runs on default and protected branches and findings appear under **Security → Code scanning alerts** for triage.

Jira: [NXENG-741](https://hyland.atlassian.net/browse/NXENG-741) (epic [NXENG-117](https://hyland.atlassian.net/browse/NXENG-117))

## Root cause

`nuxeo-elements` did not yet commit a `.github/workflows/codeql.yml` workflow. Without it, org-level default setup cannot run CodeQL consistently on this repo’s maintenance/LTS branches and pull requests.

## Changes

* **`.github/workflows/codeql.yml`**: Add the **CodeQL Advanced** workflow generated for this repository.
  * **Triggers**: `push` and `pull_request` on `maintenance-3.1.x`, `lts-20[0-9][0-9]`, legacy maintenance branches, and `master`; weekly schedule (`34 22 * * 4`).
  * **Languages**: `actions` and `javascript-typescript`, with `build-mode: none` for initial coverage.
  * Uses `actions/checkout@v6` and `github/codeql-action` init/analyze `@v4`.

## Test plan

- [ ] Merge and confirm the **CodeQL Advanced** workflow runs on `maintenance-3.1.x` (push or PR).
- [ ] Verify **Security → Code scanning** shows results for this repository.
- [ ] Triage any new alerts (fix, dismiss with justification, or track follow-up work).

## Notes

* Companion PR for `lts-2025`: https://github.com/nuxeo/nuxeo-elements/pull/1698
* Follow-up: review CodeQL alerts after the first successful run; enable extended query packs or a Node build step if needed.