### PR TITLE
NXENG-741: Add CodeQL Advanced workflow [lts-2025]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]", "maintenance-2.2.x", "maintenance-2.4.x", "maintenance-3.0.x", "master" ]
+  pull_request:
+    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]", "maintenance-2.2.x", "maintenance-2.4.x", "maintenance-3.0.x", "master" ]
+  schedule:
+    - cron: '34 22 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: actions
+          build-mode: none
+        - language: javascript-typescript
+          build-mode: none
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+    - name: Run manual build steps
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]", "maintenance-2.2.x", "maintenance-2.4.x", "maintenance-3.0.x", "master" ]
+    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]" ]
   pull_request:
-    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]", "maintenance-2.2.x", "maintenance-2.4.x", "maintenance-3.0.x", "master" ]
+    branches: [ "maintenance-3.1.x", "lts-20[0-9][0-9]" ]
   schedule:
     - cron: '34 22 * * 4'
 


### PR DESCRIPTION
## Problem

Nuxeo Engineering enabled organization-level **Code scanning** default setup with CodeQL for repositories tagged `nuxeo-engineering`. Repositories need an explicit **CodeQL Advanced** GitHub Actions workflow so analysis runs on default and protected branches and findings appear under **Security → Code scanning alerts** for triage.

Jira: [NXENG-741](https://hyland.atlassian.net/browse/NXENG-741) (epic [NXENG-117](https://hyland.atlassian.net/browse/NXENG-117))

## Root cause

`nuxeo-elements` did not yet commit a `.github/workflows/codeql.yml` workflow on `lts-2025`. Without it, org-level default setup cannot run CodeQL consistently on this repo’s LTS branches and pull requests.

## Changes

* **`.github/workflows/codeql.yml`**: Add the **CodeQL Advanced** workflow (same configuration as maintenance-3.1.x, cherry-picked onto `lts-2025`).
  * **Triggers**: `push` and `pull_request` on `maintenance-3.1.x`, `lts-20[0-9][0-9]`, legacy maintenance branches, and `master`; weekly schedule (`34 22 * * 4`).
  * **Languages**: `actions` and `javascript-typescript`, with `build-mode: none` for initial coverage.
  * Uses `actions/checkout@v6` and `github/codeql-action` init/analyze `@v4`.

## Test plan

- [ ] Merge and confirm the **CodeQL Advanced** workflow runs on `lts-2025` (push or PR).
- [ ] Verify **Security → Code scanning** shows results for this repository.
- [ ] Triage any new alerts (fix, dismiss with justification, or track follow-up work).

## Notes

* Pairs with https://github.com/nuxeo/nuxeo-elements/pull/1696 (`maintenance-3.1.x`).
* Replaces closed https://github.com/nuxeo/nuxeo-elements/pull/1697 (that PR reused `narasimhahyland-patch-1` and compared maintenance history to `lts-2025`).
* Follow-up: review CodeQL alerts after the first successful run; enable extended query packs or a Node build step if needed.