### PR TITLE
ELEMENTS-2102: Clear 12 SonarCloud findings split out of the ELEMENTS-2093 register [lts-2025]

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-Nuxeo = Nuxeo || {};
+window.Nuxeo = window.Nuxeo || {};
 Nuxeo.UI = Nuxeo.UI || {};
 Nuxeo.UI.config = Nuxeo.UI.config || {};
 const { config } = Nuxeo.UI;

--- a/ui/nuxeo-data-table/iron-data-table.js
+++ b/ui/nuxeo-data-table/iron-data-table.js
@@ -947,14 +947,9 @@ function hasRowDetailTemplate(node) {
     }
 
     _isFocusable(target) {
-      // eslint-disable-next-line no-constant-condition
-      if (false) {
-        // https://nemisj.com/focusable/
-        // tabIndex is not reliable in IE.
-        return target.tabIndex >= 0;
-      }
-      // unreliable with Shadow, document.activeElement doesn't go inside
-      // the shadow root.
+      // tabIndex is not used to decide this (see https://nemisj.com/focusable/); it was never
+      // reliable in IE, and document.activeElement is unreliable with Shadow DOM because it
+      // does not go inside the shadow root.
       return (
         target.contains(dom(document.activeElement).node) ||
         target instanceof Nuxeo.DataTableCheckbox ||

--- a/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
+++ b/ui/nuxeo-document-permissions/nuxeo-document-acl-table.js
@@ -278,8 +278,8 @@ import './nuxeo-popup-permission.js';
     aclFilterChanged(fn) {
       this._aclFilter =
         fn &&
-        function() {
-          return this.__dataHost[fn].apply(this.__dataHost, arguments);
+        function(...args) {
+          return this.__dataHost[fn](...args);
         };
       this._updateAces();
     }
@@ -287,8 +287,8 @@ import './nuxeo-popup-permission.js';
     aceFilterChanged(fn) {
       this._aceFilter =
         fn &&
-        function() {
-          return this.__dataHost[fn].apply(this.__dataHost, arguments);
+        function(...args) {
+          return this.__dataHost[fn](...args);
         };
       this._updateAces();
     }

--- a/ui/nuxeo-document-preview.js
+++ b/ui/nuxeo-document-preview.js
@@ -235,7 +235,7 @@ import './marked-element.js';
     _updateBlob() {
       if (this.document) {
         // adapt the Note to mimic a Blob
-        if (this.document.schemas.find((schema) => schema.name === 'note') && this.xpath === 'file:content') {
+        if (this.document.schemas.some((schema) => schema.name === 'note') && this.xpath === 'file:content') {
           this._blob = {
             text: this.document.properties['note:note'],
             'mime-type': this.document.properties['note:mime_type'],

--- a/ui/nuxeo-page-provider-display-behavior.js
+++ b/ui/nuxeo-page-provider-display-behavior.js
@@ -262,8 +262,8 @@ export const PageProviderDisplayBehavior = [
     detached() {
       this.unlisten(this.nxProvider, 'update', '_updateResults');
       this.unlisten(this.nxProvider, 'loading-changed', '_updateLoading');
-      this.$.list.unlisten.call(this.$.list, this.$.list, 'selected', '_selectionHandler');
-      this.$.list.unlisten.call(this.$.list, this.$.list, 'tap', '_selectionHandler');
+      this.$.list.unlisten(this.$.list, 'selected', '_selectionHandler');
+      this.$.list.unlisten(this.$.list, 'tap', '_selectionHandler');
     },
 
     _nxProviderChanged(nxProvider) {
@@ -514,10 +514,10 @@ export const PageProviderDisplayBehavior = [
     _selectionEnabledChanged() {
       this.$.list.selectionEnabled = this.selectionEnabled;
       this.$.list.multiSelection = this.multiSelection;
-      this.$.list.unlisten.call(this.$.list, this.$.list, 'selected', '_selectionHandler');
+      this.$.list.unlisten(this.$.list, 'selected', '_selectionHandler');
       if (this.selectionEnabled && !this.selectOnTap) {
-        this.$.list.unlisten.call(this.$.list, this.$.list, 'tap', '_selectionHandler');
-        this.$.list.listen.call(this.$.list, this.$.list, 'selected', '_selectionHandler');
+        this.$.list.unlisten(this.$.list, 'tap', '_selectionHandler');
+        this.$.list.listen(this.$.list, 'selected', '_selectionHandler');
       }
     },
 

--- a/ui/widgets/nuxeo-actions-menu.js
+++ b/ui/widgets/nuxeo-actions-menu.js
@@ -317,7 +317,7 @@ import './nuxeo-tooltip.js';
           dropdownElements.map((list) => list.removeAttribute('tabindex'));
         }, 0);
       }
-      if (e && e.type && e.composedPath().find((el) => el.id === 'reparent' || el.id === 'dropdownButton')) {
+      if (e && e.type && e.composedPath().some((el) => el.id === 'reparent' || el.id === 'dropdownButton')) {
         return; // skip events from within reparented actions
       }
       this.__layoutDebouncer = Debouncer.debounce(this.__layoutDebouncer, microTask, () => {

--- a/ui/widgets/nuxeo-user-tag.js
+++ b/ui/widgets/nuxeo-user-tag.js
@@ -300,11 +300,10 @@ import './nuxeo-tooltip.js';
 
     _layout() {
       if (this && this.parentNode) {
-        const selectedElement = this;
-        const parentElement = this._getHTMLRootNode(selectedElement);
+        const parentElement = this._getHTMLRootNode(this);
         let elementWidth = this._calculateElementWidth(parentElement);
         const childNodes = Array.from(parentElement.children);
-        const userAvatar = Array.from(selectedElement.shadowRoot.querySelectorAll('.user-avatar'));
+        const userAvatar = Array.from(this.shadowRoot.querySelectorAll('.user-avatar'));
         const userAvatarWidth = userAvatar[0].offsetWidth;
         const totalAvatarWidth = userAvatar.length * userAvatarWidth;
         const otherElementWidth = childNodes.reduce((totalWidth, currentValue) => {


### PR DESCRIPTION
## Problem

12 SonarCloud findings sat in the [ELEMENTS-2093](https://hyland.atlassian.net/browse/ELEMENTS-2093) acceptance register, graded **High** or **Critical** and marked do-not-fix.

A per-site re-read found the register had graded the risk of a *previously attempted, botched* mechanical edit rather than the risk of the correct fix — the same flaw [ELEMENTS-2100](https://hyland.atlassian.net/browse/ELEMENTS-2100) found in the `S1135` group. Once the correct fix is considered, all 12 are provable no-ops or dead-code deletions.

## Root cause

Per rule, what the register got wrong:

| Rule | Register's reason to accept | Why that does not hold |
| --- | --- | --- |
| `S6676` ×5 | `.call()` is "plausibly deliberate to pin `this` across mixin composition"; removing it can silently rebind `this` and break page-provider callbacks | Every site is `this.$.list.unlisten.call(this.$.list, …)` — the receiver handed to `.call()` is the *same object the method was read from*. `x.f.call(x, a)` ≡ `x.f(a)` unconditionally. `this.$` is Polymer's cached node map, so `this.$.list` is stable; adjacent lines already use the bare form |
| `S7754` ×2 | Needs per-site proof that the return value is unused | The proof is on the line: both calls sit inside an `if` condition, the result is never bound or read, and schema objects and DOM elements are never falsy. Same proof the three `iron-data-table.js` sites got under ELEMENTS-2089 |
| `S6666` ×2 | "Spread conversion changes arity handling"; "spreading a large ACE array can exhaust the call stack where apply did not" | Both wrong. Rest parameters forward the identical list, and `function()` / `function(...args)` both report `length === 0`. `Function#apply` with a large array is the *classic* source of that overflow, so spread is no worse — and `arguments` here is a filter callback's 2–3 args, not an ACE array |
| `S2703` | Adding a declaration scopes `Nuxeo` to the module, so addons lose the namespace and bootstrap breaks | True of `let`/`const`/`var`, but `window.Nuxeo = window.Nuxeo \|\| {}` satisfies the rule *and* keeps the global — already the idiom at `core/nuxeo-element.js:23` and `dataviz/nuxeo-aggregate-data-behavior.js:22` |
| `S7740` | Critical, inherited from the `ui/nuxeo-slots.js` site | Inherited only; ELEMENTS-2093 footnote ¹ already recorded that the risk here was never assessed. `selectedElement` is never reassigned, and `_layout`'s own `reduce` callback already compares against bare `this`, proving they are the same reference |
| `S2589` | "Likely a real logic bug"; needs its own ticket and root-cause analysis first | The condition is the literal `false`, already suppressed with `eslint-disable-next-line no-constant-condition`, guarding a dead IE-era branch. Nothing to root-cause |

`core/config.js` is also an ES module (`export default config`), so the bare `Nuxeo = Nuxeo || {}` was an undeclared strict-mode write that throws `ReferenceError` unless an earlier import had already established the global. Going through `window` removes that load-order dependency, making the fix strictly safer than the status quo.

## Changes

- `ui/nuxeo-page-provider-display-behavior.js` — drop the redundant `.call(this.$.list, …)` at lines 265, 266, 517, 519, 520 (`S6676` ×5)
- `ui/nuxeo-document-preview.js:238`, `ui/widgets/nuxeo-actions-menu.js:320` — `.find(` → `.some(` (`S7754` ×2)
- `ui/nuxeo-document-permissions/nuxeo-document-acl-table.js:282, 291` — forward with rest parameters instead of `.apply(this.__dataHost, arguments)` (`S6666` ×2)
- `core/config.js:19` — `window.Nuxeo = window.Nuxeo || {};` (`S2703`)
- `ui/widgets/nuxeo-user-tag.js:303` — use `this` directly, drop the `selectedElement` alias (`S7740`)
- `ui/nuxeo-data-table/iron-data-table.js:951` — delete the dead `if (false)` branch and its now-unnecessary ESLint suppression, keeping the explanation of why `tabIndex` is not used (`S2589`)

For `S2703` only line 19 changes. The two lines below it assign to *properties* of an object that exists by then rather than to an undeclared identifier, so `S2703` never fired on them — and prefixing only the root bootstrap line matches `core/nuxeo-element.js`.

## Test plan

- `npm run lint` — 0 errors (20 pre-existing `wc/*` warnings, unchanged); Prettier reports no differences
- `npm test` — core 164, ui 3888/3889, dataviz 29 passed; 0 failures, 2 pre-existing skips in `ui`
- **No test expectations were edited.** That was the deliberate safety check: every change here is behaviour-preserving by construction, so if a test had needed adjusting, the change would have been wrong rather than the test

Behaviour-preserving by construction, per rule:

- `S6676`, `S6666` — provably identical call semantics
- `S7754` — return value unused; both operands of the `&&` stay truthiness checks
- `S2703`, `S7740` — same object reached by a different expression
- `S2589` — removal of unreachable code

No public API, template binding, event name or i18n key changes.

## Notes

**`S3735` ×3 on `ui/viewers/nuxeo-pdf-viewer.js` is deliberately excluded.** ELEMENTS-2093's rationale for it is wrong on the facts — those `void err;` / `void e;` statements mark an intentionally-unused *caught exception*, not fire-and-forget promises, and there are no promises at any of the three sites. But clearing the rule is not mechanical either: `void err` is what makes the caught exception *referenced*, so removing it leaves an unused binding — the exact shape [ELEMENTS-2090](https://hyland.atlassian.net/browse/ELEMENTS-2090) was raised to fix under `S2486`, whose remedy there was to log. Doing that here means logging on a path that throws for every cross-origin PDF iframe, the same per-frame noise ELEMENTS-2090 had to add a warn-once guard for. That is a judgement call, not a sweep, so the three stay accepted in ELEMENTS-2093 with a corrected rationale.

ELEMENTS-2093 has been trimmed to **46 findings across 15 rules**, with these 12 recorded in a "Moved to ELEMENTS-2102 — do NOT accept these" table that preserves their SonarCloud issue keys, so they can be confirmed **Fixed** rather than Accepted once this merges. Six of its remaining rationales were corrected in the same pass.

Companion PR on the other LTS line: #1703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
